### PR TITLE
Fix PixelTools.approx() comparing packed ARGB ints instead of per-channel

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -104,23 +104,16 @@ public class PixelTools {
     */
    public static boolean approx(Color color, int tolerance, Pixel[] pixels) {
 
-      RGBColor refColor = RGBColor.fromAwt(color);
+      RGBColor ref = RGBColor.fromAwt(color);
+      int minR = Math.max(ref.red - tolerance, 0),   maxR = Math.min(ref.red + tolerance, 255);
+      int minG = Math.max(ref.green - tolerance, 0), maxG = Math.min(ref.green + tolerance, 255);
+      int minB = Math.max(ref.blue - tolerance, 0),  maxB = Math.min(ref.blue + tolerance, 255);
 
-      RGBColor minColor = new RGBColor(
-         Math.max(refColor.red - tolerance, 0),
-         Math.max(refColor.green - tolerance, 0),
-         Math.max(refColor.blue - tolerance, 0),
-         refColor.alpha
+      return Arrays.stream(pixels).allMatch(p ->
+         p.red()   >= minR && p.red()   <= maxR &&
+         p.green() >= minG && p.green() <= maxG &&
+         p.blue()  >= minB && p.blue()  <= maxB
       );
-
-      RGBColor maxColor = new RGBColor(
-         Math.min(refColor.red + tolerance, 255),
-         Math.min(refColor.green + tolerance, 255),
-         Math.min(refColor.blue + tolerance, 255),
-         refColor.alpha
-      );
-
-      return Arrays.stream(pixels).allMatch(p -> p.toARGBInt() >= minColor.toARGBInt() && p.toARGBInt() <= maxColor.toARGBInt());
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -1,8 +1,10 @@
 package com.sksamuel.scrimage.core.color
 
+import com.sksamuel.scrimage.pixels.Pixel
 import com.sksamuel.scrimage.pixels.PixelTools
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.awt.Color
 import java.awt.Point
 
 class PixelToolsTest : FunSpec({
@@ -55,6 +57,32 @@ class PixelToolsTest : FunSpec({
       PixelTools.offsetToPoint(99, 100) shouldBe Point(99, 0)
       PixelTools.offsetToPoint(199, 100) shouldBe Point(99, 1)
       PixelTools.offsetToPoint(101, 100) shouldBe Point(1, 1)
+   }
+
+   // Regression: approx() compared packed ARGB ints numerically rather than
+   // checking each channel independently. A pixel with an out-of-range green
+   // (or blue) could pass if its packed int happened to fall within the
+   // numeric range of [minColor.toARGBInt(), maxColor.toARGBInt()].
+   test("approx rejects pixel whose green is out of tolerance even when packed int is in range") {
+      // ref = (255, 100, 100, 100), tolerance = 10  →  each channel must be in [90, 110]
+      // pixel has green=200 which is outside [90,110], but the packed int
+      // 0xFF64C864 = 4284794890 falls between 0xFF5A5A5A = 4284111450 (min) and
+      // 0xFF6E6E6E = 4285427310 (max), so the old code accepted it as a false positive.
+      val ref = Color(100, 100, 100, 255)
+      val pixel = Pixel(0, 0, 100, 200, 100, 255)  // green=200, way out of tolerance
+      PixelTools.approx(ref, 10, arrayOf(pixel)) shouldBe false
+   }
+
+   test("approx accepts pixel with all channels within tolerance") {
+      val ref = Color(100, 100, 100, 255)
+      val pixel = Pixel(0, 0, 105, 95, 108, 255)
+      PixelTools.approx(ref, 10, arrayOf(pixel)) shouldBe true
+   }
+
+   test("approx rejects pixel whose red is out of tolerance") {
+      val ref = Color(100, 100, 100, 255)
+      val pixel = Pixel(0, 0, 50, 100, 100, 255)
+      PixelTools.approx(ref, 10, arrayOf(pixel)) shouldBe false
    }
 
 })


### PR DESCRIPTION
## Summary

- `approx()` built `minColor` and `maxColor` RGBColor objects (with clamped per-channel bounds) then compared `p.toARGBInt()` numerically against them
- Packed ARGB integers are ordered by `(alpha, red, green, blue)` lexicographically, not by individual channel tolerance — a pixel with an out-of-range green channel could pass the check if its combined integer value happened to fall within the numeric range
- Example: ref=(255,100,100,100), tolerance=10 → range [0xFF5A5A5A, 0xFF6E6E6E]. A pixel with green=200 packs to 0xFF64C864 = 4284794890, which falls inside that integer range, falsely accepted
- This bug affects `autocrop()` with non-zero `colorTolerance`: pixels that should be considered border pixels may not be (or vice versa)
- Fix: compare each channel independently

## Test plan

- [x] `approx rejects pixel whose green is out of tolerance even when packed int is in range` — the precise false-positive from the bug
- [x] `approx accepts pixel with all channels within tolerance` — correct positive case
- [x] `approx rejects pixel whose red is out of tolerance` — correct negative case

🤖 Generated with [Claude Code](https://claude.com/claude-code)