### PR TITLE
Fix infinite loop in AwtImage.patch()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -365,8 +365,8 @@ public class AwtImage {
    public Pixel[] patch(int x, int y, int patchWidth, int patchHeight) {
       Pixel[] px = pixels();
       Pixel[] patch = new Pixel[patchWidth * patchHeight];
-      for (int i = y; i < y + patchHeight; y++) {
-         System.arraycopy(px, offset(x, y), patch, offset(0, y), patchWidth);
+      for (int i = 0; i < patchHeight; i++) {
+         System.arraycopy(px, offset(x, y + i), patch, offset(0, i), patchWidth);
       }
       return patch;
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/A.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/A.kt
@@ -1,0 +1,4 @@
+package com.sksamuel.scrimage
+
+object A {
+}

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/A.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/A.kt
@@ -1,4 +1,0 @@
-package com.sksamuel.scrimage
-
-object A {
-}


### PR DESCRIPTION
## Summary

- The `patch()` method in `AwtImage.java` contained a `for` loop that incremented `y` instead of `i`, so the loop variable `i` never advanced
- Because `y` grows each iteration, the condition `i < y + patchHeight` is always true, creating an infinite loop whenever `patchHeight > 0`
- Fixed by rewriting the loop to iterate `i` from `0` to `patchHeight` and addressing rows as `y + i`

**Before:**
```java
for (int i = y; i < y + patchHeight; y++) {
    System.arraycopy(px, offset(x, y), patch, offset(0, y), patchWidth);
}
```

**After:**
```java
for (int i = 0; i < patchHeight; i++) {
    System.arraycopy(px, offset(x, y + i), patch, offset(0, i), patchWidth);
}
```

## Test plan

- [ ] Call `patch()` on any image with `patchHeight > 0` and verify it returns without hanging
- [ ] Verify the returned patch contains the correct pixels from the expected region

🤖 Generated with [Claude Code](https://claude.com/claude-code)