### PR TITLE
Fix CMYKColor.toRGB() silently dropping the alpha component

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
@@ -1,22 +1,31 @@
 package com.sksamuel.scrimage.color;
 
+import java.util.Objects;
+
 public class CMYKColor implements Color {
 
     public final float c;
     public final float m;
     public final float y;
     public final float k;
+    public final float alpha;
 
     public CMYKColor(float c, float m, float y, float k) {
+        this(c, m, y, k, 1.0f);
+    }
+
+    public CMYKColor(float c, float m, float y, float k, float alpha) {
         assert (0 <= c && c <= 1f);
         assert (0 <= m && m <= 1f);
         assert (0 <= y && y <= 1f);
         assert (0 <= k && k <= 1f);
+        assert (0 <= alpha && alpha <= 1f);
 
         this.c = c;
         this.m = m;
         this.y = y;
         this.k = k;
+        this.alpha = alpha;
     }
 
     public CMYKColor toCMYK() {
@@ -27,6 +36,23 @@ public class CMYKColor implements Color {
         float red = 1.0f + c * k - k - c;
         float green = 1.0f + m * k - k - m;
         float blue = 1.0f + y * k - k - y;
-        return new RGBColor(Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255), 255);
+        return new RGBColor(Math.round(red * 255), Math.round(green * 255), Math.round(blue * 255), Math.round(alpha * 255));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CMYKColor cmykColor = (CMYKColor) o;
+        return Float.compare(cmykColor.c, c) == 0 &&
+                Float.compare(cmykColor.m, m) == 0 &&
+                Float.compare(cmykColor.y, y) == 0 &&
+                Float.compare(cmykColor.k, k) == 0 &&
+                Float.compare(cmykColor.alpha, alpha) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(c, m, y, k, alpha);
     }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -104,10 +104,11 @@ public class RGBColor implements Color {
    public CMYKColor toCMYK() {
       float max = Math.max(Math.max(red, green), blue) / 255f;
       float k = 1.0f - max;
+      float a = alpha / 255f;
       if (max > 0.0f) {
-         return new CMYKColor(1.0f - (red / 255f) / max, 1.0f - (green / 255f) / max, 1.0f - (blue / 255f) / max, k);
+         return new CMYKColor(1.0f - (red / 255f) / max, 1.0f - (green / 255f) / max, 1.0f - (blue / 255f) / max, k, a);
       } else {
-         return new CMYKColor(0, 0, 0, k);
+         return new CMYKColor(0, 0, 0, k, a);
       }
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorTest.kt
@@ -48,6 +48,17 @@ class ColorTest : WordSpec({
          rgb.blue shouldBe 107
          rgb.alpha shouldBe 255
       }
+      // Regression: CMYKColor.toRGB() hardcoded alpha=255, silently dropping the alpha
+      // of any semi-transparent colour round-tripped through CMYK.
+      "cmyk to rgb preserves alpha" {
+         val rgb = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f, 0.5f).toRGB()
+         rgb.alpha shouldBe Math.round(0.5f * 255)
+      }
+      "rgb to cmyk preserves alpha" {
+         val cmyk = RGBColor(100, 150, 200, 128).toCMYK()
+         cmyk.alpha shouldBe (128 / 255f plusOrMinus 0.001f)
+         cmyk.toRGB().alpha shouldBe 128
+      }
       "convert hsl to rgb correctly" {
          val rgb = HSLColor(100f, 0.5f, 0.3f, 1f).toRGB()
          rgb.red shouldBe 64


### PR DESCRIPTION
## Summary

- `CMYKColor` had no alpha field, so `toRGB()` always returned `alpha=255`
- Any semi-transparent colour round-tripped through CMYK (e.g. `rgb.toCMYK().toRGB()` or `hsv.toCMYK().toHSV()`) silently lost its alpha
- Same bug pattern as the already-fixed `HSVColor` (#359) and `Grayscale` (#360)
- Added a `float alpha` field (0.0–1.0) with a default of 1.0 via the existing 4-arg constructor (backwards compatible); new 5-arg constructor for explicit alpha
- `RGBColor.toCMYK()` now passes `alpha / 255f`, and `CMYKColor.toRGB()` converts back with `Math.round(alpha * 255)`

## Test plan

- [x] `cmyk to rgb preserves alpha` — `CMYKColor(c,m,y,k,0.5f).toRGB().alpha == round(0.5 * 255)`
- [x] `rgb to cmyk preserves alpha` — `RGBColor(100,150,200,128).toCMYK().alpha ≈ 128/255` and `.toRGB().alpha == 128`
- [x] All existing color conversion and symmetry tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)