### PR TITLE
Finished and tested Drawable, removed draw methods from Canvas

### DIFF
--- a/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Canvas.scala
+++ b/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Canvas.scala
@@ -28,7 +28,7 @@ case class Canvas(image: Image,
   def draw(drawables: Drawable*): Canvas = {
     val copy = image.copy
     val g = g2(copy)
-    drawables.foreach(d.draw(g))
+    drawables.foreach(_.draw(g))
     g.dispose()
     this.copy(image = copy)
   }
@@ -36,94 +36,7 @@ case class Canvas(image: Image,
   def draw(drawables: Iterable[Drawable]): Canvas = {
     val copy = image.copy
     val g = g2(copy)
-    drawables.foreach(d.draw(g))
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def fill: Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.fillRect(0, 0, copy.width, copy.height)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawLine(x1: Int, y1: Int, x2: Int, y2: Int): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawLine(x1, y1, x2, y2)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawImage(x: Int, y: Int, imageToDraw: Image): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawImage(imageToDraw.awt, x, y, null)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def fillRect(x: Int, y: Int, w: Int, h: Int): Canvas = fillPoly(Polygon.rectange(x, y, w, h))
-  def fillPoly(polygon: Polygon): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.fillPolygon(polygon.points.map(_.x).toArray, polygon.points.map(_.y).toArray, polygon.points.size)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawRoundedRect(x: Int,
-                      y: Int,
-                      width: Int,
-                      height: Int,
-                      arcWidth: Int,
-                      arcHeight: Int): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawRoundRect(x, y, width, height, arcWidth, arcHeight)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def fillRoundedRect(x: Int, y: Int, width: Int, height: Int, arcWidth: Int, arcHeight: Int): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.fillRoundRect(x, y, width, height, arcWidth, arcHeight)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawOval(x: Int, y: Int, width: Int, height: Int): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawOval(x, y, width, height)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def fillOval(x: Int, y: Int, width: Int, height: Int): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.fillOval(x, y, width, height)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawRect(x: Int, y: Int, w: Int, h: Int): Canvas = drawPoly(Polygon.rectange(x, y, w, h))
-  def drawPoly(polygon: Polygon): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawPolygon(polygon.points.map(_.x).toArray, polygon.points.map(_.y).toArray, polygon.points.size)
-    g.dispose()
-    this.copy(image = copy)
-  }
-
-  def drawString(x: Int, y: Int, text: String): Canvas = {
-    val copy = image.copy
-    val g = g2(copy)
-    g.drawString(text, x, y)
+    drawables.foreach(_.draw(g))
     g.dispose()
     this.copy(image = copy)
   }
@@ -141,7 +54,7 @@ case class Canvas(image: Image,
    * @return A new image with the given image applied using the given composite.
    */
   def composite(composite: Composite, applicative: Image): Image = {
-    val copy = this.copy
+    val copy = image.copy
     composite.apply(copy, applicative)
     copy
   }
@@ -152,15 +65,4 @@ object Canvas {
   implicit def canvas2image(canvas: Canvas): Image = canvas.image
 }
 
-case class Point(x: Int, y: Int)
 
-object Point {
-  implicit def tuple2point(p: (Int, Int)): Point = Point(p._1, p._2)
-}
-
-case class Polygon(points: Seq[Point])
-object Polygon {
-  def rectange(x: Int, y: Int, width: Int, height: Int) = {
-    Polygon(Seq(x -> y, (x + width) -> y, (x + width) -> (y + height), x -> (y + height)))
-  }
-}

--- a/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Drawable.scala
+++ b/canvas/src/main/scala/com/sksamuel/scrimage/canvas/Drawable.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.scrimage.canvas
 
 import java.awt.Graphics2D
-import com.sksamuel.scrimage.Color
+import com.sksamuel.scrimage.{Color,  Image}
 
 trait Drawable {
     def draw(g: Graphics2D) : Unit
@@ -10,12 +10,14 @@ trait Drawable {
 }
 
 object Drawable {
-    def apply(draw: Graphics2D => ()) = new Drawable{
+    def apply(draw: Graphics2D => Unit): Drawable = new Drawable{
         def draw(g: Graphics2D) = draw(g)
     }
+    def apply(img: Image, x: Int, y: Int) = DrawableImage(img, x, y)
+    def apply(str: String, x: Int, y: Int) = DrawableString(str, x, y)
 }
 
-class ColoredDrawable(painter: Painter, drawable: D) extends Drawable {
+case class ColoredDrawable(painter: Painter, drawable: Drawable) extends Drawable {
     def draw(g: Graphics2D) = {
         val previousPaint = g.getPaint
         g.setPaint(painter.paint)
@@ -24,35 +26,95 @@ class ColoredDrawable(painter: Painter, drawable: D) extends Drawable {
     }
 }
 
-
-case class DRect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+case class Rect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
     def draw(g: Graphics2D) = g.drawRect(x, y, width, height)
-    def fill = FillableDRect(x, y, width, height)
+    def fill = FilledRect(x, y, width, height)
     def rounded(arcWidth: Int, arcHeight: Int) =
-        RoundedDRect(x, y, width, height, arcWidth, arcHeight)
+        RoundedRect(x, y, width, height, arcWidth, arcHeight)
 }
 
-case class FillableDRect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+case class FilledRect(x: Int, y: Int, width: Int, height: Int) extends Drawable {
     def draw(g: Graphics2D) = g.fillRect(x, y, width, height)
     def rounded(arcWidth: Int, arcHeight: Int) =
-        FilledRoundedDRect(x, y, width, height, arcWidth, arcHeight)
+        FilledRoundedRect(x, y, width, height, arcWidth, arcHeight)
 }
 
-case class RoundedDRect(x: Int, y: Int, width: Int, height: Int,
+case class RoundedRect(x: Int, y: Int, width: Int, height: Int,
                                arcWidth: Int, arcHeight: Int) extends Drawable {
     def draw(g: Graphics2D) = g.drawRoundRect(x, y, width, height, arcWidth, arcHeight)
-    def fill = FillableRoundedRect(x, y, width, height, arcWidth, arcHeight)
+    def fill = FilledRoundedRect(x, y, width, height, arcWidth, arcHeight)
 }
 
-case class FilledRoundedDRect(x: Int, y: Int, width: Int, height: Int,
+case class FilledRoundedRect(x: Int, y: Int, width: Int, height: Int,
                                arcWidth: Int, arcHeight: Int) extends Drawable {
     def draw(g: Graphics2D) = g.fillRoundRect(x, y, width, height, arcWidth, arcHeight)
 }
 
-case class DLine(x0: Int, y0: Int, x1: Int, y1: Int) extends Drawable {
+case class Line(x0: Int, y0: Int, x1: Int, y1: Int) extends Drawable {
     def draw(g: Graphics2D) = g.drawLine(x0, y0, x1, y1)
 }
 
-case class DImage(x: Int, y: Int, imageToDraw: Image) extends Drawable {
+case class Arc(x: Int, y: Int, width: Int, height: Int,
+                       startAngle: Int, endAngle: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawArc(x, y, width, height, startAngle, endAngle)
+    def fill = FilledArc(x, y, width, height, startAngle, endAngle)
+}
+
+case class FilledArc(x: Int, y: Int, width: Int, height: Int,
+                       startAngle: Int, endAngle: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.fillArc(x, y, width, height, startAngle, endAngle)
+}
+
+case class Oval(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawOval(x, y, width, height)
+    def fill = FilledOval(x, y, width, height)
+}
+
+case class FilledOval(x: Int, y: Int, width: Int, height: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.fillOval(x, y, width, height)
+}
+
+
+case class Point(x: Int, y: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawLine(x, y, x, y)
+}
+
+object Point {
+  implicit def tuple2point(p: (Int, Int)): Point = Point(p._1, p._2)
+}
+
+case class Polygon(points: Seq[Point]) extends Drawable {
+    def draw(g: Graphics2D) = g.drawPolygon(points.map(_.x).toArray,
+                                                points.map(_.y).toArray,
+                                                points.size)
+    def fill = FilledPolygon(points)
+    def open = Polyline(points)
+}
+
+case class Polyline(points: Seq[Point]) extends Drawable {
+    def draw(g: Graphics2D) = g.drawPolyline(points.map(_.x).toArray,
+                                                points.map(_.y).toArray,
+                                                points.size)
+    def close = Polygon(points)
+}
+
+case class FilledPolygon(points: Seq[Point]) extends Drawable {
+    def draw(g: Graphics2D) = g.fillPolygon(points.map(_.x).toArray,
+                                            points.map(_.y).toArray,
+                                            points.size)
+}
+
+object Polygon {
+  def rectangle(x: Int, y: Int, width: Int, height: Int) = {
+    Polygon(Seq(x -> y, (x + width) -> y, (x + width) -> (y + height), x -> (y + height)))
+  }
+}
+
+case class DrawableString(text: String, x: Int, y: Int) extends Drawable {
+    def draw(g: Graphics2D) = g.drawString(text, x, y)
+}
+
+case class DrawableImage(imageToDraw: Image, x: Int, y: Int) extends Drawable {
     def draw(g: Graphics2D) = g.drawImage(imageToDraw.awt, x, y, null)
 }
+

--- a/canvas/src/test/scala/com/sksamuel/scrimage/canvas/DrawableTest.scala
+++ b/canvas/src/test/scala/com/sksamuel/scrimage/canvas/DrawableTest.scala
@@ -5,16 +5,57 @@ import org.scalatest.FunSuite
 import com.sksamuel.scrimage.{X11Colorlist, Image}
 
 class DrawableTest extends FunSuite {
-  val blank = Image.filled(200, 100, X11Colorlist.White)
+
+  def assertSameImage(img1: Image, img2: Image) : Unit = {
+    assert(img1.width === img2.width)
+    assert(img1.height === img2.height)
+    for(x <- 0 until img1.width; y <- 0 until img2.height){
+      assert(img1.pixel(x, y) === img2.pixel(x, y))
+    }
+  }
+
+  val blank = Image.filled(300, 200, X11Colorlist.White)
+
 
   test("The lines are correctly drawn") {
-    val image1 = new Canvas(blank).drawLine(10, 5, 20, 25)
-        .drawLine(30, 50, 200, 200)
-        .drawLine(100, 100, 120, 130)
-    val image2 = new Canvas(blank)
-    image2.draw(DLine(10, 5, 20, 25),
-                DLine(30, 50, 200, 200),
-                DLine(100, 100, 120, 130))
-    assert(image1 == image2)
+    val canvas = new Canvas(blank).draw(
+        Line(10, 5, 20, 25),
+        Line(30, 50, 30, 200),
+        Line(100, 100, 120, 120)
+    )
+    val img = canvas.image
+    val black = X11Colorlist.Black.toInt
+    assert(img.pixel(10, 5) === black)
+    assert(img.pixel(20, 25) === black)
+    assert(img.pixel(30, 100) === black)
+    assert(img.pixel(110, 110) === black)
+  }
+
+  test("The colors are correctly put") {
+    val canvas = new Canvas(blank).draw(
+        Line(10, 5, 20, 25),
+        Line(30, 50, 30, 200).withPainter(X11Colorlist.Red),
+        Line(100, 100, 120, 120)
+    )
+    val img = canvas.image
+    val black = X11Colorlist.Black.toInt
+    val red = X11Colorlist.Red.toInt
+    assert(img.pixel(20, 25) === black)
+    assert(img.pixel(30, 100) === red)
+    assert(img.pixel(110, 110) === black)
+  }
+
+  test("Rectangle and polygones draw the same thing")  {
+    val canvas1 = new Canvas(blank).draw(
+      Rect(10, 20, 30, 30),
+      Rect(100, 120, 50, 20).fill
+    )
+    val canvas2 = new Canvas(blank).draw(
+        Polygon.rectangle(10, 20, 30, 30),
+        Polygon.rectangle(100, 120, 50, 20).fill
+    )
+    val img1 = canvas1.image
+    val img2 = canvas2.image
+    assertSameImage(img1, img2)
   }
 }

--- a/canvas/src/test/scala/com/sksamuel/scrimage/canvas/ImplicitTest.scala
+++ b/canvas/src/test/scala/com/sksamuel/scrimage/canvas/ImplicitTest.scala
@@ -9,7 +9,7 @@ class ImplicitTest extends FlatSpec {
 
   "an image" should "be implicitly convertable to a canvas" in {
     val image = Image.empty(100, 100)
-    val canvas = image.fillRect(0, 0, 10, 10)
+    val canvas = image.draw(Rect(0, 0, 10, 10).fill)
   }
 
   "a canvas" should "be implicitly convertable to an image" in {


### PR DESCRIPTION
As discuted I finished the Drawable class.
The case class' with an extensive name: DrawableImage and DrawableString have a constructor in the compagnion object of Drawable.

I tested my methods by using the scrimage-canvas as a project depending from scrimage-core.1.4.1
