### PR TITLE
Fix StreamingGifWriter.writeFrame mutating caller's ImmutableImage in compressed mode

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -124,19 +124,21 @@ public class StreamingGifWriter extends AbstractGifWriter {
          @Override
          public GifStream writeFrame(ImmutableImage image) throws IOException {
             if (compressed && last != null) {
-               DataBuffer inputBuffer = image.awt().getRaster().getDataBuffer();
+               // Copy the input so we don't mutate the caller's image when zero-filling
+               // pixels that match the previous frame (the diff step below).
+               ImmutableImage work = image.copy();
+               DataBuffer workBuffer = work.awt().getRaster().getDataBuffer();
                DataBuffer lastBuffer = last.awt().getRaster().getDataBuffer();
-               // must copy the image before assigning it to last, because we will modify it in the next step
-               last = image.copy();
-               for (int i = 0; i < inputBuffer.getSize(); i++) {
-                  if (inputBuffer.getElem(i) == lastBuffer.getElem(i)) {
-                     inputBuffer.setElem(i, 0);
+               for (int i = 0; i < workBuffer.getSize(); i++) {
+                  if (workBuffer.getElem(i) == lastBuffer.getElem(i)) {
+                     workBuffer.setElem(i, 0);
                   }
                }
-               writer.writeToSequence(new IIOImage(image.awt(), null, imageMetaData), imageWriteParam);
+               last = image.copy();
+               writer.writeToSequence(new IIOImage(work.awt(), null, imageMetaData), imageWriteParam);
             } else {
                writer.writeToSequence(new IIOImage(image.awt(), null, imageMetaData), imageWriteParam);
-               last = image;
+               last = image.copy();
             }
             return this;
          }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
@@ -3,6 +3,7 @@
 package com.sksamuel.scrimage.core.nio
 
 import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
 import com.sksamuel.scrimage.nio.AnimatedGifReader
 import com.sksamuel.scrimage.nio.ImageSource
 import com.sksamuel.scrimage.nio.StreamingGifWriter
@@ -49,6 +50,35 @@ class StreamingGifWriterTest : WordSpec({
          stream.close()
          val bytes = output.toByteArray()
          bytes shouldBe IOUtils.toByteArray(javaClass.getResourceAsStream("/gif/fallingroof_scaled.gif"))
+      }
+
+      "not mutate caller's ImmutableImage in compressed mode" {
+         // Two 8x8 images where most pixels match, so the compressed diff path
+         // will attempt to zero-fill matching cells.
+         val image1 = ImmutableImage.create(8, 8, BufferedImage.TYPE_INT_ARGB)
+         val image2 = ImmutableImage.create(8, 8, BufferedImage.TYPE_INT_ARGB)
+         for (y in 0 until 8) {
+            for (x in 0 until 8) {
+               val color = RGBColor(x * 30, y * 30, 128, 255)
+               image1.setColor(x, y, color)
+               image2.setColor(x, y, color)
+            }
+         }
+         // Differ on exactly one pixel so image2 is distinguishable
+         image2.setColor(3, 3, RGBColor(255, 0, 0, 255))
+
+         val snap1: IntArray = image1.pixels().map { it.argb }.toIntArray()
+         val snap2: IntArray = image2.pixels().map { it.argb }.toIntArray()
+
+         val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(image1)
+         stream.writeFrame(image2)
+         stream.close()
+
+         image1.pixels().map { it.argb }.toIntArray().toList() shouldBe snap1.toList()
+         image2.pixels().map { it.argb }.toIntArray().toList() shouldBe snap2.toList()
       }
    }
 


### PR DESCRIPTION
## Summary

In compressed mode (`StreamingGifWriter().withCompression(true)`), `writeFrame(image)` grabs the caller's `ImmutableImage`'s `DataBuffer` and sets every pixel that matches the previous frame to `0`. This mutates the caller's image in place — a direct immutability-contract violation, and the same class of bug as the recent fix to `ImmutableImage.filter()` (f9ce2819).

Additionally, the non-compressed branch assigned `last = image`, aliasing the caller's image as the next frame's diff basis — if the caller later mutated the image, the compressed diff would be wrong on the next write.

## Change

- Compressed branch: copy the input up front, zero-fill the copy's buffer, snapshot the unmodified input into `last`, write the copy.
- Non-compressed branch: `last = image.copy()` instead of `last = image`.

Bytes written to the output stream are identical — the existing golden-file test (`"use transparent pixels when compression is set"`) continues to pass.

## Test

New `StreamingGifWriterTest` case: build two `ImmutableImage`s with mostly-matching pixels, snapshot their pixel arrays, write both in compressed mode, then assert the inputs are unchanged. This test fails on master; passes with the fix.

Found during code review on 2026-04-16.