### PR TITLE
Prevent unnecessary duplication of byte arrays

### DIFF
--- a/core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -678,15 +678,7 @@ object Image {
     * @param bytes the bytes from the format stream
     * @return a new Image
     */
-  def apply(bytes: Array[Byte]): Image = apply(new ByteArrayInputStream(bytes))
-
-  def apply(in: InputStream): Image = {
-    require(in != null)
-    require(in.available > 0)
-
-    val bytes = IOUtils.toByteArray(in) // lets buffer in case we have to repeat
-    IOUtils.closeQuietly(in)
-
+  def apply(bytes: Array[Byte]): Image = {
     try {
       apply(ImageIO.read(new ByteArrayInputStream(bytes)))
     } catch {
@@ -716,6 +708,16 @@ object Image {
             }
         }.getOrElse(throw new RuntimeException("Unparsable image"))
     }
+  }
+
+  def apply(in: InputStream): Image = {
+    require(in != null)
+    require(in.available > 0)
+
+    val bytes = IOUtils.toByteArray(in) // lets buffer in case we have to repeat
+    IOUtils.closeQuietly(in)
+
+    apply(bytes)
   }
 
   def apply(file: File): Image = {

--- a/core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -31,6 +31,8 @@ import thirdparty.mortennobel.{ResampleFilters, ResampleOp}
 import scala.List
 import scala.concurrent.ExecutionContext
 
+class ImageParseException extends RuntimeException("Unparsable image")
+
 /** An Image represents an abstraction over a set of pixels that allow operations such
   * as resize, scale, rotate, flip, trim, pad, cover, fit. An image does not
   * contain its underlying data directly, but instead delegates to a Raster. A Raster is a simple data
@@ -706,7 +708,7 @@ object Image {
                 case e: Exception => None
               }
             }
-        }.getOrElse(throw new RuntimeException("Unparsable image"))
+        }.getOrElse(throw new ImageParseException)
     }
   }
 


### PR DESCRIPTION
Creating an Image from a byte array previously would create a stream
from the byte array, and then another byte array from that stream, from
which other streams would be created.

Flip the relationship between the methods that expect byte arrays and
streams, so that when a byte array is given, streams are created
directly from it rather than creating an additional duplicate byte
array.

Also, add an exception class for image parsing failures. This is useful for calling code to be able to easily distinguish/pattern match image parsing errors from other types of runtime exceptions without catching all runtime exceptions, performing a string comparison, and possibly rethrowing.