### PR TITLE
Changed the API of AsyncImage.scala

### DIFF
--- a/core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -27,6 +27,7 @@ import thirdparty.mortennobel.{ResampleFilters, ResampleOp}
 import com.sksamuel.scrimage.Position.Center
 import com.sksamuel.scrimage.io.ImageWriter
 import scala.Array
+import scala.concurrent.ExecutionContext
 
 /**
  * @author Stephen Samuel
@@ -34,7 +35,7 @@ import scala.Array
  *         Image is class that represents an in memory image.
  *
  */
-class Image(val awt: BufferedImage) extends ImageLike[Image] {
+class Image(val awt: BufferedImage) extends ImageLike[Image] with WritableImageLike {
 
   require(awt != null, "Wrapping image cannot be null")
   val SCALE_THREADS = Runtime.getRuntime.availableProcessors()
@@ -673,7 +674,7 @@ class Image(val awt: BufferedImage) extends ImageLike[Image] {
    *
    * @return an AsyncImage wrapping this image.
    */
-  def toAsync: AsyncImage = AsyncImage(this)
+  def toAsync(implicit executionContext: ExecutionContext): AsyncImage = AsyncImage(this)
 
   /**
    * Clears all image data to the given color

--- a/core/src/main/scala/com/sksamuel/scrimage/ImageLike.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/ImageLike.scala
@@ -325,6 +325,23 @@ trait ImageLike[R] {
   def scale(scaleFactor: Double, scaleMethod: ScaleMethod = Bicubic): R =
     scaleTo((width * scaleFactor).toInt, (height * scaleFactor).toInt, scaleMethod)
 
+  def pixels: Array[Int]
+
+  /**
+   *
+   * @param pixel the pixel colour to look for.
+   * @return true if there exists at least one pixel that has the given pixels color
+   */
+  def exists(pixel: Int) = pixels.exists(_ == pixel)
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: ImageLike[_] => other.pixels.sameElements(pixels)
+    case _ => false
+  }
+}
+
+trait WritableImageLike {
+
   def writer[T <: ImageWriter](format: Format[T]): T
 
   def write: Array[Byte] = write(Format.PNG)
@@ -351,17 +368,4 @@ trait ImageLike[R] {
     writer(format).write(out)
   }
 
-  def pixels: Array[Int]
-
-  /**
-   *
-   * @param pixel the pixel colour to look for.
-   * @return true if there exists at least one pixel that has the given pixels color
-   */
-  def exists(pixel: Int) = pixels.exists(_ == pixel)
-
-  override def equals(obj: Any): Boolean = obj match {
-    case other: ImageLike[_] => other.pixels.sameElements(pixels)
-    case _ => false
-  }
 }

--- a/core/src/main/scala/com/sksamuel/scrimage/io/AsyncImageWriter.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/io/AsyncImageWriter.scala
@@ -1,0 +1,54 @@
+package com.sksamuel.scrimage.io
+
+import java.io.{ByteArrayInputStream, InputStream, File, OutputStream}
+import scala.concurrent.{Future, ExecutionContext}
+import org.apache.commons.io.{IOUtils, FileUtils}
+
+class AsyncImageWriter[T <: ImageWriter](writer: T) {
+
+
+  /**
+   * Writes out this image to the given stream.
+   *
+   * @param out the stream to write out to
+   */
+  def write(out: OutputStream)(implicit executionContext: ExecutionContext): Future[Unit] = Future {
+    writer.write(out)
+  }
+
+  /**
+   * Writes out this image to the given filepath.
+   *
+   * @param path the path to write out to.
+   */
+  def write(path: String)(implicit executionContext: ExecutionContext): Future[Unit] = Future {
+    writer.write(path)
+  }
+
+  /**
+   * Writes out this image to the given file.
+   *
+   * @param file the file to write out to.
+   */
+  def write(file: File)(implicit executionContext: ExecutionContext):Future[Unit] = Future {
+    writer.write(file)
+  }
+
+  /**
+   * Writes out this image to a byte array.
+   *
+   * @return the byte array
+   */
+  def write()(implicit executionContext: ExecutionContext): Future[Array[Byte]] = Future {
+    writer.write()
+  }
+
+  /**
+   * Returns an input stream that reads from this image.
+   */
+  def toStream(implicit executionContext: ExecutionContext): Future[InputStream] = Future {
+    val bytes = writer.write()
+    new ByteArrayInputStream(bytes)
+  }
+
+}

--- a/core/src/test/scala/com/sksamuel/scrimage/AsyncImageTest.scala
+++ b/core/src/test/scala/com/sksamuel/scrimage/AsyncImageTest.scala
@@ -7,6 +7,8 @@ import scala.concurrent.duration._
 /** @author Stephen Samuel */
 class AsyncImageTest extends FunSuite with BeforeAndAfter with OneInstancePerTest {
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   val in = getClass.getResourceAsStream("/com/sksamuel/scrimage/bird.jpg")
   val image = Image(in)
 


### PR DESCRIPTION
ExecutionContext should not be chosen by the library but injected with implicits. Passing an executionContext to the constructor of AsyncImage keeps the ImageLike operations (which avoids lots of code duplication).
