### PR TITLE
Fix alpha channel lost in HSLColor.toRGB() for chromatic colors

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
@@ -69,7 +69,7 @@ public class HSLColor implements Color {
             float r = hue2rgb(p, q, h + 1f / 3f);
             float g = hue2rgb(p, q, h);
             float b = hue2rgb(p, q, h - 1f / 3f);
-            return new RGBColor(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), 255);
+            return new RGBColor(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), Math.round(alpha * 255));
         }
     }
 


### PR DESCRIPTION
## Summary

- `HSLColor.toRGB()` has two branches: achromatic (grey) and chromatic (all other colors)
- The achromatic branch correctly preserved alpha with `Math.round(alpha * 255)`
- The chromatic branch hardcoded `255`, silently stripping transparency from any semi-transparent colored HSL value

**Before:**
```java
return new RGBColor(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), 255);
```

**After:**
```java
return new RGBColor(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), Math.round(alpha * 255));
```

## Test plan

- [ ] Create a semi-transparent `HSLColor` (alpha < 1.0) with non-zero saturation, call `toRGB()`, and verify alpha is preserved
- [ ] Verify fully opaque HSL colors (alpha = 1.0) still produce alpha = 255 in the output
- [ ] Verify the achromatic path (saturation = 0) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)