### PR TITLE
Fix GifSequenceWriter.bytes() never calling writer.dispose()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
@@ -80,7 +80,6 @@ public class GifSequenceWriter extends AbstractGifWriter {
 
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
          try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos)) {
-
             writer.setOutput(output);
             writer.prepareWriteSequence(null);
 
@@ -92,6 +91,8 @@ public class GifSequenceWriter extends AbstractGifWriter {
             output.flush();
             return baos.toByteArray();
          }
+      } finally {
+         writer.dispose();
       }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
@@ -18,6 +18,12 @@ class GifSequenceWriterTest : WordSpec({
          val actual = GifSequenceWriter().withFrameDelay(500).bytes(frames.toTypedArray())
          actual shouldBe IOUtils.toByteArray(javaClass.getResourceAsStream("/com/sksamuel/scrimage/nio/animated_birds.gif"))
       }
+      "not leak ImageWriter on repeated calls" {
+         val frames = arrayOf(bird)
+         repeat(100) {
+            GifSequenceWriter().bytes(frames)
+         }
+      }
    }
 
 })


### PR DESCRIPTION
## Summary

- `GifSequenceWriter.bytes()` obtained an `ImageWriter` via `ImageIO.getImageWritersBySuffix("gif").next()` but never called `writer.dispose()`
- On the happy path `dispose()` was simply missing; on any exception it was also skipped
- `StreamingGifWriter.prepareStream()` correctly calls `writer.dispose()` in its `close()` method — the sequence writer had the same oversight as previously fixed in GifWriter, JpegWriter, TwelveMonkeysWriter, and TiffWriter
- Fixed by adding `writer.dispose()` in a `finally` block wrapping the try-with-resources block

## Test plan

- [x] `not leak ImageWriter on repeated calls` — 100 iterations of `bytes()`, exercises the writer lifecycle
- [x] Existing `write all frames` test continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)