### PR TITLE
Fix resource leak in TwelveMonkeysWriter.write()

### DIFF
--- a/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TwelveMonkeysWriter.java
+++ b/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TwelveMonkeysWriter.java
@@ -17,11 +17,12 @@ abstract class TwelveMonkeysWriter implements ImageWriter {
     @Override
     public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
         javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName(format()).next();
-        ImageOutputStream ios = ImageIO.createImageOutputStream(out);
-        ImageWriteParam params = writer.getDefaultWriteParam();
-        writer.setOutput(ios);
-        writer.write(null, new IIOImage(image.awt(), null, null), params);
-        ios.close();
-        writer.dispose();
+        try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
+            ImageWriteParam params = writer.getDefaultWriteParam();
+            writer.setOutput(ios);
+            writer.write(null, new IIOImage(image.awt(), null, null), params);
+        } finally {
+            writer.dispose();
+        }
     }
 }

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.scrimage.io
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.BmpWriter
+import com.sksamuel.scrimage.nio.SgiWriter
+import com.sksamuel.scrimage.nio.TiffWriter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+// https://github.com/sksamuel/scrimage/pull/354
+class TwelveMonkeysWriterTest : FunSpec({
+
+   val original = ImmutableImage.loader().fromStream(javaClass.getResourceAsStream("/picard.jpeg"))
+      .scaleTo(100, 100)
+
+   test("BmpWriter round-trips image dimensions") {
+      val bytes = original.bytes(BmpWriter())
+      val actual = ImmutableImage.loader().fromBytes(bytes)
+      actual.width shouldBe original.width
+      actual.height shouldBe original.height
+   }
+
+   test("TiffWriter round-trips image dimensions") {
+      val bytes = original.bytes(TiffWriter())
+      val actual = ImmutableImage.loader().fromBytes(bytes)
+      actual.width shouldBe original.width
+      actual.height shouldBe original.height
+   }
+
+   test("SgiWriter round-trips image dimensions") {
+      val bytes = original.bytes(SgiWriter())
+      val actual = ImmutableImage.loader().fromBytes(bytes)
+      actual.width shouldBe original.width
+      actual.height shouldBe original.height
+   }
+
+   test("BmpWriter write does not leak resources on repeated writes") {
+      repeat(100) {
+         original.bytes(BmpWriter())
+      }
+   }
+})

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
@@ -2,7 +2,7 @@ package com.sksamuel.scrimage.io
 
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.nio.BmpWriter
-import com.sksamuel.scrimage.nio.SgiWriter
+import com.sksamuel.scrimage.nio.TgaWriter
 import com.sksamuel.scrimage.nio.TiffWriter
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -27,8 +27,8 @@ class TwelveMonkeysWriterTest : FunSpec({
       actual.height shouldBe original.height
    }
 
-   test("SgiWriter round-trips image dimensions") {
-      val bytes = original.bytes(SgiWriter())
+   test("TgaWriter round-trips image dimensions") {
+      val bytes = original.bytes(TgaWriter())
       val actual = ImmutableImage.loader().fromBytes(bytes)
       actual.width shouldBe original.width
       actual.height shouldBe original.height


### PR DESCRIPTION
## Summary

- `ios` and `writer` were closed via straight-line calls with no try/finally, so any exception thrown during `writer.write()` left both resources open
- Fixed by wrapping `ios` in try-with-resources (guarantees close even on exception) and disposing `writer` in a finally block

**Before:**
```java
javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName(format()).next();
ImageOutputStream ios = ImageIO.createImageOutputStream(out);
// ...
writer.write(null, new IIOImage(image.awt(), null, null), params);
ios.close();
writer.dispose();
```

**After:**
```java
javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName(format()).next();
try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
    // ...
    writer.write(null, new IIOImage(image.awt(), null, null), params);
} finally {
    writer.dispose();
}
```

## Test plan

- [ ] Verify writing still works correctly for all formats that extend `TwelveMonkeysWriter`
- [ ] Simulate a write failure and confirm neither `ios` nor `writer` is leaked (e.g. via a mock or by checking that `dispose()` is called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)