### PR TITLE
Autocrop changes

### DIFF
--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/AutocropOps.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/AutocropOps.scala
@@ -1,26 +1,32 @@
 package com.sksamuel.scrimage
 
+import scala.annotation.tailrec
+
 object AutocropOps {
 
   type PixelsExtractor = (Int, Int, Int, Int) => Array[Pixel]
 
-  def scanright(color: Color, height: Int, col: Int, f: PixelsExtractor): Int = {
-    if (PixelTools.uniform(color, f(col, 0, 1, height))) scanright(color, height, col + 1, f)
-    else col
+  @tailrec
+  final def scanright(color: Color, height: Int, width: Int, col: Int, f: PixelsExtractor): Int = {
+    if (col == width || !PixelTools.uniform(color, f(col, 0, 1, height))) col
+    else scanright(color, height, width, col + 1, f)
   }
 
-  def scanleft(color: Color, height: Int, col: Int, f: PixelsExtractor): Int = {
-    if (PixelTools.uniform(color, f(col, 0, 1, height))) scanleft(color, height, col - 1, f)
-    else col
+  @tailrec
+  final def scanleft(color: Color, height: Int, width: Int, col: Int, f: PixelsExtractor): Int = {
+    if (col == 0 || !PixelTools.uniform(color, f(col, 0, 1, height))) col
+    else scanleft(color, height, width, col - 1, f)
   }
 
-  def scandown(color: Color, width: Int, row: Int, f: PixelsExtractor): Int = {
-    if (PixelTools.uniform(color, f(0, row, width, 1))) scandown(color, width, row + 1, f)
-    else row
+  @tailrec
+  final def scandown(color: Color, height: Int, width: Int, row: Int, f: PixelsExtractor): Int = {
+    if (row == height || !PixelTools.uniform(color, f(0, row, width, 1))) row
+    else scandown(color, height, width, row + 1, f)
   }
 
-  def scanup(color: Color, width: Int, row: Int, f: PixelsExtractor): Int = {
-    if (PixelTools.uniform(color, f(0, row, width, 1))) scanup(color, width, row - 1, f)
-    else row
+  @tailrec
+  final def scanup(color: Color, height: Int, width: Int, row: Int, f: PixelsExtractor): Int = {
+    if (row == 0 || !PixelTools.uniform(color, f(0, row, width, 1))) row
+    else scanup(color, height, width, row - 1, f)
   }
 }

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -70,10 +70,10 @@ class Image(awt: BufferedImage, val metadata: ImageMetadata) extends MutableAwtI
     * @return
     */
   def autocrop(color: Color): Image = {
-    val x1 = AutocropOps.scanright(color, height, 0, pixels)
-    val x2 = AutocropOps.scanleft(color, height, width - 1, pixels)
-    val y1 = AutocropOps.scandown(color, width, 0, pixels)
-    val y2 = AutocropOps.scanup(color, width, height - 1, pixels)
+    val x1 = AutocropOps.scanright(color, height, width, 0, pixels)
+    val x2 = AutocropOps.scanleft(color, height, width, width - 1, pixels)
+    val y1 = AutocropOps.scandown(color, height, width, 0, pixels)
+    val y2 = AutocropOps.scanup(color, height, width, height - 1, pixels)
     subimage(x1, y1, x2 - x1, y2 - y1)
   }
 

--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/ParImage.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/ParImage.scala
@@ -32,10 +32,10 @@ class ParImage(awt: BufferedImage, val metadata: ImageMetadata) extends MutableA
    * @return
    */
   def autocrop(color: Color)(implicit executor: ExecutionContext): Future[ParImage] = {
-    val x1F = Future(AutocropOps.scanright(color, height, 0, pixels))
-    val x2F = Future(AutocropOps.scanleft(color, height, width - 1, pixels))
-    val y1F = Future(AutocropOps.scandown(color, width, 0, pixels))
-    val y2F = Future(AutocropOps.scanup(color, width, height - 1, pixels))
+    val x1F = Future(AutocropOps.scanright(color, height, width, 0, pixels))
+    val x2F = Future(AutocropOps.scanleft(color, height, width, width - 1, pixels))
+    val y1F = Future(AutocropOps.scandown(color, height, width, 0, pixels))
+    val y2F = Future(AutocropOps.scanup(color, height, width, height - 1, pixels))
     for ( x1 <- x1F; x2 <- x2F; y1 <- y1F; y2 <- y2F ) yield {
       subimage(x1, y1, x2 - x1, y2 - y1)
     }


### PR DESCRIPTION
Hello.

Autocrop method throws ```ArrayIndexOutOfBoundsException``` when working with all-white images because ```AutocropOps``` functions have not array bound checks. I don't know is this bug or feature, but I made my variant of ```AutocropOps```.

I create array bound checks and tail recursion optimization.