### PR TITLE
Dedupe ARGB ints before allocating RGBColor in AwtImage.colours()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -426,7 +426,8 @@ public class AwtImage {
     * @return the set of distinct Colors
     */
    public Set<RGBColor> colours() {
-      return Arrays.stream(pixels()).map(Pixel::toColor).collect(Collectors.toSet());
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      return Arrays.stream(argb).distinct().mapToObj(RGBColor::fromARGBInt).collect(Collectors.toSet());
    }
 
    /**

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Wraps an AWT BufferedImage with some basic helper functions related to sizes, pixels etc.
@@ -474,12 +474,10 @@ public class AwtImage {
     * @return the set of distinct Colors
     */
    public Set<RGBColor> colours() {
+      // Dedupe the packed ints first so RGBColor is only allocated once per
+      // distinct colour, rather than once per pixel.
       int[] argb = argbints();
-      Set<RGBColor> colours = new HashSet<>();
-      for (int p : argb) {
-         colours.add(RGBColor.fromARGBInt(p));
-      }
-      return colours;
+      return Arrays.stream(argb).distinct().mapToObj(RGBColor::fromARGBInt).collect(Collectors.toSet());
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ColoursDistinctTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ColoursDistinctTest.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pin-down tests for AwtImage.colours() after the dedup-on-int fast path:
+ * dedup is performed on packed ARGB ints first, then RGBColor is allocated
+ * only for the surviving distinct values.
+ */
+class ColoursDistinctTest : FunSpec({
+
+   test("colours returns the set of distinct ARGB values, alpha included") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),     // opaque red
+         Pixel(1, 0, 0, 255, 0, 255),     // opaque green
+         Pixel(0, 1, 255, 0, 0, 255),     // duplicate opaque red
+         Pixel(1, 1, 255, 0, 0, 128)      // semi-transparent red — distinct from opaque
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val colours = image.colours()
+      colours shouldContainExactlyInAnyOrder setOf(
+         RGBColor(255, 0, 0, 255),
+         RGBColor(0, 255, 0, 255),
+         RGBColor(255, 0, 0, 128)
+      )
+   }
+
+   test("colours of a uniform image is a single-element set") {
+      val pixels = Array(16) { Pixel(it % 4, it / 4, 100, 200, 50, 255) }
+      val image = ImmutableImage.create(4, 4, pixels)
+      val colours = image.colours()
+      colours.size shouldBe 1
+      colours.first() shouldBe RGBColor(100, 200, 50, 255)
+   }
+
+   test("colours preserves alpha (transparent black is distinct from opaque black)") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 0, 0, 0, 255),
+         Pixel(1, 0, 0, 0, 0, 0)
+      )
+      val image = ImmutableImage.create(2, 1, pixels)
+      val colours = image.colours()
+      colours.size shouldBe 2
+      colours shouldContainExactlyInAnyOrder setOf(
+         RGBColor(0, 0, 0, 255),
+         RGBColor(0, 0, 0, 0)
+      )
+   }
+})


### PR DESCRIPTION
## Summary

- The previous `colours()` implementation allocated one `Pixel` per pixel (via `pixels()`) and then one `RGBColor` per pixel, before letting the `HashSet` collapse duplicates. So allocations scaled with the pixel count even though the result is bounded by the (typically far smaller) distinct-colour count.
- Replace with a single bulk `getRGB` read, `IntStream.distinct()` against the int array, then `RGBColor::fromARGBInt` only on the surviving distinct values. Allocations now scale with the number of distinct colours, not the pixel count.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)