### PR TITLE
Use bulk getRGB/setRGB in MutableImage in-place ops

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -33,17 +33,27 @@ public class MutableImage extends AwtImage {
     * @param mapper the function to transform pixel x,y with existing value p into new pixel value p' (p prime)
     */
    public void mapInPlace(Function<Pixel, Color> mapper) {
-      Arrays.stream(points()).forEach(point -> {
-         Color c = mapper.apply(pixel(point.x, point.y));
-         awt().setRGB(point.x, point.y, c.getRGB());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            Color c = mapper.apply(new Pixel(x, y, argb[i]));
+            argb[i++] = c.getRGB();
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
-      Arrays.stream(pixels()).forEach(pixel -> {
-         Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(pixel, color);
-         awt().setRGB(pixel.x, pixel.y, withoutTrans.toARGBInt());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            Pixel pixel = new Pixel(x, y, argb[i]);
+            argb[i++] = PixelTools.replaceTransparencyWithColor(pixel, color).toARGBInt();
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    /**
@@ -87,13 +97,17 @@ public class MutableImage extends AwtImage {
    }
 
    public void contrastInPlace(double factor) {
-      Arrays.stream(points()).forEach(p -> {
-         Pixel pixel = pixel(p.x, p.y);
-         int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
-         int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
-         int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
-         Pixel pixel2 = new Pixel(pixel.x, pixel.y, r, g, b, pixel.alpha());
-         setPixel(pixel2);
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            Pixel pixel = new Pixel(x, y, argb[i]);
+            int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
+            int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
+            int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
+            argb[i++] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 }


### PR DESCRIPTION
## Summary
- `mapInPlace`, `replaceTransparencyInPlace`, and `contrastInPlace` iterated `points()`/`pixels()` and called `BufferedImage.getRGB(x, y)` and `setRGB(x, y, argb)` once per pixel. Each call goes through `ColorModel` and `SampleModel` and performs bounds checks, making it orders of magnitude slower than the bulk `getRGB(int[],...)` / `setRGB(int[],...)` variants.
- Switch to a single bulk read into an `int[]`, modify in place, single bulk write back. Also avoids the per-call `points()` / `pixels()` allocation of a `width * height` auxiliary array.
- Pixel semantics are preserved: the user callback / inline math still receives a `Pixel` constructed from the same ARGB int as before.

## Test plan
- [x] Full scrimage-tests suite passes (covers map / contrast / removeTransparency)