### PR TITLE
Change `fromStream` stream size validation logic

### DIFF
--- a/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
+++ b/scrimage-core/src/main/scala/com/sksamuel/scrimage/Image.scala
@@ -891,8 +891,8 @@ object Image extends Using {
     */
   def fromStream(in: InputStream, `type`: Int = CANONICAL_DATA_TYPE): Image = {
     require(in != null, "InputStream must not be null")
-    require(in.available > 0, "InputStream must have more than 0 bytes available")
     val bytes = IOUtils.toByteArray(in)
+    require(bytes.nonEmpty, "InputStream must not be empty")
     apply(bytes, `type`)
   }
 


### PR DESCRIPTION
Changes the `fromStream` stream size validation logic to use the byte array size instead of the `available` bytes.

Fix #169 