### PR TITLE
Fix alpha channel lost in RGBColor.toHSV() and toHSL()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -146,7 +146,7 @@ public class RGBColor implements Color {
          h = f / 6;
       }
 
-      return new HSVColor(h * 360f, s, max, 1f);
+      return new HSVColor(h * 360f, s, max, alpha / 255f);
    }
 
    // credit to https://github.com/mjackson/mjijackson.github.com/blob/master/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript.txt
@@ -183,7 +183,7 @@ public class RGBColor implements Color {
          h = f / 6;
       }
 
-      return new HSLColor(h * 360f, s, l, 1f);
+      return new HSLColor(h * 360f, s, l, alpha / 255f);
    }
 
    @Override


### PR DESCRIPTION
## Summary

- `RGBColor.toHSV()` and `RGBColor.toHSL()` both hardcoded the alpha component to `1f`, silently discarding transparency when converting a semi-transparent RGB color to HSV or HSL
- Fixed to normalise alpha consistently with how the other channels are handled: `alpha / 255f`
- This is the inverse of the HSLColor→RGB alpha bug: transparency was already being lost in both directions

**Before:**
```java
return new HSVColor(h * 360f, s, max, 1f);
// ...
return new HSLColor(h * 360f, s, l, 1f);
```

**After:**
```java
return new HSVColor(h * 360f, s, max, alpha / 255f);
// ...
return new HSLColor(h * 360f, s, l, alpha / 255f);
```

## Test plan

- [ ] Create a semi-transparent `RGBColor` (alpha < 255), call `toHSV()` and verify the returned `HSVColor` alpha equals `alpha / 255f`
- [ ] Same for `toHSL()`
- [ ] Verify fully opaque colors (alpha = 255) still produce alpha = 1.0 in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)