### PR TITLE
added padWith function

### DIFF
--- a/core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -574,11 +574,20 @@ class Image(val awt: BufferedImage) extends ImageLike[Image] with WritableImageL
   def padTo(targetWidth: Int, targetHeight: Int, color: Color = X11Colorlist.White): Image = {
     val w = if (width < targetWidth) targetWidth else width
     val h = if (height < targetHeight) targetHeight else height
-    val filled = Image.filled(w, h, color)
-    val g = filled.awt.getGraphics
     val x = ((w - width) / 2.0).toInt
     val y = ((h - height) / 2.0).toInt
-    g.drawImage(awt, x, y, null)
+    padWith(x, y, w-width-x, h-height-y)
+  }
+
+  /**
+  * Creates a new image by adding the given number of columns/rows on left, top, right and bottom
+  */
+  def padWith(left: Int, top: Int, right: Int, bottom: Int, color: Color = RGBColor(255, 255, 255)): Image = {
+    val w = width + left + right
+    val h = height + top + bottom
+    val filled = Image.filled(w, h, color)
+    val g = filled.awt.getGraphics
+    g.drawImage(awt, left, top, null)
     g.dispose()
     filled
   }

--- a/core/src/test/scala/com/sksamuel/scrimage/ImageTest.scala
+++ b/core/src/test/scala/com/sksamuel/scrimage/ImageTest.scala
@@ -185,6 +185,13 @@ class ImageTest extends FunSuite with BeforeAndAfter {
     assert(1304 === padded.height)
   }
 
+  test("trim should revert padWith") {
+    val image = Image.empty(85, 56)
+    val same = image.padWith(10, 2, 5, 7).trim(10, 2, 5, 7)
+    assert(image.width === same.width)
+    assert(image.height === same.height)
+  }
+
   test("when flipping on x axis the dimensions are retained") {
     val flipped = image.flipX
     assert(1944 === flipped.width)


### PR DESCRIPTION
I needed to control precisely how my image was padded (to center a particular part of the image),
so I added this "padWith" function, that looks like "trim"
I'm not sure about the name, but "pad" was taken.
I also added a simple test.
The "padTo" function has be also modified to use "padWith".
