### PR TITLE
upgrade to metadata-extractor version without stack overflow vulnerab…

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object Build extends AutoPlugin {
     val org = "com.sksamuel.scrimage"
     val TwelveMonkeysVersion = "3.4.2"
     val PngjVersion = "2.1.0"
-    val MetadataExtractorVersion = "2.12.0"
+    val MetadataExtractorVersion = "2.13.0"
     val ScalatestVersion = "3.0.8"
     val CommonsIoVersion = "2.6"
   }


### PR DESCRIPTION
…ility

Hello @sksamuel, 

scrimage currently uses metadata-extractor 2.12.0, which suffers from a stackoverflow vulnerability (see https://github.com/drewnoakes/metadata-extractor-dotnet/pull/190 for details - in the dotnet version of metadata-extractor)

The vulnerability is fixed in version 2.13.0 of metadata-extractor (see https://github.com/drewnoakes/metadata-extractor-dotnet/pull/190#issuecomment-588491238).

Can we please upgrade to metadata-extractor 2.13.0?

P.S. see https://github.com/sksamuel/scrimage/issues/187