### PR TITLE
Use Arrays.fill for DataBufferInt-backed fill operations

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -45,6 +45,8 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.awt.image.BufferedImageOp;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferInt;
 import java.awt.image.WritableRaster;
 import java.io.File;
 import java.io.IOException;
@@ -270,8 +272,15 @@ public class ImmutableImage extends MutableImage {
       ImmutableImage target = create(width, height, type);
       WritableRaster targetRaster = target.awt().getRaster();
       Object colorElements = target.awt().getColorModel().getDataElements(RGBColor.fromAwt(color).toARGBInt(), null);
-      for (int w = 0; w < width; w++) {
-         for (int h = 0; h < height; h++) {
+      DataBuffer buffer = targetRaster.getDataBuffer();
+      if (buffer instanceof DataBufferInt
+         && colorElements instanceof int[]
+         && ((int[]) colorElements).length == 1) {
+         Arrays.fill(((DataBufferInt) buffer).getData(), ((int[]) colorElements)[0]);
+         return target;
+      }
+      for (int h = 0; h < height; h++) {
+         for (int w = 0; w < width; w++) {
             targetRaster.setDataElements(w, h, colorElements);
          }
       }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -6,6 +6,8 @@ import com.sksamuel.scrimage.pixels.PixelTools;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferInt;
 import java.awt.image.RescaleOp;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
@@ -52,7 +54,18 @@ public class MutableImage extends AwtImage {
    public void fillInPlace(Color color) {
       WritableRaster raster = awt().getRaster();
       Object colorElements = awt().getColorModel().getDataElements(RGBColor.fromAwt(color).toARGBInt(), null);
-      Arrays.stream(points()).forEach(point -> raster.setDataElements(point.x, point.y, colorElements));
+      DataBuffer buffer = raster.getDataBuffer();
+      if (buffer instanceof DataBufferInt
+         && colorElements instanceof int[]
+         && ((int[]) colorElements).length == 1) {
+         Arrays.fill(((DataBufferInt) buffer).getData(), ((int[]) colorElements)[0]);
+         return;
+      }
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            raster.setDataElements(x, y, colorElements);
+         }
+      }
    }
 
    /**


### PR DESCRIPTION
## Summary
- `ImmutableImage.filled(...)` and `MutableImage.fillInPlace(...)` called `WritableRaster.setDataElements(x, y, ...)` once per pixel. For the common `DataBufferInt`-backed types (`TYPE_INT_ARGB`, `TYPE_INT_RGB`), the underlying storage is a single packed int per pixel, so the entire buffer can be filled with `Arrays.fill` — no per-pixel ColorModel/SampleModel dispatch.
- The fast path is gated on the buffer being a `DataBufferInt` and `getDataElements()` returning a length-1 `int[]`, so the resulting pixel data is byte-identical to before.
- The fallback loop is flipped to row-major iteration (closer to the underlying memory layout) for non-`DataBufferInt` types.

## Test plan
- [x] Full scrimage-tests suite passes (existing fill/forEach/map regression coverage)