### PR TITLE
Fix dead validation and resource leak in PngWriter

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
@@ -60,30 +60,31 @@ public class PngWriter implements ImageWriter {
    @Override
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
    
-      if (compressionLevel < 0 && compressionLevel >= 10) {
+      if (compressionLevel < 0 || compressionLevel >= 10) {
          throw new IOException("Compression level must be between 0 (none) and 9 (max)");
       }
 
       ImageTypeSpecifier type = ImageTypeSpecifier.createFromBufferedImageType(image.getType());
       javax.imageio.ImageWriter writer = ImageIO.getImageWriters(type, "png").next();
-      ImageWriteParam param = writer.getDefaultWriteParam();
+      try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
+         ImageWriteParam param = writer.getDefaultWriteParam();
 
-      if (param.canWriteCompressed()) {
-         switch (compressionLevel) {
-            case 0: // none
-               param.setCompressionMode(ImageWriteParam.MODE_DISABLED);
-               break;
-            default:
-               param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-               param.setCompressionQuality((9-compressionLevel)/8.0f); // 9=0.0 (same as previously), 8=0.125, ... 2=0.875, 1=1.0 (same as previously)
-               break;
+         if (param.canWriteCompressed()) {
+            switch (compressionLevel) {
+               case 0: // none
+                  param.setCompressionMode(ImageWriteParam.MODE_DISABLED);
+                  break;
+               default:
+                  param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+                  param.setCompressionQuality((9 - compressionLevel) / 8.0f);
+                  break;
+            }
          }
-      }
 
-      ImageOutputStream ios = ImageIO.createImageOutputStream(out);
-      writer.setOutput(ios);
-      writer.write(null, new IIOImage(image.awt(), null, null), param);
-      writer.dispose();
-      ios.close();
+         writer.setOutput(ios);
+         writer.write(null, new IIOImage(image.awt(), null, null), param);
+      } finally {
+         writer.dispose();
+      }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
@@ -40,6 +40,20 @@ class PngWriterTest : WordSpec({
          actual.height shouldBe expected.height
          actual shouldBe expected
       }
+      // Regression test: compressionLevel < 0 || compressionLevel >= 10 was written as && so the
+      // validation was dead code — values outside 0-9 were silently accepted.
+      "invalid compression level below 0 is rejected" {
+         val ex = runCatching { original.bytes(PngWriter(-1)) }.exceptionOrNull()
+         ex?.message shouldBe "Compression level must be between 0 (none) and 9 (max)"
+      }
+      "invalid compression level of 10 is rejected" {
+         val ex = runCatching { original.bytes(PngWriter(10)) }.exceptionOrNull()
+         ex?.message shouldBe "Compression level must be between 0 (none) and 9 (max)"
+      }
+      "valid boundary compression levels 0 and 9 are accepted" {
+         original.bytes(PngWriter(0)).size shouldBe original.bytes(PngWriter.NoCompression).size
+         original.bytes(PngWriter(9)).size shouldBe original.bytes(PngWriter.MaxCompression).size
+      }
    }
 
 })


### PR DESCRIPTION
## Summary

Two bugs fixed in `PngWriter.write()`:

### 1. Dead compression-level validation (`&&` → `||`)

The guard condition was logically impossible — a value cannot be simultaneously `< 0` AND `>= 10`, so the `IOException` was never thrown and any compression level was silently accepted.

**Before:**
```java
if (compressionLevel < 0 && compressionLevel >= 10) {
```
**After:**
```java
if (compressionLevel < 0 || compressionLevel >= 10) {
```

Note: the commented-out Scala `require` just above the method had the correct logic (`>= 0 && < 10`), confirming the intent.

### 2. Resource leak on write failure

`ImageOutputStream` and `ImageWriter` were closed via straight-line calls with no `try/finally`. Any exception thrown during `writer.write()` left both resources open. Fixed with try-with-resources for the stream and `writer.dispose()` in a `finally` block — the same pattern used in `TwelveMonkeysWriter`.

## Test plan

- [x] `PngWriter(-1)` throws `IOException` with the expected message
- [x] `PngWriter(10)` throws `IOException` with the expected message  
- [x] Boundary levels 0 and 9 are still accepted and produce the expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)