### PR TITLE
now closing streams with a Using trait for #98

### DIFF
--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -805,7 +805,7 @@ class Image(awt: BufferedImage, val metadata: ImageMetadata) extends MutableAwtI
   }
 }
 
-object Image {
+object Image extends Using {
 
   ImageIO.scanForPlugins()
 
@@ -856,7 +856,6 @@ object Image {
     require(in != null)
     require(in.available > 0)
     val bytes = IOUtils.toByteArray(in)
-    in.close()
     apply(bytes, `type`)
   }
 
@@ -877,7 +876,7 @@ object Image {
   def fromFile(file: File): Image = fromPath(file.toPath)
   def fromPath(path: Path): Image = {
     require(path != null)
-    fromStream(Files.newInputStream(path))
+    using(Files.newInputStream(path))(stream => fromStream(stream))
   }
 
   /**

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/Using.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/Using.scala
@@ -1,0 +1,11 @@
+package com.sksamuel.scrimage
+
+trait Using {
+
+  def using[A, B <: {def close() : Unit}](closeable: B)(f: B => A): A =
+    try {
+      f(closeable)
+    } finally {
+      closeable.close()
+    }
+}

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/WriteContext.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/WriteContext.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Paths, Path}
 
 import com.sksamuel.scrimage.nio.ImageWriter
 
-class WriteContext(writer: ImageWriter, image: Image) {
+class WriteContext(writer: ImageWriter, image: Image) extends Using {
 
   def bytes: Array[Byte] = {
     val bos = new ByteArrayOutputStream
@@ -23,9 +23,9 @@ class WriteContext(writer: ImageWriter, image: Image) {
   }
 
   def write(path: Path): Path = {
-    val out = Files.newOutputStream(path)
-    writer.write(image, out)
-    out.close()
+    using(Files.newOutputStream(path)) { out =>
+      writer.write(image, out)
+    }
     path
   }
 

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/canvas/Font.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/canvas/Font.scala
@@ -7,6 +7,8 @@ import java.io.InputStream
 import java.nio.file.{Files, Path}
 import java.awt.{Font => JFont}
 
+import com.sksamuel.scrimage.Using
+
 import scala.language.implicitConversions
 
 case class Font(wrapped: JFont, bold: Boolean = false, italic: Boolean = false) {
@@ -25,7 +27,7 @@ case class Font(wrapped: JFont, bold: Boolean = false, italic: Boolean = false) 
   }
 }
 
-object Font {
+object Font extends Using {
 
   implicit def awtToFont(awt: java.awt.Font): Font = Font(awt)
 
@@ -45,7 +47,7 @@ object Font {
     Font(new JFont(font.getName, JFont.PLAIN, 12))
   }
 
-  def createTrueType(path: Path): Font = createTrueType(Files.newInputStream(path))
+  def createTrueType(path: Path): Font = using(Files.newInputStream(path))(createTrueType)
 }
 
 case class Padding(left: Int, right: Int, top: Int, bottom: Int)

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/nio/GifWriter.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/nio/GifWriter.scala
@@ -20,11 +20,11 @@ import java.io.OutputStream
 import javax.imageio.stream.MemoryCacheImageOutputStream
 import javax.imageio.{IIOImage, ImageIO, ImageWriteParam}
 
-import com.sksamuel.scrimage.Image
+import com.sksamuel.scrimage.{Using, Image}
 import org.apache.commons.io.IOUtils
 
 /** @author Stephen Samuel */
-case class GifWriter(progressive: Boolean) extends ImageWriter {
+case class GifWriter(progressive: Boolean) extends ImageWriter with Using {
 
   def withProgressive(progressive: Boolean): GifWriter = GifWriter.Progressive
 
@@ -39,11 +39,11 @@ case class GifWriter(progressive: Boolean) extends ImageWriter {
       params.setProgressiveMode(ImageWriteParam.MODE_DISABLED)
     }
 
-    val output = new MemoryCacheImageOutputStream(out)
-    writer.setOutput(output)
-    writer.write(null, new IIOImage(image.awt, null, null), params)
-    writer.dispose()
-    output.close()
+    using(new MemoryCacheImageOutputStream(out)) { output =>
+      writer.setOutput(output)
+      writer.write(null, new IIOImage(image.awt, null, null), params)
+      writer.dispose()
+    }
     IOUtils.closeQuietly(out)
   }
 }

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/nio/ImageReader.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/nio/ImageReader.scala
@@ -3,7 +3,7 @@ package com.sksamuel.scrimage.nio
 import java.io.{File, InputStream}
 import java.nio.file.{Files, Path}
 
-import com.sksamuel.scrimage.{Image, ImageParseException}
+import com.sksamuel.scrimage.{Using, Image, ImageParseException}
 import org.apache.commons.io.IOUtils
 
 import scala.util.Try
@@ -11,7 +11,7 @@ import scala.util.Try
 /**
  * Utilites for reading of an Image to an array of bytes in a specified format.
  */
-object ImageReader {
+object ImageReader extends Using {
 
   private val readers = List(JavaImageIOReader, PngReader, JavaImageIO2Reader)
 
@@ -20,7 +20,9 @@ object ImageReader {
   }
 
   def fromPath(path: Path, `type`: Int = Image.CANONICAL_DATA_TYPE): Image = {
-    fromStream(Files.newInputStream(path), `type`)
+    using(Files.newInputStream(path)) { stream =>
+      fromStream(stream, `type`)
+    }
   }
 
   def fromStream(in: InputStream, `type`: Int = Image.CANONICAL_DATA_TYPE): Image = {


### PR DESCRIPTION
#98 Assuming the stream requestor is responsible for closing it, so I did not touch methods consuming or returning streams.

I was not so sure about the reader classes like `PngReader` & `JavaImageIOReader`

I did not touch stream handling in tests - this should not matter much

Tests are still green