### PR TITLE
Bulk getRGB/setRGB in contrastInPlace and replaceTransparencyInPlace

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -42,10 +42,16 @@ public class MutableImage extends AwtImage {
    }
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
-      Arrays.stream(pixels()).forEach(pixel -> {
-         Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(pixel, color);
-         awt().setRGB(pixel.x, pixel.y, withoutTrans.toARGBInt());
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color);
+            argb[i] = withoutTrans.toARGBInt();
+            i++;
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 
    /**
@@ -100,13 +106,18 @@ public class MutableImage extends AwtImage {
    }
 
    public void contrastInPlace(double factor) {
-      Arrays.stream(points()).forEach(p -> {
-         Pixel pixel = pixel(p.x, p.y);
-         int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
-         int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
-         int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
-         Pixel pixel2 = new Pixel(pixel.x, pixel.y, r, g, b, pixel.alpha());
-         setPixel(pixel2);
-      });
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            Pixel pixel = new Pixel(x, y, argb[i]);
+            int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
+            int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
+            int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
+            argb[i] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();
+            i++;
+         }
+      }
+      awt().setRGB(0, 0, width, height, argb, 0, width);
    }
 }


### PR DESCRIPTION
## Summary

- `MutableImage.contrastInPlace` and `MutableImage.replaceTransparencyInPlace` both previously made one `awt.getRGB` and one `awt.setRGB` call per pixel via `Arrays.stream(points())` / `Arrays.stream(pixels())`. Replace with a single bulk `getRGB(0, 0, w, h, ...)` read into an `int[]`, an in-memory transform of each ARGB int, and a single bulk `setRGB(0, 0, w, h, ...)` write.
- `contrastInPlace` backs `ImmutableImage.contrast()`. `replaceTransparencyInPlace` backs `ImmutableImage.removeTransparency()` (also used by `JpegWriter` when stripping alpha before encoding).
- No behaviour change: same per-pixel formula, applied in row-major order.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (covers `contrast` against a golden image and JPEG writes which exercise the alpha-strip path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)