### PR TITLE
Use bulk get/setRGB in MutableImage map and replaceTransparency

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -35,17 +35,27 @@ public class MutableImage extends AwtImage {
     * @param mapper the function to transform pixel x,y with existing value p into new pixel value p' (p prime)
     */
    public void mapInPlace(Function<Pixel, Color> mapper) {
-      Arrays.stream(points()).forEach(point -> {
-         Color c = mapper.apply(pixel(point.x, point.y));
-         awt().setRGB(point.x, point.y, c.getRGB());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            argb[i] = mapper.apply(new Pixel(x, y, argb[i])).getRGB();
+            i++;
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
-      Arrays.stream(pixels()).forEach(pixel -> {
-         Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(pixel, color);
-         awt().setRGB(pixel.x, pixel.y, withoutTrans.toARGBInt());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            argb[i] = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color).toARGBInt();
+            i++;
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    /**


### PR DESCRIPTION
## Summary
- `MutableImage.mapInPlace` and `replaceTransparencyInPlace` previously called `awt.setRGB(x, y, ...)` per pixel inside a stream over `points()` / `pixels()`. Per-pixel `setRGB` unmanages the backing image and is much slower than a single bulk `setRGB(0, 0, w, h, ...)`.
- Both methods now read the whole pixel grid with one `getRGB`, mutate the buffer in a tight loop, and write it back with one `setRGB`.
- Drops the `width*height` `Point` allocation in `mapInPlace` and the `Pixel[]` allocation in `replaceTransparencyInPlace`.

`mapInPlace` is called by `ImmutableImage.map`, `toGrayscale`, and `create(w, h, Pixel[])`, so this affects a lot of pixel-mapping paths.

## Test plan
- [x] Full `scrimage-tests` suite passes locally
- [x] Touched paths covered by `PixelsTest`, `ImageTest`, `RGBColorTest`, transform/gradient tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)