### PR TITLE
Fix StreamingGifWriter resource leaks in prepareStream(File) and close()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -91,7 +91,16 @@ public class StreamingGifWriter extends AbstractGifWriter {
 
    public GifStream prepareStream(File file, int imageType) throws IOException {
       FileOutputStream output = new FileOutputStream(file);
-      return prepareStream(output, imageType);
+      try {
+         return prepareStream(output, imageType);
+      } catch (IOException | RuntimeException e) {
+         try {
+            output.close();
+         } catch (IOException suppressed) {
+            e.addSuppressed(suppressed);
+         }
+         throw e;
+      }
    }
 
    public GifStream prepareStream(OutputStream output, int imageType) throws IOException {
@@ -175,10 +184,19 @@ public class StreamingGifWriter extends AbstractGifWriter {
 
          @Override
          public void close() throws IOException {
-            writer.endWriteSequence();
-            writer.dispose();
-            ios.close();
-            output.close();
+            try {
+               writer.endWriteSequence();
+            } finally {
+               try {
+                  writer.dispose();
+               } finally {
+                  try {
+                     ios.close();
+                  } finally {
+                     output.close();
+                  }
+               }
+            }
          }
       };
    }


### PR DESCRIPTION
## Summary

Two resource leaks in `StreamingGifWriter`, both on exception paths — the same class of bug as the recent fixes to JpegWriter/GifWriter (662a5ebc) and GifSequenceWriter (dddfbd11):

1. **`prepareStream(File, int)` leaks its `FileOutputStream`** if the downstream `prepareStream(OutputStream, int)` throws (for example, if `ImageIO.getImageWritersBySuffix("gif")` returns no writer, or `prepareWriteSequence` fails). The file handle is left open with no path to `close()`.
2. **`GifStream.close()` doesn't cascade on exception.** The current code runs `writer.endWriteSequence()`, `writer.dispose()`, `ios.close()`, `output.close()` back-to-back; if any step throws, the subsequent ones are skipped. If `endWriteSequence` throws, `dispose`/`ios.close`/`output.close` all leak.

## Change

- `prepareStream(File, int)`: try/catch around the inner call, closing `output` on exception with `Throwable.addSuppressed` to preserve the original cause.
- `GifStream.close()`: nested try/finally so every cleanup step runs. Matches the resource-cleanup style used in other scrimage nio writers.

## Test

No new failure-path tests. Driving these exception paths requires mocking frameworks this repo doesn't use; refactoring the method for injectable dependencies would be a larger change than the bug fix itself. The PR relies on:
- Code review of the try/finally structure.
- The existing `StreamingGifWriterTest` (including the compressed golden-file test and the dispose-method tests) continuing to pass, which confirms the happy path is unchanged.

Found during code review on 2026-04-16.