### PR TITLE
Fix ImmutableImage.filter() mutating the original image in place

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -654,7 +654,7 @@ public class ImmutableImage extends MutableImage {
       List<Integer> types = Arrays.stream(filter.types()).boxed().collect(Collectors.toList());
       ImmutableImage target;
       if (types.isEmpty() || types.contains(getType())) {
-         target = this;
+         target = copy();
       } else {
          target = copy(types.get(0));
       }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BrightnessFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BrightnessFilterTest.kt
@@ -16,4 +16,14 @@ class BrightnessFilterTest : FunSpec({
       original.filter(BrightnessFilter(1.4f)) shouldBe expected
    }
 
+   // Regression: filter() set target = this when the image type matched the filter's
+   // required types (or types() returned empty, the common case). BufferedOpFilter
+   // applies the op in-place via op().filter(image.awt(), image.awt()), so the
+   // "immutable" original was silently mutated.
+   test("filter does not mutate the original image") {
+      val snapshot = original.copy()
+      original.filter(BrightnessFilter(1.4f))
+      original shouldBe snapshot
+   }
+
 })


### PR DESCRIPTION
## Summary

- `ImmutableImage.filter(Filter)` was documented as "The original (this) image is unchanged" but violated its own contract
- When `filter.types()` returns an empty array (the default for all `BufferedOpFilter` subclasses), the code set `target = this` and called `filter.apply(target)` directly on the original
- `BufferedOpFilter.apply()` calls `op().filter(image.awt(), image.awt())` — passing the same `BufferedImage` as both source and destination, which modifies it in place (per the Java ImageIO contract)
- Every call to `filter()` with a standard `BufferedOpFilter` (brightness, blur, contrast, etc.) silently mutated the calling image, making the return value irrelevant for detecting side effects
- Fix: always `copy()` (or `copy(type)`) before applying the filter, exactly as was already done when the image type needed conversion

## Test plan

- [x] `filter does not mutate the original image` in `BrightnessFilterTest` — takes a snapshot before filtering, applies the filter, asserts the original is unchanged
- [x] Existing `filter output matches expected` test continues to pass (verifying the filtered copy is still correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)