### PR TITLE
Fix #144, black bar occurring on images with an odd size.

### DIFF
--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/DimensionTools.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/DimensionTools.scala
@@ -28,9 +28,9 @@ object DimensionTools {
     val yscale = target._2 / source._2.toDouble
 
     if (xscale > yscale) {
-      ((source._1 * xscale).toInt, (source._2 * xscale).toInt)
+      ((source._1 * xscale).ceil.toInt, (source._2 * xscale).ceil.toInt)
     } else {
-      ((source._1 * yscale).toInt, (source._2 * yscale).toInt)
+      ((source._1 * yscale).ceil.toInt, (source._2 * yscale).ceil.toInt)
     }
   }
 

--- a/scrimage-core/src/test/scala/com/sksamuel/scrimage/DimensionToolsTest.scala
+++ b/scrimage-core/src/test/scala/com/sksamuel/scrimage/DimensionToolsTest.scala
@@ -38,12 +38,12 @@ class DimensionToolsTest extends FunSuite with BeforeAndAfter with OneInstancePe
 
   test("when covering an area that is wider and taller than the aspect ratio is maintained") {
     val covered = DimensionTools.dimensionsToCover((106, 120), (80, 100))
-    assert((106, 132) === covered)
+    assert((106, 133) === covered)
   }
 
   test("when covering an area that is smaller the dimensions reduce to match") {
     val covered = DimensionTools.dimensionsToCover((145, 300), (657, 526))
-    assert((374, 300) === covered)
+    assert((375, 300) === covered)
   }
 }
 

--- a/scrimage-core/src/test/scala/com/sksamuel/scrimage/Issue144Test.scala
+++ b/scrimage-core/src/test/scala/com/sksamuel/scrimage/Issue144Test.scala
@@ -1,0 +1,20 @@
+package com.sksamuel.scrimage
+
+import org.scalatest.{Matchers, WordSpec}
+
+class Issue144Test extends WordSpec with Matchers {
+
+  "Cover resize" should {
+    "not produce a black bar on an image with an odd size" in {
+      val img = Image.filled(2357, 2400, Color.White)
+
+      val resized = img.cover(200, 200)
+      val pixel   = resized.pixel(199, 0)
+
+      pixel.red shouldBe 255
+      pixel.blue shouldBe 255
+      pixel.green shouldBe 255
+    }
+  }
+
+}


### PR DESCRIPTION
The problem was caused by calling toInt after floating multiplication, which rounds down,