### PR TITLE
fix quickstart scala examples

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -20,7 +20,7 @@ around the [TwelveMonkeys](https://github.com/haraldk/TwelveMonkeys) library.
 === "SBT"
 
     ```scala
-    libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-core" % "$version"
+    libraryDependencies += "com.sksamuel.scrimage" % "scrimage-core" % "$version"
     libraryDependencies += "com.sksamuel.scrimage" %% "scrimage-scala" % "$version"
     ```
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -40,7 +40,7 @@ around the [TwelveMonkeys](https://github.com/haraldk/TwelveMonkeys) library.
 ### Scala Helpers
 
 If you are using Scala and you have added the scala module, then add the import
-`import com.sksamuel.scrimage.scala._` to bring into scope some useful implicits.
+`import com.sksamuel.scrimage.implicits._` to bring into scope some useful implicits.
 
 Firstly, an implicit `PNGWriter` so you do not have to specify it when outputting images.
 Secondly, a conversion to / from


### PR DESCRIPTION
1. core library is a java library, hence only one % should be used
2. the package of the scala implicits has changed