### PR TITLE
Fix grayscale conversion

### DIFF
--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/color.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/color.scala
@@ -20,13 +20,13 @@ trait Color {
 
   def toHSL: HSLColor = toRGB.toHSL
 
-  def toGreyscale: Grayscale = {
+  def toGrayscale: Grayscale = {
     val rgb = toRGB
-    val red = 0.21 * rgb.red
-    val green = 0.71 * rgb.green
-    val blue = 0.07 * rgb.blue
+    val red = 0.2126 * rgb.red
+    val green = 0.7152 * rgb.green
+    val blue = 0.0722 * rgb.blue
     val gray = red + green + blue
-    Grayscale(Math.round(gray * 255).toInt, rgb.alpha)
+    Grayscale(Math.round(gray).toInt, rgb.alpha)
   }
 
   /**
@@ -276,6 +276,6 @@ case class HSLColor(hue: Float, saturation: Float, lightness: Float, alpha: Floa
   }
 }
 
-case class Grayscale(grey: Int, alpha: Int = 255) extends Color {
-  override def toRGB: RGBColor = RGBColor(grey, grey, grey, alpha)
+case class Grayscale(gray: Int, alpha: Int = 255) extends Color {
+  override def toRGB: RGBColor = RGBColor(gray, gray, gray, alpha)
 }

--- a/scrimage-core/src/test/scala/com/sksamuel/scrimage/ColorTest.scala
+++ b/scrimage-core/src/test/scala/com/sksamuel/scrimage/ColorTest.scala
@@ -30,6 +30,10 @@ class ColorTest extends WordSpec with Matchers {
       hsl.saturation shouldBe 0.4121f +- 0.01f
       hsl.value shouldBe 1f +- 0.01f
     }
+    "convert rgb to grayscale correctly" in {
+      val rgb = RGBColor(100, 100, 100)
+      rgb.toGrayscale.gray shouldBe 100
+    }
     "convert cmyk to rgb correctly" in {
       val rgb = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f).toRGB
       rgb.red shouldBe 138
@@ -50,6 +54,13 @@ class ColorTest extends WordSpec with Matchers {
       rgb.green shouldBe 77
       rgb.blue shouldBe 69
       rgb.alpha shouldBe 255
+    }
+    "convert grayscale to rgb correctly" in {
+      val rgb = Grayscale(100, 128).toRGB
+      rgb.red shouldBe 100
+      rgb.green shouldBe 100
+      rgb.blue shouldBe 100
+      rgb.alpha shouldBe 128
     }
     "be symmetric in rgb" in {
       val rgb = RGBColor(1, 2, 3)
@@ -116,6 +127,9 @@ class ColorTest extends WordSpec with Matchers {
 
       val cmyk = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f)
       cmyk.toCMYK shouldBe cmyk
+
+      val gray = Grayscale(100)
+      gray.toGrayscale shouldBe gray
     }
   }
 }


### PR DESCRIPTION
Fix #161 

I also changed `Grey` to `Gray`,  as `Gray` showed up in more places in the code.