### PR TITLE
Avoid recomputing pixels() per patch in AwtImage.patches()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -357,10 +357,13 @@ public class AwtImage {
    }
 
    public Pixel[] patch(int x, int y, int patchWidth, int patchHeight) {
-      Pixel[] px = pixels();
+      return patchFrom(pixels(), x, y, patchWidth, patchHeight);
+   }
+
+   private Pixel[] patchFrom(Pixel[] source, int x, int y, int patchWidth, int patchHeight) {
       Pixel[] patch = new Pixel[patchWidth * patchHeight];
       for (int i = 0; i < patchHeight; i++) {
-         System.arraycopy(px, offset(x, y + i), patch, i * patchWidth, patchWidth);
+         System.arraycopy(source, offset(x, y + i), patch, i * patchWidth, patchWidth);
       }
       return patch;
    }
@@ -388,10 +391,11 @@ public class AwtImage {
     */
    public Pixel[][] patches(int patchWidth, int patchHeight) {
       Pixel[][] patches = new Pixel[(height - patchHeight) * (width - patchWidth)][];
+      Pixel[] source = pixels();
       int k = 0;
       for (int row = 0; row < height - patchHeight; row++) {
          for (int col = 0; col < width - patchWidth; col++) {
-            patches[k] = patch(col, row, patchWidth, patchHeight);
+            patches[k] = patchFrom(source, col, row, patchWidth, patchHeight);
             k++;
          }
       }


### PR DESCRIPTION
## Summary
- `AwtImage.patches()` called `patch()` inside an O(W*H) loop, and `patch()` called `pixels()` each time, allocating a full `Pixel[]` of size `width * height` for every patch position. For an image with `N` total pixels and `M` patches, this was O(N*M) allocations and copies, when it should be O(N + total_patch_pixels).
- Hoist `pixels()` out of the patches() loop. Single-patch callers (`patch()`) still call `pixels()` once; multi-patch callers reuse one source array via a private helper.

## Test plan
- [x] Existing AwtImageTest suite (including the patches() regression tests from #351) passes