### PR TITLE
Fix Color.average() returning premultiplied-alpha values as straight-alpha

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -74,10 +74,14 @@ public interface Color {
    default RGBColor average(Color other) {
       RGBColor c1 = this.toRGB();
       RGBColor c2 = other.toRGB();
-      int r = (c1.red * c1.alpha / 255) + (c2.red * c2.alpha * (255 - c1.alpha) / (255 * 255));
-      int g = (c1.green * c1.alpha / 255) + (c2.green * c2.alpha * (255 - c1.alpha) / (255 * 255));
-      int b = (c1.blue * c1.alpha / 255) + (c2.blue * c2.alpha * (255 - c1.alpha) / (255 * 255));
-      int a = c1.alpha + (c2.alpha * (255 - c1.alpha) / 255);
+      double a1 = c1.alpha / 255.0;
+      double a2 = c2.alpha / 255.0;
+      double aOut = a1 + a2 * (1.0 - a1);
+      if (aOut == 0.0) return new RGBColor(0, 0, 0, 0);
+      int r = (int) Math.round((c1.red * a1 + c2.red * a2 * (1.0 - a1)) / aOut);
+      int g = (int) Math.round((c1.green * a1 + c2.green * a2 * (1.0 - a1)) / aOut);
+      int b = (int) Math.round((c1.blue * a1 + c2.blue * a2 * (1.0 - a1)) / aOut);
+      int a = (int) Math.round(aOut * 255);
       return new RGBColor(r, g, b, a);
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
@@ -161,4 +161,59 @@ class ColorTest : WordSpec({
       }
    }
 
+   // Regression tests: Color.average() was returning premultiplied-alpha RGB values
+   // stored as straight-alpha, making partially-transparent blends too dark.
+   "Color.average" should {
+      "source-over opaque colors returns this color" {
+         // Porter-Duff source-over: fully opaque source occludes destination entirely
+         val c1 = RGBColor(200, 100, 50, 255)
+         val c2 = RGBColor(100, 200, 150, 255)
+         val avg = c1.average(c2)
+         avg.red shouldBe 200
+         avg.green shouldBe 100
+         avg.blue shouldBe 50
+         avg.alpha shouldBe 255
+      }
+      "both fully transparent returns transparent black" {
+         val c1 = RGBColor(255, 0, 0, 0)
+         val c2 = RGBColor(0, 255, 0, 0)
+         val avg = c1.average(c2)
+         avg shouldBe RGBColor(0, 0, 0, 0)
+      }
+      "transparent source over opaque destination yields destination" {
+         val c1 = RGBColor(255, 0, 0, 0)    // invisible red
+         val c2 = RGBColor(0, 0, 255, 255)  // opaque blue
+         val avg = c1.average(c2)
+         avg.red shouldBe 0
+         avg.green shouldBe 0
+         avg.blue shouldBe 255
+         avg.alpha shouldBe 255
+      }
+      "opaque source over transparent destination yields source" {
+         val c1 = RGBColor(255, 0, 0, 255)  // opaque red
+         val c2 = RGBColor(0, 0, 255, 0)    // invisible blue
+         val avg = c1.average(c2)
+         avg.red shouldBe 255
+         avg.green shouldBe 0
+         avg.blue shouldBe 0
+         avg.alpha shouldBe 255
+      }
+      "semi-transparent blend normalizes RGB by output alpha" {
+         // c1 = semi-transparent red (128 alpha), c2 = semi-transparent blue (128 alpha)
+         // a1 = a2 = 128/255 ≈ 0.502
+         // aOut = 0.502 + 0.502 * (1 - 0.502) ≈ 0.752  →  a = round(0.752 * 255) = 192
+         // r_premult = 255 * 0.502 ≈ 128 — old (buggy) code returned 128
+         // r_straight = 128 / 0.752 ≈ 170           — fixed code returns 170
+         // b_premult = 255 * 0.502 * 0.498 ≈ 64     — old code returned 64
+         // b_straight = 64 / 0.752 ≈ 85             — fixed code returns 85
+         val c1 = RGBColor(255, 0, 0, 128)
+         val c2 = RGBColor(0, 0, 255, 128)
+         val avg = c1.average(c2)
+         avg.red shouldBe 170
+         avg.green shouldBe 0
+         avg.blue shouldBe 85
+         avg.alpha shouldBe 192
+      }
+   }
+
 })


### PR DESCRIPTION
## Summary

- `Color.average()` uses the Porter-Duff source-over compositing formula, which produces premultiplied RGB values internally
- The premultiplied values were being stored directly into `RGBColor` (a straight-alpha type) without dividing by the output alpha
- This makes partially-transparent blends produce RGB channels that are too dark — a red pixel with alpha=128 blended over a blue pixel with alpha=128 produced red=128 (premultiplied) instead of red=170 (straight-alpha)
- Fix: divide each channel by `aOut` before rounding, converting from premultiplied to straight-alpha

## Test plan

- [x] `source-over opaque colors returns this color` — fully opaque source occludes destination (aOut=1, no normalization needed)
- [x] `both fully transparent returns transparent black` — edge case guard
- [x] `transparent source over opaque destination yields destination` — a=0 source is invisible
- [x] `opaque source over transparent destination yields source` — a=0 destination is invisible
- [x] `semi-transparent blend normalizes RGB by output alpha` — the previously broken case: red=128 (buggy) vs red=170 (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)