### PR TITLE
Compose JPEG-safe (alpha-free) image in a single Graphics2D pass

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
@@ -7,6 +7,8 @@ import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -72,7 +74,15 @@ public class JpegWriter implements ImageWriter {
       // so have to convert to a non alpha type
       BufferedImage noAlpha;
       if (image.awt().getColorModel().hasAlpha()) {
-         noAlpha = image.toImmutableImage().removeTransparency(java.awt.Color.WHITE).toNewBufferedImage(BufferedImage.TYPE_INT_RGB);
+         noAlpha = new BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB);
+         Graphics2D g2 = noAlpha.createGraphics();
+         try {
+            g2.setColor(Color.WHITE);
+            g2.fillRect(0, 0, image.width, image.height);
+            g2.drawImage(image.awt(), 0, 0, null);
+         } finally {
+            g2.dispose();
+         }
       } else {
          noAlpha = image.awt();
       }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterTest.kt
@@ -5,8 +5,11 @@ package com.sksamuel.scrimage.core.nio
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.metadata.Tag
 import com.sksamuel.scrimage.nio.JpegWriter
+import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
 
 class JpegWriterTest : FunSpec({
 
@@ -38,5 +41,43 @@ class JpegWriterTest : FunSpec({
          Tag("a", -3, "0", "foo"),
          Tag("b", 0, "8", "boo")
       )
+   }
+
+   // The single-Graphics2D-pass alpha removal must produce the same blend
+   // result as the previous two-pass replaceTransparency + toNewBufferedImage:
+   // alpha-blend the source over a white background. We use a 16x16 image
+   // because JPEG's 8x8 DCT block quantization produces large artifacts on
+   // tiny images; sampling away from the edge gives much closer values.
+   test("alpha is composited over white when writing JPEG") {
+      // 16x16 image: top half fully transparent, bottom half semi-transparent
+      // blue (alpha=128). Both halves should converge to white / blue-over-white
+      // after compositing.
+      val w = 16; val h = 16
+      val pixels = Array(w * h) { i ->
+         val x = i % w; val y = i / w
+         if (y < h / 2) Pixel(x, y, 100, 50, 25, 0)        // fully transparent
+         else Pixel(x, y, 0, 0, 255, 128)                  // semi blue
+      }
+      val image = ImmutableImage.create(w, h, pixels)
+      val bytes = image.bytes(JpegWriter().withCompression(95))
+      val decoded = ImmutableImage.loader().fromBytes(bytes)
+
+      decoded.width shouldBe w
+      decoded.height shouldBe h
+
+      // Sample from the centre of each half, away from block edges.
+      val transparent = decoded.pixel(w / 2, 1)
+      // alpha=0 over white → white
+      (255 - transparent.red()) shouldBeLessThanOrEqual 8
+      (255 - transparent.green()) shouldBeLessThanOrEqual 8
+      (255 - transparent.blue()) shouldBeLessThanOrEqual 8
+
+      // Semi-transparent blue alpha-composited over white:
+      // r = 255*(1-128/255) + 0*(128/255) ≈ 127
+      // g ≈ 127, b ≈ 255
+      val semi = decoded.pixel(w / 2, h - 2)
+      Math.abs(semi.red() - 127) shouldBeLessThanOrEqual 12
+      Math.abs(semi.green() - 127) shouldBeLessThanOrEqual 12
+      Math.abs(semi.blue() - 255) shouldBeLessThanOrEqual 12
    }
 })


### PR DESCRIPTION
## Summary

- When the source has an alpha channel `JpegWriter` previously chained `removeTransparency(WHITE)` (which `copy()`s the source then walks every pixel applying the SrcOver formula via `replaceTransparencyInPlace`) and `toNewBufferedImage(TYPE_INT_RGB)` (a Graphics2D redraw into a freshly allocated buffer). That's two full pixel-buffer passes plus two allocations.
- Replace with a single `TYPE_INT_RGB` target filled white and drawn over once via `Graphics2D`. `AlphaComposite.SRC_OVER` onto an opaque destination produces the same blended result the manual `(r * a + 255 * (255 - a)) / 255` formula computed, so the encoded JPEG bytes are equivalent (within the usual JPEG quantization).

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (covers `JpegWriterTest`, including issue84 which exercises the alpha-strip path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)