### PR TITLE
Use bulk getRGB/setRGB in MutableImage.mapInPlace

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -35,10 +35,15 @@ public class MutableImage extends AwtImage {
     * @param mapper the function to transform pixel x,y with existing value p into new pixel value p' (p prime)
     */
    public void mapInPlace(Function<Pixel, Color> mapper) {
-      Arrays.stream(points()).forEach(point -> {
-         Color c = mapper.apply(pixel(point.x, point.y));
-         awt().setRGB(point.x, point.y, c.getRGB());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            argb[i] = mapper.apply(new Pixel(x, y, argb[i])).getRGB();
+            i++;
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    public void replaceTransparencyInPlace(java.awt.Color color) {


### PR DESCRIPTION
## Summary

- `MutableImage.mapInPlace` currently iterates via `Arrays.stream(points())`, calling `awt.getRGB(x, y)` and `awt.setRGB(x, y, ...)` once per pixel. Replaces both with a single bulk `getRGB(0, 0, w, h, ...)` read, an in-memory transform of the `int[]`, and a single bulk `setRGB(0, 0, w, h, ...)` write.
- `mapInPlace` backs `ImmutableImage.map()`, `toGrayscale()`, `create(w, h, Pixel[])`, and several filters (`BlackThresholdFilter`, `OpacityFilter`, `GrayscaleFilter`), so the win propagates to all of them.
- No behaviour change: pixels are still visited in row-major order with the same `Pixel` argument and the resulting `Color.getRGB()` packed ARGB int written back to the same coordinate.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (covers `map`, `contrast`, `brightness`, grayscale, and filter regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)