### PR TITLE
Fix HSVColor.toRGB() silently dropping the alpha component

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
@@ -35,7 +35,8 @@ public class HSVColor implements Color {
 
    public RGBColor toRGB() {
       int rgb = java.awt.Color.HSBtoRGB(hue / 360f, saturation, value);
-      return RGBColor.fromRGBInt(rgb);
+      RGBColor noAlpha = RGBColor.fromRGBInt(rgb);
+      return new RGBColor(noAlpha.red, noAlpha.green, noAlpha.blue, Math.round(alpha * 255));
    }
 
    @Override

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
@@ -55,6 +55,13 @@ class ColorTest : WordSpec({
          rgb.blue shouldBe 38
          rgb.alpha shouldBe 255
       }
+      // Regression: HSVColor.toRGB() was calling RGBColor.fromRGBInt() which discards
+      // the packed alpha (always 0xFF from HSBtoRGB) and defaults to 255, losing the
+      // HSVColor's own alpha field.
+      "hsv to rgb preserves alpha" {
+         val rgb = HSVColor(150f, 0.2f, 0.3f, 0.5f).toRGB()
+         rgb.alpha shouldBe Math.round(0.5f * 255)
+      }
       "convert hsv to rgb correctly 1" {
          val rgb = HSVColor(150f, 0.2f, 0.3f, 1f).toRGB()
          rgb.red shouldBe 61


### PR DESCRIPTION
## Summary

- `HSVColor` stores alpha as a float in [0, 1], but `toRGB()` always returned `RGBColor` with alpha=255
- `java.awt.Color.HSBtoRGB()` always sets the alpha byte to 0xFF in the result
- `RGBColor.fromRGBInt()` discards the packed alpha entirely and defaults to 255
- Any `HSVColor` with `alpha != 1.0` would silently lose its alpha on the round-trip to RGB
- Same class of bug previously fixed in `RGBColor.toHSV()` (PR #352) and `HSLColor.toRGB()` (PR #349)

## Test plan

- [x] `hsv to rgb preserves alpha` — verifies that a semi-transparent HSVColor (alpha=0.5) round-trips correctly to alpha=128 in RGB

🤖 Generated with [Claude Code](https://claude.com/claude-code)