### PR TITLE
Fast-path AwtImage color queries to int comparisons

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -283,7 +283,12 @@ public class AwtImage {
     * @return true if there exists at least one pixel that has the given pixels color
     */
    public boolean contains(Color color) {
-      return exists(p -> p.toARGBInt() == RGBColor.fromAwt(color).toARGBInt());
+      int target = color.getRGB();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      for (int v : argb) {
+         if (v == target) return true;
+      }
+      return false;
    }
 
    /**
@@ -436,7 +441,13 @@ public class AwtImage {
     * @return the number of pixels that matched the colour of the given pixel
     */
    public long count(Color color) {
-      return count(p -> p.toColor().equals(RGBColor.fromAwt(color)));
+      int target = color.getRGB();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      long n = 0;
+      for (int v : argb) {
+         if (v == target) n++;
+      }
+      return n;
    }
 
    /**
@@ -588,8 +599,12 @@ public class AwtImage {
     * @param color the color to test pixels against
     */
    public boolean isFilled(Color color) {
-      int argbColor = RGBColor.fromAwt(color).toARGBInt();
-      return forAll(p -> p.argb == argbColor);
+      int target = color.getRGB();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      for (int v : argb) {
+         if (v != target) return false;
+      }
+      return true;
    }
 
    public Path output(ImageWriter writer, String path) throws IOException {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ColorQueryTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ColorQueryTest.kt
@@ -1,0 +1,67 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Pin-down tests for the int-comparison fast paths of contains(Color),
+ * count(Color), and isFilled(Color).
+ */
+class ColorQueryTest : FunSpec({
+
+   test("contains returns true when at least one pixel matches the color") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),
+         Pixel(1, 0, 0, 255, 0, 255),
+         Pixel(0, 1, 0, 0, 255, 255),
+         Pixel(1, 1, 255, 255, 255, 255)
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      image.contains(Color(0, 255, 0)) shouldBe true
+      image.contains(Color.WHITE) shouldBe true
+   }
+
+   test("contains returns false when no pixel matches") {
+      val pixels = arrayOf(Pixel(0, 0, 255, 0, 0, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      image.contains(Color.GREEN) shouldBe false
+   }
+
+   test("contains is alpha-aware (RGBA exact match required)") {
+      // pixel is opaque red; checking for transparent red should NOT match
+      val pixels = arrayOf(Pixel(0, 0, 255, 0, 0, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      image.contains(Color(255, 0, 0, 128)) shouldBe false
+   }
+
+   test("count(Color) returns the number of exact ARGB matches") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),
+         Pixel(1, 0, 0, 255, 0, 255),
+         Pixel(0, 1, 255, 0, 0, 255),
+         Pixel(1, 1, 255, 0, 0, 255)
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      image.count(Color.RED) shouldBe 3L
+      image.count(Color.GREEN) shouldBe 1L
+      image.count(Color.BLUE) shouldBe 0L
+   }
+
+   test("isFilled returns true when every pixel matches") {
+      val pixels = Array(9) { Pixel(it % 3, it / 3, 100, 200, 50, 255) }
+      val image = ImmutableImage.create(3, 3, pixels)
+      image.isFilled(Color(100, 200, 50, 255)) shouldBe true
+   }
+
+   test("isFilled returns false when one pixel differs") {
+      val pixels = Array(9) { i ->
+         if (i == 4) Pixel(i % 3, i / 3, 0, 0, 0, 255)
+         else Pixel(i % 3, i / 3, 100, 200, 50, 255)
+      }
+      val image = ImmutableImage.create(3, 3, pixels)
+      image.isFilled(Color(100, 200, 50, 255)) shouldBe false
+   }
+})


### PR DESCRIPTION
## Summary

- `contains(Color)`, `count(Color)`, and `isFilled(Color)` all reduce to a packed-ARGB int comparison, but the existing implementations forced a `Pixel[]` materialisation plus per-pixel allocation: `contains` and `isFilled` ran a `Predicate<Pixel>` over the array; `count(Color)` went further and built a fresh `RGBColor` per pixel just to call `equals()`.
- Replace each with a single bulk `getRGB` read and compare against `color.getRGB()` directly. Both sides go through the image's `ColorModel`, so the packed-ARGB layout matches and behaviour is preserved. Allocations drop to one `int[]` regardless of image size.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (existing image-equality / fill / count regression coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)