### PR TITLE
Add ImmutableImageLoader.fromTorchTensor() for CHW tensor data

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImmutableImageLoader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImmutableImageLoader.java
@@ -5,6 +5,7 @@ import com.sksamuel.scrimage.metadata.ImageMetadata;
 import com.sksamuel.scrimage.metadata.OrientationTools;
 
 import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -140,6 +141,95 @@ public class ImmutableImageLoader {
       if (in == null)
          throw new IOException("Input stream is null");
       return load(new InputStreamImageSource(in));
+   }
+
+   /**
+    * Creates an {@link ImmutableImage} from a PyTorch-style tensor stored as a flat int array.
+    *
+    * <p>The tensor must be in CHW (channel, height, width) order with pixel values in the range
+    * 0–255. Supported channel counts are 1 (grayscale), 3 (RGB), and 4 (RGBA).
+    *
+    * <p>The resulting image type is {@link BufferedImage#TYPE_INT_ARGB} for 4-channel tensors,
+    * {@link BufferedImage#TYPE_INT_RGB} for 1- or 3-channel tensors, unless overridden via
+    * {@link #type(int)}.
+    *
+    * @param data   flat tensor data in CHW order, values 0–255
+    * @param width  image width (W dimension)
+    * @param height image height (H dimension)
+    * @return a new {@link ImmutableImage}
+    * @throws IllegalArgumentException if the channel count is not 1, 3, or 4, or if the data
+    *                                  length does not match width × height × channels
+    */
+   public ImmutableImage fromTorchTensor(int[] data, int width, int height) {
+      int numPixels = width * height;
+      if (numPixels == 0)
+         throw new IllegalArgumentException("width and height must both be greater than zero");
+      if (data.length % numPixels != 0)
+         throw new IllegalArgumentException(
+            "Data length " + data.length + " is not divisible by width × height (" + numPixels + ")");
+      int channels = data.length / numPixels;
+      if (channels != 1 && channels != 3 && channels != 4)
+         throw new IllegalArgumentException(
+            "Tensor must have 1, 3, or 4 channels but has " + channels);
+
+      int defaultType = channels == 4 ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+      int imageType = type > 0 ? type : defaultType;
+      BufferedImage buffered = new BufferedImage(width, height, imageType);
+
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            int idx = y * width + x;
+            int argb;
+            if (channels == 1) {
+               int v = clamp(data[idx]);
+               argb = (255 << 24) | (v << 16) | (v << 8) | v;
+            } else if (channels == 3) {
+               int r = clamp(data[idx]);
+               int g = clamp(data[numPixels + idx]);
+               int b = clamp(data[2 * numPixels + idx]);
+               argb = (255 << 24) | (r << 16) | (g << 8) | b;
+            } else {
+               int r = clamp(data[idx]);
+               int g = clamp(data[numPixels + idx]);
+               int b = clamp(data[2 * numPixels + idx]);
+               int a = clamp(data[3 * numPixels + idx]);
+               argb = (a << 24) | (r << 16) | (g << 8) | b;
+            }
+            buffered.setRGB(x, y, argb);
+         }
+      }
+
+      return ImmutableImage.wrapAwt(buffered);
+   }
+
+   /**
+    * Creates an {@link ImmutableImage} from a PyTorch-style tensor stored as a flat float array.
+    *
+    * <p>The tensor must be in CHW (channel, height, width) order with pixel values in the range
+    * 0.0–1.0. Values outside this range are clamped. Supported channel counts are 1 (grayscale),
+    * 3 (RGB), and 4 (RGBA).
+    *
+    * <p>The resulting image type is {@link BufferedImage#TYPE_INT_ARGB} for 4-channel tensors,
+    * {@link BufferedImage#TYPE_INT_RGB} for 1- or 3-channel tensors, unless overridden via
+    * {@link #type(int)}.
+    *
+    * @param data   flat tensor data in CHW order, values 0.0–1.0
+    * @param width  image width (W dimension)
+    * @param height image height (H dimension)
+    * @return a new {@link ImmutableImage}
+    * @throws IllegalArgumentException if the channel count is not 1, 3, or 4, or if the data
+    *                                  length does not match width × height × channels
+    */
+   public ImmutableImage fromTorchTensor(float[] data, int width, int height) {
+      int[] intData = new int[data.length];
+      for (int i = 0; i < data.length; i++) {
+         intData[i] = Math.round(data[i] * 255f);
+      }
+      return fromTorchTensor(intData, width, height);
+   }
+
+   private static int clamp(int value) {
+      return Math.max(0, Math.min(255, value));
    }
 
    public ImmutableImage load(ImageSource source) throws IOException {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.scrimage.core.color
 
+import com.sksamuel.scrimage.color.HSLColor
 import com.sksamuel.scrimage.color.HSVColor
 import com.sksamuel.scrimage.color.RGBColor
 import io.kotest.core.spec.style.StringSpec
@@ -48,6 +49,18 @@ class RGBColorTest : StringSpec({
          this.value shouldBe (0.498F plusOrMinus 0.01F)
       }
       RGBColor(255, 255, 255).toHSV() shouldBe HSVColor(0F, 0F, 1F, 1F)
+   }
+
+   "toHSV preserves alpha from RGB" {
+      RGBColor(59, 68, 127, 128).toHSV().alpha shouldBe (128 / 255f plusOrMinus 0.001f)
+      RGBColor(59, 68, 127, 0).toHSV().alpha shouldBe 0f
+      RGBColor(59, 68, 127, 255).toHSV().alpha shouldBe 1f
+   }
+
+   "toHSL preserves alpha from RGB" {
+      RGBColor(59, 68, 127, 128).toHSL().alpha shouldBe (128 / 255f plusOrMinus 0.001f)
+      RGBColor(59, 68, 127, 0).toHSL().alpha shouldBe 0f
+      RGBColor(59, 68, 127, 255).toHSL().alpha shouldBe 1f
    }
 
    "convert to HSV and back to RGB" {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImmutableImageLoaderTorchTensorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImmutableImageLoaderTorchTensorTest.kt
@@ -1,0 +1,98 @@
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.ImmutableImageLoader
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ImmutableImageLoaderTorchTensorTest : FunSpec() {
+   init {
+
+      test("fromTorchTensor int[] reconstructs RGB pixel values from CHW layout") {
+         // 2x2 image, 3 channels (RGB), CHW layout:
+         // R channel: [[10, 20], [30, 40]]
+         // G channel: [[50, 60], [70, 80]]
+         // B channel: [[90, 100], [110, 120]]
+         val data = intArrayOf(
+            10, 20, 30, 40,   // R plane, row-major
+            50, 60, 70, 80,   // G plane
+            90, 100, 110, 120 // B plane
+         )
+         val image = ImmutableImageLoader.create().fromTorchTensor(data, 2, 2)
+         image.width shouldBe 2
+         image.height shouldBe 2
+         image.pixel(0, 0).red() shouldBe 10
+         image.pixel(0, 0).green() shouldBe 50
+         image.pixel(0, 0).blue() shouldBe 90
+         image.pixel(1, 0).red() shouldBe 20
+         image.pixel(1, 0).green() shouldBe 60
+         image.pixel(1, 0).blue() shouldBe 100
+         image.pixel(0, 1).red() shouldBe 30
+         image.pixel(0, 1).green() shouldBe 70
+         image.pixel(0, 1).blue() shouldBe 110
+         image.pixel(1, 1).red() shouldBe 40
+         image.pixel(1, 1).green() shouldBe 80
+         image.pixel(1, 1).blue() shouldBe 120
+      }
+
+      test("fromTorchTensor int[] handles grayscale (1-channel) tensor") {
+         // 2x2, 1 channel — value replicated to R, G, B
+         val data = intArrayOf(10, 20, 30, 40)
+         val image = ImmutableImageLoader.create().fromTorchTensor(data, 2, 2)
+         image.pixel(0, 0).red() shouldBe 10
+         image.pixel(0, 0).green() shouldBe 10
+         image.pixel(0, 0).blue() shouldBe 10
+         image.pixel(1, 1).red() shouldBe 40
+      }
+
+      test("fromTorchTensor int[] handles RGBA (4-channel) tensor") {
+         // 1x1, 4 channels: R=100, G=150, B=200, A=128
+         val data = intArrayOf(100, 150, 200, 128)
+         val image = ImmutableImageLoader.create().fromTorchTensor(data, 1, 1)
+         image.pixel(0, 0).red() shouldBe 100
+         image.pixel(0, 0).green() shouldBe 150
+         image.pixel(0, 0).blue() shouldBe 200
+         image.pixel(0, 0).alpha() shouldBe 128
+      }
+
+      test("fromTorchTensor int[] clamps out-of-range values") {
+         // 2x2, 3 channels — first pixel red=-10 (clamp to 0), second pixel red=300 (clamp to 255)
+         val data = intArrayOf(
+            -10, 300, 0, 0, // R
+            0, 0, 0, 0,     // G
+            0, 0, 0, 0      // B
+         )
+         val image = ImmutableImageLoader.create().fromTorchTensor(data, 2, 2)
+         image.pixel(0, 0).red() shouldBe 0
+         image.pixel(1, 0).red() shouldBe 255
+      }
+
+      test("fromTorchTensor float[] converts 0.0-1.0 values to 0-255") {
+         // 1x2 image, 3 channels: left pixel black, right pixel white
+         val data = floatArrayOf(
+            0f, 1f, // R
+            0f, 1f, // G
+            0f, 1f  // B
+         )
+         val image = ImmutableImageLoader.create().fromTorchTensor(data, 2, 1)
+         image.pixel(0, 0).red() shouldBe 0
+         image.pixel(1, 0).red() shouldBe 255
+      }
+
+      test("fromTorchTensor throws on unsupported channel count") {
+         // 8 values for a 2x2 image = 2 channels, which is not supported
+         val data = intArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+         shouldThrow<IllegalArgumentException> {
+            ImmutableImageLoader.create().fromTorchTensor(data, 2, 2)
+         }
+      }
+
+      test("fromTorchTensor throws when data length does not match dimensions") {
+         // 3 values is not divisible by 2×2=4
+         val data = intArrayOf(1, 2, 3)
+         shouldThrow<IllegalArgumentException> {
+            ImmutableImageLoader.create().fromTorchTensor(data, 2, 2)
+         }
+      }
+   }
+}


### PR DESCRIPTION
Closes #318

## Summary

Adds `fromTorchTensor()` to `ImmutableImageLoader` so callers can construct a Scrimage image directly from a PyTorch-style tensor without going through an encoded image format.

Two overloads are provided:

```java
// Integer tensor, values 0–255
ImmutableImage fromTorchTensor(int[] data, int width, int height)

// Float tensor, values 0.0–1.0
ImmutableImage fromTorchTensor(float[] data, int width, int height)
```

**Input format:** flat array in CHW (channel, height, width) order — the standard PyTorch layout. The channel count is inferred from `data.length / (width × height)`:

| Channels | Interpretation |
|---|---|
| 1 | Grayscale — value replicated to R, G, B |
| 3 | RGB |
| 4 | RGBA |

Out-of-range values are clamped to 0–255. The `type()` loader option is respected; defaults to `TYPE_INT_ARGB` for 4-channel tensors and `TYPE_INT_RGB` otherwise.

**Typical usage (Scala/storch):**

```scala
// tensor shape: [3, height, width], values 0–255 (int32)
val data: Array[Int] = tensor.to(torch.int32).toArray
val image = ImmutableImage.loader().fromTorchTensor(data, width, height)

// tensor shape: [3, height, width], values 0.0–1.0 (float32)
val data: Array[Float] = tensor.toArray
val image = ImmutableImage.loader().fromTorchTensor(data, width, height)
```

## Test plan

- [x] RGB pixel values correctly mapped from CHW layout
- [x] Grayscale (1-channel) tensor replicates value to R, G, B
- [x] RGBA (4-channel) tensor preserves alpha
- [x] Out-of-range int values are clamped
- [x] Float overload scales 0.0–1.0 to 0–255
- [x] Throws `IllegalArgumentException` for unsupported channel count
- [x] Throws `IllegalArgumentException` when data length doesn't match dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)