### PR TITLE
Fix Color.paint() silently dropping the alpha component

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -89,6 +89,6 @@ public interface Color {
     * Returns this colour as an AWT Paint.
     */
    default Paint paint() {
-      return new java.awt.Color(toRGB().toARGBInt());
+      return new java.awt.Color(toRGB().toARGBInt(), true);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
@@ -67,4 +67,28 @@ class RGBColorTest : StringSpec({
       val rgb = RGBColor(255, 255, 255)
       rgb.toHSV().toRGB() shouldBe rgb
    }
+
+   // Regression: Color.paint() used new java.awt.Color(toARGBInt()) which calls the
+   // single-int constructor that forces alpha=0xFF, silently dropping the color's alpha.
+   // Fix: pass hasAlpha=true so the constructor reads alpha from bits 24-31.
+   "paint() preserves alpha for semi-transparent color" {
+      val halfTransparentRed = RGBColor(255, 0, 0, 128)
+      val paint = halfTransparentRed.paint() as java.awt.Color
+      paint.alpha shouldBe 128
+      paint.red shouldBe 255
+      paint.green shouldBe 0
+      paint.blue shouldBe 0
+   }
+
+   "paint() preserves alpha for fully transparent color" {
+      val transparent = RGBColor(0, 255, 0, 0)
+      val paint = transparent.paint() as java.awt.Color
+      paint.alpha shouldBe 0
+   }
+
+   "paint() preserves alpha for fully opaque color" {
+      val opaque = RGBColor(0, 0, 255, 255)
+      val paint = opaque.paint() as java.awt.Color
+      paint.alpha shouldBe 255
+   }
 })


### PR DESCRIPTION
## Summary

- `Color.paint()` returns `new java.awt.Color(toRGB().toARGBInt())`
- The single-int `java.awt.Color(int)` constructor documents that it creates an **opaque** color — it ORs `0xFF000000` over whatever bits 24-31 contain, discarding the actual alpha
- Any semi-transparent or fully-transparent `Color` value would produce a fully-opaque `Paint`, silently corrupting alpha-based drawing operations
- Fix: use `new java.awt.Color(toRGB().toARGBInt(), true)` — the two-arg constructor reads bits 24-31 as alpha

## Test plan

- [ ] New regression tests in `RGBColorTest`: verify `paint()` preserves alpha for semi-transparent (128), fully-transparent (0), and fully-opaque (255) colors
- [ ] Existing test suite still passes: `./gradlew :scrimage-tests:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)