### PR TITLE
Fix version syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ Scrimage is cross compiled for scala 2.12, 2.11 and 2.10.
 
 If using SBT then you want:
 ```scala
-libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-core" % "2.x.x"
+libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-core" % "2.+"
 
-libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-io-extra" % "2.x.x"
+libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-io-extra" % "2.+"
 
-libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-filters" % "2.x.x"
+libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-filters" % "2.+"
 ```
 
 Maven:


### PR DESCRIPTION
See https://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html