### PR TITLE
Fix resource leaks in JpegWriter and GifWriter

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
@@ -58,6 +58,7 @@ public class GifWriter implements ImageWriter {
         try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {
             writer.setOutput(output);
             writer.write(null, new IIOImage(image.awt(), null, null), params);
+        } finally {
             writer.dispose();
         }
     }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
@@ -77,11 +77,11 @@ public class JpegWriter implements ImageWriter {
          noAlpha = image.awt();
       }
 
-      MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out);
-      writer.setOutput(output);
-      writer.write(null, new IIOImage(noAlpha, null, null), params);
-      output.close();
-      writer.dispose();
-//        IOUtils.closeQuietly(out);
+      try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {
+         writer.setOutput(output);
+         writer.write(null, new IIOImage(noAlpha, null, null), params);
+      } finally {
+         writer.dispose();
+      }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifWriterTest.kt
@@ -27,4 +27,10 @@ class GifWriterTest : FunSpec({
       expected shouldBe actual
    }
 
+   test("GifWriter write does not leak resources on repeated writes") {
+      repeat(100) {
+         original.bytes(GifWriter.Default)
+      }
+   }
+
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterTest.kt
@@ -24,6 +24,12 @@ class JpegWriterTest : FunSpec({
       img.bytes(w) // was throwing with bug
    }
 
+   test("JpegWriter write does not leak resources on repeated writes") {
+      repeat(100) {
+         original.bytes(JpegWriter.Default)
+      }
+   }
+
    test("!jpeg writer should write metadata") {
       val img = ImmutableImage.loader().fromResource("/vossen.jpg")
       val file = img.output(JpegWriter.Default, "metadatatest.jpg")


### PR DESCRIPTION
## Summary

- **JpegWriter**: `MemoryCacheImageOutputStream` was allocated without try-with-resources; if `writer.write()` threw an exception, neither `output.close()` nor `writer.dispose()` would be called
- **GifWriter**: `writer.dispose()` was inside the try block after `writer.write()`; if `writer.write()` threw, `dispose()` would be skipped
- Fixed both by wrapping the stream in try-with-resources and calling `writer.dispose()` in a `finally` block
- Same pattern already fixed in `TwelveMonkeysWriter` (PR #354) and `TiffWriter` (PR #357)

## Test plan

- [x] `JpegWriter write does not leak resources on repeated writes` — 100 iterations; exercises the writer/stream lifecycle
- [x] `GifWriter write does not leak resources on repeated writes` — 100 iterations; same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)