### PR TITLE
Improve exception message when a resize filter cannot be applied

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
+++ b/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
@@ -79,6 +79,11 @@ public class ResampleOp extends AdvancedResizeOp {
     horizontalSubsamplingData = createSubSampling(filter, srcWidth, dstWidth);
     verticalSubsamplingData = createSubSampling(filter, srcHeight, dstHeight);
 
+    if (srcWidth < horizontalSubsamplingData.numContributors || srcHeight < verticalSubsamplingData.numContributors) {
+      throw new RuntimeException("Error doing rescale. Source size was " + srcWidth + "x" + srcHeight + " but must be" +
+        " at least " + horizontalSubsamplingData.numContributors + "x" + verticalSubsamplingData.numContributors);
+    }
+
     final BufferedImage scrImgCopy = srcImg;
     final byte[][] workPixelsCopy = workPixels;
 


### PR DESCRIPTION
Scrimage is currently throwing an `ArrayIndexOutOfBoundsException` if a resize filter cannot be applied because the image is too small (there are not enough sample points).

This PR adds a an early check to throw a `RuntimeException` with a better error message when this  happens.

Fix #162 (Kind of... there's still an exception, but at least now it's easier to find out what's going on)