### PR TITLE
Fix AwtImage.pixels() returning transparent pixels for TYPE_INT_RGB images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -125,7 +125,7 @@ public class AwtImage {
          } else if (awt().getType() == BufferedImage.TYPE_INT_RGB) {
             while (index < data.length) {
                Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index]);
+               pixels[index] = new Pixel(point.x, point.y, data[index] | 0xFF000000);
                index++;
             }
          } else if (awt().getType() == BufferedImage.TYPE_4BYTE_ABGR) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -1,10 +1,12 @@
 package com.sksamuel.scrimage.core
 
+import com.sksamuel.scrimage.AwtImage
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.awt.image.BufferedImage
 
 class AwtImageTest : FunSpec({
 
@@ -33,6 +35,22 @@ class AwtImageTest : FunSpec({
       patches[1][0].red() shouldBe 1
       // patch 3 → col=0, row=1 → pixel index 4 → red=4
       patches[3][0].red() shouldBe 4
+   }
+
+   // Regression: AwtImage.pixels() fast path for TYPE_INT_RGB read data[index] directly,
+   // but TYPE_INT_RGB stores 0x00RRGGBB (alpha bits are 0), so every pixel came back with
+   // alpha=0 (fully transparent) instead of alpha=255 (opaque).
+   test("pixels() on TYPE_INT_RGB image returns opaque pixels") {
+      val buf = BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB)
+      buf.setRGB(0, 0, 0x00FF0000) // red
+      buf.setRGB(1, 0, 0x0000FF00) // green
+      buf.setRGB(0, 1, 0x000000FF) // blue
+      buf.setRGB(1, 1, 0x00FFFFFF) // white
+      val image = AwtImage(buf)
+      image.pixels().forEach { p -> p.alpha() shouldBe 255 }
+      image.pixels()[0].red() shouldBe 255
+      image.pixels()[1].green() shouldBe 255
+      image.pixels()[2].blue() shouldBe 255
    }
 
    test("AwtImage.points return array of points") {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -6,7 +6,6 @@ import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.awt.image.BufferedImage
 
 class AwtImageTest : FunSpec({
 
@@ -41,7 +40,7 @@ class AwtImageTest : FunSpec({
    // but TYPE_INT_RGB stores 0x00RRGGBB (alpha bits are 0), so every pixel came back with
    // alpha=0 (fully transparent) instead of alpha=255 (opaque).
    test("pixels() on TYPE_INT_RGB image returns opaque pixels") {
-      val buf = BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB)
+      val buf = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_RGB)
       buf.setRGB(0, 0, 0x00FF0000) // red
       buf.setRGB(1, 0, 0x0000FF00) // green
       buf.setRGB(0, 1, 0x000000FF) // blue


### PR DESCRIPTION
## Summary

- `AwtImage.pixels()` has a fast path for `TYPE_INT_RGB` images that reads raw `DataBufferInt` entries directly as ARGB pixel values
- `TYPE_INT_RGB` stores each pixel as `0x00RRGGBB` — the high byte (alpha) is always zero in the buffer
- This caused every pixel to come back with `alpha = 0` (fully transparent), while the slow-path via `awt.getRGB()` correctly returns `alpha = 255` (opaque)
- Fix: OR `0xFF000000` into the raw data so the constructed `Pixel` sees opaque alpha, matching what `BufferedImage.getRGB()` returns

## Test plan

- [ ] New regression test in `AwtImageTest`: creates a `BufferedImage.TYPE_INT_RGB` image, wraps it in `AwtImage`, calls `pixels()`, and asserts every pixel has `alpha == 255` and correct RGB components
- [ ] Existing tests still pass: `./gradlew :scrimage-tests:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)