### PR TITLE
Fix Grayscale(int) single-arg constructor defaulting alpha to 0

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
@@ -8,7 +8,7 @@ public class Grayscale implements Color {
     public final int alpha;
 
     public Grayscale(int gray) {
-        this(gray, 0);
+        this(gray, 255);
     }
 
     public Grayscale(int gray, int alpha) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
@@ -90,6 +90,13 @@ class ColorTest : WordSpec({
          rgb.blue shouldBe 100
          rgb.alpha shouldBe 128
       }
+      // Regression: Grayscale(int) defaulted alpha to 0 (fully transparent) while
+      // RGBColor(int,int,int) defaults to 255 (fully opaque). Inconsistent and
+      // almost always wrong for a no-args-given opaque gray.
+      "Grayscale single-arg constructor defaults to opaque" {
+         Grayscale(100).alpha shouldBe 255
+         Grayscale(100).toRGB().alpha shouldBe 255
+      }
       "be symmetric in rgb" {
          val rgb = RGBColor(1, 2, 3)
          rgb.toCMYK().toRGB() shouldBe rgb


### PR DESCRIPTION
## Summary

- `Grayscale(int gray)` delegated to `Grayscale(gray, 0)`, making the pixel fully transparent
- `RGBColor(int, int, int)` defaults alpha to 255 (fully opaque) — the analogue is consistent
- A user writing `new Grayscale(100)` and using it as a fill color would produce an invisible pixel
- Changed default alpha to 255 to match `RGBColor` and the natural expectation for a no-alpha constructor

## Test plan

- [x] `Grayscale single-arg constructor defaults to opaque` — verifies `Grayscale(100).alpha == 255` and `Grayscale(100).toRGB().alpha == 255`
- [x] Existing reflexive test `gray.toGrayscale() shouldBe gray` continues to pass (LumaGrayscale preserves the alpha from toRGB())

🤖 Generated with [Claude Code](https://claude.com/claude-code)