### PR TITLE
Added drawable objects in scrimage.canvas

### DIFF
--- a/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Canvas.scala
+++ b/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Canvas.scala
@@ -25,6 +25,22 @@ case class Canvas(image: Image,
     g2
   }
 
+  def draw(drawables: Drawable*): Canvas = {
+    val copy = image.copy
+    val g = g2(copy)
+    drawables.foreach(d.draw(g))
+    g.dispose()
+    this.copy(image = copy)
+  }
+
+  def draw(drawables: Iterable[Drawable]): Canvas = {
+    val copy = image.copy
+    val g = g2(copy)
+    drawables.foreach(d.draw(g))
+    g.dispose()
+    this.copy(image = copy)
+  }
+
   def fill: Canvas = {
     val copy = image.copy
     val g = g2(copy)

--- a/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Drawable.scala
+++ b/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Drawable.scala
@@ -1,0 +1,58 @@
+package com.sksamuel.scrimage.canvas
+
+import java.awt.Graphics2D
+import com.sksamuel.scrimage.Color
+
+trait Drawable {
+    def draw(g: Graphics2D) : Unit
+    def withPainter(color: Color) = ColoredDrawable(color, this)
+    def withPainter(painter: Painter) = ColoredDrawable(painter, this)
+}
+
+object Drawable {
+    def apply(draw: Graphics2D => ()) = new Drawable{
+        def draw(g: Graphics2D) = draw(g)
+    }
+}
+
+class ColoredDrawable(painter: Painter, drawable: D) extends Drawable {
+    def draw(g: Graphics2D) = {
+        val previousPaint = g.getPaint
+        g.setPaint(painter.paint)
+        drawable.draw(g)
+        g.setPaint(previousPaint)
+    }
+}
+
+
+case class DRect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawRect(x, y, width, height)
+    def fill = FillableDRect(x, y, width, height)
+    def rounded(arcWidth: Int, arcHeight: Int) =
+        RoundedDRect(x, y, width, height, arcWidth, arcHeight)
+}
+
+case class FillableDRect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.fillRect(x, y, width, height)
+    def rounded(arcWidth: Int, arcHeight: Int) =
+        FilledRoundedDRect(x, y, width, height, arcWidth, arcHeight)
+}
+
+case class RoundedDRect(x: Int, y: Int, width: Int, height: Int,
+                               arcWidth: Int, arcHeight: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawRoundRect(x, y, width, height, arcWidth, arcHeight)
+    def fill = FillableRoundedRect(x, y, width, height, arcWidth, arcHeight)
+}
+
+case class FilledRoundedDRect(x: Int, y: Int, width: Int, height: Int,
+                               arcWidth: Int, arcHeight: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.fillRoundRect(x, y, width, height, arcWidth, arcHeight)
+}
+
+case class DLine(x0: Int, y0: Int, x1: Int, y1: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawLine(x0, y0, x1, y1)
+}
+
+case class DImage(x: Int, y: Int, imageToDraw: Image) extends Drawable {
+    def draw(g: Graphics2D) = g.drawImage(imageToDraw.awt, x, y, null)
+}

--- a/canvas/src/test/scala/com/sksamuel/scrimage/canvas/DrawableTest.scala
+++ b/canvas/src/test/scala/com/sksamuel/scrimage/canvas/DrawableTest.scala
@@ -1,0 +1,20 @@
+package com.sksamuel.scrimage.canvas
+
+
+import org.scalatest.FunSuite
+import com.sksamuel.scrimage.{X11Colorlist, Image}
+
+class DrawableTest extends FunSuite {
+  val blank = Image.filled(200, 100, X11Colorlist.White)
+
+  test("The lines are correctly drawn") {
+    val image1 = new Canvas(blank).drawLine(10, 5, 20, 25)
+        .drawLine(30, 50, 200, 200)
+        .drawLine(100, 100, 120, 130)
+    val image2 = new Canvas(blank)
+    image2.draw(DLine(10, 5, 20, 25),
+                DLine(30, 50, 200, 200),
+                DLine(100, 100, 120, 130))
+    assert(image1 == image2)
+  }
+}


### PR DESCRIPTION
I think the Canvas code has a lot of boiler plate and isn't so efficient:
 to draw 10 lines on the canvas you create 10 times a Graphic2D and close it 10 times.

I introduced a trait Drawable and added a draw method to the Canvas that can draw a collection of Drawable at once.

You may refer to the test class to see how the code is used.
If you like the idea, I'll add more Drawable objects, and rewrite the Canvas 'drawXXX' methods using Drawable.

Note: As the current version of scrimage is not compiling, some bugs may have escaped my attention.
