### PR TITLE
Fix missing k++ in AwtImage.patches()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -398,6 +398,7 @@ public class AwtImage {
       for (int row = 0; row < height - patchHeight; row++) {
          for (int col = 0; col < width - patchWidth; col++) {
             patches[k] = patch(col, row, patchWidth, patchHeight);
+            k++;
          }
       }
       return patches;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -366,7 +366,7 @@ public class AwtImage {
       Pixel[] px = pixels();
       Pixel[] patch = new Pixel[patchWidth * patchHeight];
       for (int i = 0; i < patchHeight; i++) {
-         System.arraycopy(px, offset(x, y + i), patch, offset(0, i), patchWidth);
+         System.arraycopy(px, offset(x, y + i), patch, i * patchWidth, patchWidth);
       }
       return patch;
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -1,10 +1,39 @@
 package com.sksamuel.scrimage.core
 
 import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 class AwtImageTest : FunSpec({
+
+   // Regression tests for https://github.com/sksamuel/scrimage/pull/351
+   // k was never incremented, so every patch overwrote patches[0]
+
+   test("patches returns the correct number of non-null patches") {
+      val image = ImmutableImage.create(4, 4)
+      val patches = image.patches(2, 2)
+      patches.size shouldBe (4 - 2) * (4 - 2)  // = 4
+      patches.forEach { it shouldNotBe null }
+   }
+
+   test("patches samples pixels from the correct region") {
+      // 4x4 image where each pixel's red channel equals its flat index (0..15)
+      val pixels = Array(16) { i -> Pixel(i % 4, i / 4, i, 0, 0, 255) }
+      val image = ImmutableImage.create(4, 4, pixels)
+
+      // 1x1 patches: (4-1)*(4-1) = 9; each patch contains one pixel
+      val patches = image.patches(1, 1)
+      patches.size shouldBe 9
+
+      // patch 0 → col=0, row=0 → pixel index 0 → red=0
+      patches[0][0].red() shouldBe 0
+      // patch 1 → col=1, row=0 → pixel index 1 → red=1
+      patches[1][0].red() shouldBe 1
+      // patch 3 → col=0, row=1 → pixel index 4 → red=4
+      patches[3][0].red() shouldBe 4
+   }
 
    test("AwtImage.points return array of points") {
       val image = ImmutableImage.create(6, 4)


### PR DESCRIPTION
## Summary

- `patches()` allocates an array of size `(height - patchHeight) * (width - patchWidth)` but the index variable `k` is never incremented inside the loop
- Every extracted patch overwrites `patches[0]`, leaving all other slots `null`

**Before:**
```java
for (int row = 0; row < height - patchHeight; row++) {
    for (int col = 0; col < width - patchWidth; col++) {
        patches[k] = patch(col, row, patchWidth, patchHeight);
    }
}
```

**After:**
```java
for (int row = 0; row < height - patchHeight; row++) {
    for (int col = 0; col < width - patchWidth; col++) {
        patches[k] = patch(col, row, patchWidth, patchHeight);
        k++;
    }
}
```

## Test plan

- [ ] Call `patches()` on an image and verify the returned array length matches `(height - patchHeight) * (width - patchWidth)`
- [ ] Verify no elements in the returned array are `null`
- [ ] Verify each patch contains pixels from the correct region of the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)