### PR TITLE
Fix green/blue channel swap in Pixel.mapByComponent()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
@@ -142,7 +142,7 @@ public class Pixel {
    }
 
    public Pixel mapByComponent(Function<Integer, Integer> f) {
-      return new Pixel(x, y, f.apply(red()), f.apply(blue()), f.apply(green()), f.apply(alpha()));
+      return new Pixel(x, y, f.apply(red()), f.apply(green()), f.apply(blue()), f.apply(alpha()));
    }
 
    @Override


### PR DESCRIPTION
## Summary

- `Pixel.mapByComponent()` passed green and blue to the `Pixel` constructor in the wrong order
- The constructor signature is `Pixel(x, y, red, green, blue, alpha)` but the call passed `blue` before `green`, silently producing incorrect colors for any per-component transformation (e.g. brightness, contrast, gamma adjustments)

**Before:**
```java
return new Pixel(x, y, f.apply(red()), f.apply(blue()), f.apply(green()), f.apply(alpha()));
```

**After:**
```java
return new Pixel(x, y, f.apply(red()), f.apply(green()), f.apply(blue()), f.apply(alpha()));
```

## Test plan

- [ ] Apply a per-component filter (e.g. `Pixels.mapByComponent`) that modifies only the blue channel and verify the blue channel (not green) changes in the output
- [ ] Verify a no-op mapping (`x -> x`) returns identical pixels

🤖 Generated with [Claude Code](https://claude.com/claude-code)