### PR TITLE
Fix AwtImage.pixels() unreachable TYPE_4BYTE_ABGR branch returning corrupt data

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -128,12 +128,6 @@ public class AwtImage {
                pixels[index] = new Pixel(point.x, point.y, data[index]);
                index++;
             }
-         } else if (awt().getType() == BufferedImage.TYPE_4BYTE_ABGR) {
-            while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index / 4] = new Pixel(point.x, point.y, data[index / 4]);
-               index = index + 4;
-            }
          } else {
             throw new RuntimeException("Unsupported image type " + awt().getType());
          }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.scrimage.core
 
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.pixels.Pixel
+import java.awt.image.BufferedImage
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -63,5 +64,35 @@ class AwtImageTest : FunSpec({
          java.awt.Point(4, 3),
          java.awt.Point(5, 3)
       )
+   }
+
+   test("pixels() returns correct non-null array for TYPE_4BYTE_ABGR image") {
+      // A BufferedImage with TYPE_4BYTE_ABGR uses a DataBufferByte, so pixels()
+      // falls through to the getRGB per-pixel path. This test locks in that
+      // contract: correct length, no nulls, coordinates in row-major order,
+      // and ARGB values preserved.
+      val bi = BufferedImage(2, 2, BufferedImage.TYPE_4BYTE_ABGR)
+      bi.setRGB(0, 0, 0xFFFF0000.toInt()) // opaque red
+      bi.setRGB(1, 0, 0xFF00FF00.toInt()) // opaque green
+      bi.setRGB(0, 1, 0xFF0000FF.toInt()) // opaque blue
+      bi.setRGB(1, 1, 0xFFFFFFFF.toInt()) // opaque white
+
+      val image = ImmutableImage.wrapAwt(bi)
+      val pixels = image.pixels()
+
+      pixels.size shouldBe 4
+      pixels.forEach { it shouldNotBe null }
+
+      pixels[0].x shouldBe 0; pixels[0].y shouldBe 0
+      pixels[0].argb shouldBe 0xFFFF0000.toInt()
+
+      pixels[1].x shouldBe 1; pixels[1].y shouldBe 0
+      pixels[1].argb shouldBe 0xFF00FF00.toInt()
+
+      pixels[2].x shouldBe 0; pixels[2].y shouldBe 1
+      pixels[2].argb shouldBe 0xFF0000FF.toInt()
+
+      pixels[3].x shouldBe 1; pixels[3].y shouldBe 1
+      pixels[3].argb shouldBe 0xFFFFFFFF.toInt()
    }
 })


### PR DESCRIPTION
## Summary

`AwtImage.pixels()` contains an `else if (... TYPE_4BYTE_ABGR)` branch (AwtImage.java:131–136) that is **both unreachable and wrong**:

- **Unreachable:** the branch is nested inside `if (buffer instanceof DataBufferInt)`, but a `TYPE_4BYTE_ABGR` image always uses `DataBufferByte`. So at runtime, `TYPE_4BYTE_ABGR` images fall through to the outer `else` (the `getRGB` per-pixel fallback), which returns correct results.
- **Wrong if ever reached:** the array is sized `data.length` (4× the pixel count), so 3/4 of the entries would be left `null`. `offsetToPoint(index, width)` is passed the byte-offset (0, 4, 8…) rather than the pixel index, producing coordinates off by a factor of 4. And `data[index / 4]` is a meaningless read on a `DataBufferInt`.

## Change

Delete the dead branch. Runtime behavior is unchanged for every reachable path — `TYPE_4BYTE_ABGR` continues to use the correct `getRGB` fallback.

## Test

`AwtImageTest` gains a new case that builds a `TYPE_4BYTE_ABGR` `BufferedImage`, wraps it as an `ImmutableImage`, and asserts `pixels()` returns `width*height` non-null pixels with correct coordinates and ARGB values. This test passes before and after the fix (the fallback has always been correct); it locks in the contract so the bug cannot silently return.

Found during code review on 2026-04-16.