### PR TITLE
Use bulk getRGB/setRGB in AlphaMaskFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/AlphaMaskFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/AlphaMaskFilter.java
@@ -1,9 +1,6 @@
 package com.sksamuel.scrimage.filter;
 
 import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.color.RGBColor;
-
-import java.io.IOException;
 
 /**
  * Returns a new ImmutableImage with the given alpha mask applied to this image.
@@ -28,29 +25,30 @@ public class AlphaMaskFilter implements Filter {
    @Override
    public void apply(ImmutableImage image) {
 
-      RGBColor[] imageColors = image.colors();
-      RGBColor[] maskColors = mask.colors();
+      int w = image.width;
+      int h = image.height;
+      int[] imagePixels = image.awt().getRGB(0, 0, w, h, null, 0, w);
+      int[] maskPixels = mask.awt().getRGB(0, 0, w, h, null, 0, w);
 
-      int count = image.count();
-      for (int i = 0; i < count; i++) {
-         int color = imageColors[i].toARGBInt() & 0x00ffffff; // Mask preexisting alpha
+      for (int i = 0; i < imagePixels.length; i++) {
+         int color = imagePixels[i] & 0x00ffffff; // Mask preexisting alpha
          int alpha;
          switch (channel) {
             case 1:
-               alpha = (maskColors[i].toARGBInt() & 0x00FF0000) << 8; // Shift red to alpha
+               alpha = (maskPixels[i] & 0x00FF0000) << 8; // Shift red to alpha
                break;
             case 2:
-               alpha = (maskColors[i].toARGBInt() & 0x0000FF00) << 16; // Shift green to alpha
+               alpha = (maskPixels[i] & 0x0000FF00) << 16; // Shift green to alpha
                break;
             case 3:
-               alpha = (maskColors[i].toARGBInt() & 0x000000FF) << 24; // Shift blue to alpha
+               alpha = (maskPixels[i] & 0x000000FF) << 24; // Shift blue to alpha
                break;
             default:
-               alpha = (maskColors[i].toARGBInt() & 0xFF000000); // use alpha channel
+               alpha = (maskPixels[i] & 0xFF000000); // use alpha channel
                break;
          }
-         int masked = color | alpha;
-         image.setColor(i, RGBColor.fromARGBInt(masked));
+         imagePixels[i] = color | alpha;
       }
+      image.awt().setRGB(0, 0, w, h, imagePixels, 0, w);
    }
 }


### PR DESCRIPTION
## Summary

- `AlphaMaskFilter` previously called `image.colors()` and `mask.colors()`, which materialise a full `RGBColor[]` per image (one allocation per pixel on top of the underlying `Pixel[]`), and then wrote back through `image.setColor(i, RGBColor.fromARGBInt(masked))` — dispatching `PixelTools.offsetToPoint` plus a per-pixel `awt.setRGB(x, y, ...)` call. For an N-pixel image that's ~3·N transient allocations and 2·N AWT round-trips.
- Replace with a single bulk `getRGB` on the image, a single bulk `getRGB` on the mask, the same bit operations against the `int[]`s, and a single bulk `setRGB`. No per-pixel allocations; same packed ARGB output.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (filter regression coverage).
- Behaviour preserved: same channel-shift-and-OR formula, written back through the same packed-ARGB layout that `image.setColor` resolved to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)