### PR TITLE
When reading an image from a stream, stop after the first successful read

### DIFF
--- a/core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -682,7 +682,10 @@ object Image {
       case e: Exception =>
         import scala.collection.JavaConverters._
         ImageIO.getImageReaders(new ByteArrayInputStream(bytes)).asScala.foldLeft(None: Option[Image]) {
-          (value, reader) =>
+          (valueOpt, reader) =>
+          // only bother to read if it hasn't already successfully been read
+          valueOpt orElse {
+
             try {
               reader.setInput(new ByteArrayInputStream(bytes), true, true)
               val params = reader.getDefaultReadParam
@@ -699,6 +702,7 @@ object Image {
             } catch {
               case e: Exception => None
             }
+          }
         }.getOrElse(throw new RuntimeException("Unparsable image"))
     }
   }


### PR DESCRIPTION
While trying to debug a very perplexing intermittent "Unparsable image" exception that I've been getting, I've noticed that the logic to read from the stream, does not seem quite right to me. It seems that at best it's doing more work that it may need to, and at worst might actually be causing my issue (if the last reader fails, but others succeed). 

To the best of my understanding, there should be no need to try all of the readers, so long as you have one that works. I also recognize that I might be missing something. Am I missing something?
