### PR TITLE
Use bulk getRGB for AwtImage.argb()/argbints()/rgb()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -323,7 +323,13 @@ public class AwtImage {
     * @return an array containing an array for each ARGB components in that order.
     */
    public int[][] argb() {
-      return Arrays.stream(points()).map(p -> argb(p.x, p.y)).toArray(int[][]::new);
+      int[] packed = awt().getRGB(0, 0, width, height, null, 0, width);
+      int[][] result = new int[packed.length][];
+      for (int i = 0; i < packed.length; i++) {
+         int p = packed[i];
+         result[i] = new int[]{(p >> 24) & 0xFF, (p >> 16) & 0xFF, (p >> 8) & 0xFF, p & 0xFF};
+      }
+      return result;
    }
 
    /**
@@ -332,7 +338,7 @@ public class AwtImage {
     * @return an array containing the packed ARGB int for each pixel.
     */
    public int[] argbints() {
-      return Arrays.stream(points()).mapToInt(p -> color(p.x, p.y).toARGBInt()).toArray();
+      return awt().getRGB(0, 0, width, height, null, 0, width);
    }
 
    public int[] rgb(int x, int y) {
@@ -341,7 +347,13 @@ public class AwtImage {
    }
 
    public int[][] rgb() {
-      return Arrays.stream(points()).map(p -> rgb(p.x, p.y)).toArray(int[][]::new);
+      int[] packed = awt().getRGB(0, 0, width, height, null, 0, width);
+      int[][] result = new int[packed.length][];
+      for (int i = 0; i < packed.length; i++) {
+         int p = packed[i];
+         result[i] = new int[]{(p >> 16) & 0xFF, (p >> 8) & 0xFF, p & 0xFF};
+      }
+      return result;
    }
 
    /**


### PR DESCRIPTION
## Summary

- The whole-image array accessors `AwtImage.argb()` (returns `int[][]` with `[a,r,g,b]` rows), `argbints()` (returns packed `int[]`), and `rgb()` (returns `int[][]` with `[r,g,b]` rows) all iterated `Arrays.stream(points())` and called `awt.getRGB(x, y)` once per pixel via the per-coordinate helpers.
- Replace with a single bulk `getRGB(0, 0, w, h, ...)` read and trivial bit unpacking. `argbints()` now returns the bulk array directly, since `BufferedImage.getRGB` already produces packed ARGB ints in the layout the method's javadoc promises.
- No behaviour change: same row-major order, same channel ranges.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (the existing `map modifies each pixel` test asserts the `argb()` shape `[a, r, g, b]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)