### PR TITLE
Fix GrayscaleFilter luma weights: 0.21/0.71/0.07 don't sum to 1.0

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
@@ -22,10 +22,7 @@ public class GrayscaleFilter implements Filter {
 
    public void apply(ImmutableImage image) {
       image.mapInPlace((p) -> {
-         double red = 0.21 * p.red();
-         double green = 0.71 * p.green();
-         double blue = 0.07 * p.blue();
-         int gray = (int) (red + green + blue);
+         int gray = (int) Math.round(0.2126 * p.red() + 0.7152 * p.green() + 0.0722 * p.blue());
          return new RGBColor(gray, gray, gray, p.alpha()).awt();
       });
    }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GrayscaleFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GrayscaleFilterTest.kt
@@ -1,0 +1,52 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class GrayscaleFilterTest : FunSpec({
+
+   // Regression: GrayscaleFilter used luma weights 0.21/0.71/0.07 which sum to 0.99,
+   // not 1.0. A pure white pixel (255,255,255) mapped to gray 252 instead of 255.
+   // Fix: use the correct Rec. 709 weights 0.2126/0.7152/0.0722 (sum = 1.0).
+   test("white pixel maps to white after grayscale") {
+      val pixels = arrayOf(Pixel(0, 0, 255, 255, 255, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      image.filter(GrayscaleFilter())
+      val result = image.filter(GrayscaleFilter())
+      val p = result.pixel(0, 0)
+      p.red() shouldBe 255
+      p.green() shouldBe 255
+      p.blue() shouldBe 255
+   }
+
+   test("black pixel maps to black after grayscale") {
+      val pixels = arrayOf(Pixel(0, 0, 0, 0, 0, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val result = image.filter(GrayscaleFilter())
+      val p = result.pixel(0, 0)
+      p.red() shouldBe 0
+      p.green() shouldBe 0
+      p.blue() shouldBe 0
+   }
+
+   test("grayscale preserves alpha") {
+      val pixels = arrayOf(Pixel(0, 0, 200, 100, 50, 128))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val result = image.filter(GrayscaleFilter())
+      result.pixel(0, 0).alpha() shouldBe 128
+   }
+
+   test("grayscale output is neutral gray (R == G == B)") {
+      val pixels = arrayOf(Pixel(0, 0, Color(100, 150, 200).rgb).let {
+         Pixel(0, 0, 100, 150, 200, 255)
+      })
+      val image = ImmutableImage.create(1, 1, pixels)
+      val result = image.filter(GrayscaleFilter())
+      val p = result.pixel(0, 0)
+      p.red() shouldBe p.green()
+      p.green() shouldBe p.blue()
+   }
+})


### PR DESCRIPTION
## Summary

- `GrayscaleFilter` used luma weights `0.21 / 0.71 / 0.07` which sum to **0.99**, not 1.0
- A pure white pixel (255, 255, 255) converted to gray **252** instead of 255; any bright pixel was silently darkened
- Fixed by using the correct Rec. 709 weights `0.2126 / 0.7152 / 0.0722` (same as `LumaGrayscale`) and `Math.round()` instead of truncation

## Test plan

- [x] `white pixel maps to white after grayscale` — (255,255,255) → gray 255 (was 252)
- [x] `black pixel maps to black after grayscale` — (0,0,0) → gray 0
- [x] `grayscale preserves alpha` — alpha channel is passed through unchanged
- [x] `grayscale output is neutral gray (R == G == B)` — all channels equal after conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)