### PR TITLE
Fix native memory leak in ImageIOReader

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
@@ -28,20 +28,24 @@ public class ImageIOReader implements ImageReader {
    }
 
    private ImmutableImage tryLoad(javax.imageio.ImageReader reader, ImageInputStream iis, Rectangle rectangle) throws IOException {
-      reader.setInput(iis);
+      try {
+         reader.setInput(iis);
 
-      ImageReadParam params = reader.getDefaultReadParam();
-      Iterator<ImageTypeSpecifier> imageTypes = reader.getImageTypes(0);
-      if (imageTypes.hasNext()) {
-         ImageTypeSpecifier imageTypeSpecifier = imageTypes.next();
-         params.setDestinationType(imageTypeSpecifier);
-      }
-      if (rectangle != null) {
-         params.setSourceRegion(rectangle);
-      }
+         ImageReadParam params = reader.getDefaultReadParam();
+         Iterator<ImageTypeSpecifier> imageTypes = reader.getImageTypes(0);
+         if (imageTypes.hasNext()) {
+            ImageTypeSpecifier imageTypeSpecifier = imageTypes.next();
+            params.setDestinationType(imageTypeSpecifier);
+         }
+         if (rectangle != null) {
+            params.setSourceRegion(rectangle);
+         }
 
-      BufferedImage bufferedImage = reader.read(0, params);
-      return ImmutableImage.wrapAwt(bufferedImage);
+         BufferedImage bufferedImage = reader.read(0, params);
+         return ImmutableImage.wrapAwt(bufferedImage);
+      } finally {
+         reader.dispose();
+      }
    }
 
    @Override
@@ -54,25 +58,29 @@ public class ImageIOReader implements ImageReader {
       if (iis == null)
          throw new IOException("No ImageInputStream supported this image format");
 
-      Iterator<javax.imageio.ImageReader> iter;
-      if (readers.isEmpty())
-         iter = ImageIO.getImageReaders(iis);
-      else
-         iter = readers.iterator();
+      try {
+         Iterator<javax.imageio.ImageReader> iter;
+         if (readers.isEmpty())
+            iter = ImageIO.getImageReaders(iis);
+         else
+            iter = readers.iterator();
 
-      List<String> attempts = new ArrayList<>();
-      while (iter.hasNext()) {
-         try {
-            return tryLoad(iter.next(), iis, rectangle);
-         } catch (Exception e) {
-            attempts.add(e.getMessage());
+         List<String> attempts = new ArrayList<>();
+         while (iter.hasNext()) {
+            try {
+               return tryLoad(iter.next(), iis, rectangle);
+            } catch (Exception e) {
+               attempts.add(e.getMessage());
+            }
          }
-      }
 
-      if (attempts.isEmpty())
-         throw new IOException("No javax.imageio.ImageReader supported this image format");
-      else
-         throw new IOException("No javax.imageio.ImageReader supported this image format; tried " + attempts.size() + " readers; errors=" + attempts);
+         if (attempts.isEmpty())
+            throw new IOException("No javax.imageio.ImageReader supported this image format");
+         else
+            throw new IOException("No javax.imageio.ImageReader supported this image format; tried " + attempts.size() + " readers; errors=" + attempts);
+      } finally {
+         iis.close();
+      }
    }
 
    @Override

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
@@ -44,6 +44,15 @@ public class ImageIOReader implements ImageReader {
          BufferedImage bufferedImage = reader.read(0, params);
          return ImmutableImage.wrapAwt(bufferedImage);
       } finally {
+         // javax.imageio.ImageReader is a thin Java wrapper around a native decoder. When you read a JPEG,
+         // the JDK loads libjavajpeg.so and allocates native structs (Huffman tables, coefficient buffers, SOF data)
+         // using malloc. When you read a WebP, the luciad
+         // webp-imageio plugin calls WebPEncoderOptions_createConfig which does a calloc in native code.
+         // These allocations live outside the Java heap — the GC has no visibility into them.
+         //
+         //  The contract for javax.imageio.ImageReader is that you must call reader.dispose() when done.
+         //  That method triggers the JNI dispose call which runs the corresponding free() on those native structs.
+         //  Without it, the memory is permanently leaked for the lifetime of the JVM process.
          reader.dispose();
       }
    }


### PR DESCRIPTION
## Summary

- `javax.imageio.ImageReader` instances were never disposed after use, causing native memory to accumulate for each image processed (JPEG structs, WebP encoder configs, AWT surface data)
- The `ImageInputStream` created in `read()` was also never closed
- Both resources require explicit cleanup — GC alone does not free native memory held by these objects

## Changes

In `ImageIOReader.java`:
- `tryLoad()` now calls `reader.dispose()` in a `finally` block, ensuring cleanup whether the read succeeds or throws
- `read()` now closes the `ImageInputStream` in a `finally` block

## Related

Closes #307

## Test plan

- [x] Existing tests pass (`./gradlew :scrimage-core:test :scrimage-formats-extra:test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)