### PR TITLE
Added the option to use multithreading when encoding webp

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
@@ -47,12 +47,13 @@ public class CWebpHandler extends WebpHandler {
                          int q,
                          int z,
                          boolean lossless,
-                         boolean withoutAlpha) throws IOException {
+                         boolean withoutAlpha,
+                         boolean multiThread) throws IOException {
       Path input = Files.createTempFile("input", "webp").toAbsolutePath();
       Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();
       try {
          Files.write(input, bytes, StandardOpenOption.CREATE);
-         convert(input, output, m, q, z, lossless, withoutAlpha);
+         convert(input, output, m, q, z, lossless, withoutAlpha, multiThread);
          return Files.readAllBytes(output);
       } finally {
          try {
@@ -72,8 +73,8 @@ public class CWebpHandler extends WebpHandler {
                         int q,
                         int z,
                         boolean lossless,
-                        boolean withoutAlpha) throws IOException {
-
+                        boolean withoutAlpha,
+                        boolean multiThread) throws IOException {
       Path stdout = Files.createTempFile("stdout", "webp");
       List<String> commands = new ArrayList<>();
       commands.add(binary.toAbsolutePath().toString());
@@ -94,6 +95,9 @@ public class CWebpHandler extends WebpHandler {
       }
       if (withoutAlpha) {
          commands.add("-noalpha");
+      }
+      if (multiThread) {
+         commands.add("-mt");
       }
       commands.add(input.toAbsolutePath().toString());
       commands.add("-o");

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpWriter.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpWriter.java
@@ -20,6 +20,7 @@ public class WebpWriter implements ImageWriter {
    private final int m;
    private final boolean lossless;
    private final boolean noAlpha;
+   private final boolean multiThread;
 
    public WebpWriter() {
       z = -1;
@@ -27,6 +28,7 @@ public class WebpWriter implements ImageWriter {
       m = -1;
       lossless = false;
       noAlpha = false;
+      multiThread = false;
    }
 
    public WebpWriter(int z, int q, int m, boolean lossless) {
@@ -35,6 +37,7 @@ public class WebpWriter implements ImageWriter {
       this.m = m;
       this.lossless = lossless;
       this.noAlpha = false;
+      this.multiThread = false;
    }
 
    public WebpWriter(int z, int q, int m, boolean lossless, boolean noAlpha) {
@@ -43,6 +46,16 @@ public class WebpWriter implements ImageWriter {
       this.m = m;
       this.lossless = lossless;
       this.noAlpha = noAlpha;
+      this.multiThread = false;
+   }
+
+   public WebpWriter(int z, int q, int m, boolean lossless, boolean noAlpha, boolean multiThread) {
+      this.z = z;
+      this.q = q;
+      this.m = m;
+      this.lossless = lossless;
+      this.noAlpha = noAlpha;
+      this.multiThread = multiThread;
    }
 
    public WebpWriter withLossless() {
@@ -51,6 +64,10 @@ public class WebpWriter implements ImageWriter {
 
    public WebpWriter withoutAlpha() {
       return new WebpWriter(z, q, m, lossless, true);
+   }
+
+   public WebpWriter withMultiThread() {
+      return new WebpWriter(z, q, m, lossless, noAlpha, multiThread);
    }
 
    public WebpWriter withQ(int q) {
@@ -73,7 +90,7 @@ public class WebpWriter implements ImageWriter {
 
    @Override
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
-      byte[] bytes = handler.convert(image.bytes(PngWriter.NoCompression), m, q, z, lossless, noAlpha);
+      byte[] bytes = handler.convert(image.bytes(PngWriter.NoCompression), m, q, z, lossless, noAlpha, multiThread);
       out.write(bytes);
    }
 }

--- a/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/WebpTest.kt
+++ b/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/WebpTest.kt
@@ -30,6 +30,13 @@ class WebpTest : FunSpec() {
             javaClass.getResourceAsStream("/noAlpha.webp").readBytes()
       }
 
+      test("render with multi thread") {
+         val webpWriter = WebpWriter.MAX_LOSSLESS_COMPRESSION.withMultiThread()
+         ImmutableImage.loader().fromResource("/spacedock.jpg").scale(0.5)
+            .bytes(webpWriter) shouldBe
+            javaClass.getResourceAsStream("/spacedock.webp").readBytes()
+      }
+
       test("dwebp should capture error on failure") {
          val dwebpPath = WebpHandler.getBinaryPaths("dwebp")[2]
 


### PR DESCRIPTION
Hello.

First of all, thank you for creating an awesome JVM library and providing it as open source.

I'm using the scrimage library for webp encoding. It seems to be using `cwebp` for encoding, and I can apply several option flags, including `noalpha`. I think it would be nice to additionally support the (`-mt`) multithread option provided by cwebp.

The multithread feature is already provided in libwebp-1.3.2 cwebp, so if it is provided as an optional flag, I think it will work fine. I've added a new constructor for WebpWriter (keeping the old ones), and I don't think there should be any problems with backwards compatibility since the mt option defaults to false.
If you don't mind, I hope you will accept my MR.


<img width="519" alt="스크린샷 2024-04-12 오후 11 14 51" src="https://github.com/sksamuel/scrimage/assets/55838461/b739bc92-85c5-4fdc-b9b2-a4d657f31140">