### PR TITLE
Check for progressive support before disabling

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
@@ -47,10 +47,12 @@ public class GifWriter implements ImageWriter {
         javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName("gif").next();
         ImageWriteParam params = writer.getDefaultWriteParam();
 
-        if (progressive) {
-            params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
-        } else {
-            params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
+        if (params.canWriteProgressive()) {
+          if (progressive) {
+              params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
+          } else {
+              params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
+          }
         }
 
         try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
@@ -49,10 +49,12 @@ public class JpegWriter implements ImageWriter {
          params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
          params.setCompressionQuality(compression / 100f);
       }
-      if (progressive) {
-         params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
-      } else {
-         params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
+      if (params.canWriteProgressive()) {
+         if (progressive) {
+            params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
+         } else {
+            params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
+         }
       }
 
       // in openjdk, awt cannot write out jpegs that have a transparency bit, even if that is set to 255.


### PR DESCRIPTION
An exception is thrown "Progressive output not supported" when setting progressive to false.

This PR adds a check for canWriteProgressive().

```
public void setProgressiveMode(int mode) {
    if (!this.canWriteProgressive()) {
        throw new UnsupportedOperationException("Progressive output not supported");
    } else if (mode >= 0 && mode <= 3) {
        if (mode == 2) {
            throw new IllegalArgumentException("MODE_EXPLICIT not supported for progressive output");
        } else {
            this.progressiveMode = mode;
        }
    } else {
        throw new IllegalArgumentException("Illegal value for mode!");
    }
}
```