### PR TITLE
Fix resource leak in TiffWriter.write()

### DIFF
--- a/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TiffWriter.java
+++ b/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TiffWriter.java
@@ -46,18 +46,19 @@ public class TiffWriter extends TwelveMonkeysWriter {
    @Override
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
       javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName(format()).next();
-      ImageOutputStream ios = ImageIO.createImageOutputStream(out);
-      ImageWriteParam params = writer.getDefaultWriteParam();
+      try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
+         ImageWriteParam params = writer.getDefaultWriteParam();
 
-      if (compressionType != null) {
-         params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-         params.setCompressionType(compressionType);
+         if (compressionType != null) {
+            params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            params.setCompressionType(compressionType);
+         }
+
+         writer.setOutput(ios);
+         writer.write(null, new IIOImage(image.awt(), null, null), params);
+      } finally {
+         writer.dispose();
       }
-
-      writer.setOutput(ios);
-      writer.write(null, new IIOImage(image.awt(), null, null), params);
-      ios.close();
-      writer.dispose();
    }
 }
 

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
@@ -39,4 +39,12 @@ class TwelveMonkeysWriterTest : FunSpec({
          original.bytes(BmpWriter())
       }
    }
+
+   // Regression test: TiffWriter.write() overrides TwelveMonkeysWriter.write() and had the
+   // same resource-leak pattern: ios and writer were not closed in a try/finally.
+   test("TiffWriter write does not leak resources on repeated writes") {
+      repeat(100) {
+         original.bytes(TiffWriter())
+      }
+   }
 })


### PR DESCRIPTION
## Summary

`TiffWriter` extends `TwelveMonkeysWriter` but overrides `write()` with its own implementation. When `TwelveMonkeysWriter.write()` was fixed for the same issue (#354), the fix did not apply to `TiffWriter` because the method is overridden.

`TiffWriter.write()` had the original unfixed pattern: `ImageOutputStream` and `ImageWriter` were closed via straight-line calls with no `try/finally`, so any exception during `writer.write()` left both resources open.

**Before:**
```java
ImageOutputStream ios = ImageIO.createImageOutputStream(out);
// ...
writer.write(...);
ios.close();      // skipped on exception
writer.dispose(); // skipped on exception
```

**After:**
```java
try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
    // ...
    writer.write(...);
} finally {
    writer.dispose();
}
```

## Test plan

- [x] `TiffWriter` round-trips image dimensions correctly
- [x] `TiffWriter` does not leak resources across 100 repeated writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)