### PR TITLE
Use bulk getRGB/setRGB in ErrorSpotterFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
@@ -21,31 +21,39 @@ public class ErrorSpotterFilter implements Filter {
     }
 
     public int error(RGBColor rgb1, RGBColor rgb2) {
+        return errorArgb(rgb1.toARGBInt(), rgb2.toARGBInt());
+    }
+
+    private int errorArgb(int argb1, int argb2) {
         int red = 0, blue = 0, delta;
-        delta = rgb1.red - rgb2.red;
+        delta = ((argb1 >> 16) & 0xFF) - ((argb2 >> 16) & 0xFF); // red
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.blue - rgb2.blue;
+        delta = (argb1 & 0xFF) - (argb2 & 0xFF); // blue
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.green - rgb2.green;
+        delta = ((argb1 >> 8) & 0xFF) - ((argb2 >> 8) & 0xFF); // green
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.alpha - rgb2.alpha;
+        delta = ((argb1 >>> 24) & 0xFF) - ((argb2 >>> 24) & 0xFF); // alpha
         if (delta > 0) red += delta;
         else blue -= delta;
-        return new RGBColor(Math.min(ratio * red, 255), 0, Math.min(ratio * blue, 255), 255).toARGBInt();
+        int r = Math.min(ratio * red, 255);
+        int b = Math.min(ratio * blue, 255);
+        return 0xFF000000 | (r << 16) | b;
     }
 
     @Override
     public void apply(ImmutableImage src) {
         assert (src.width == base.width);
         assert (src.height == base.height);
-        for (int x = 0; x < src.width; x++) {
-            for (int y = 0; y < src.height; y++) {
-                int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)), RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
-                src.awt().setRGB(x, y, delta);
-            }
+        int w = src.width;
+        int h = src.height;
+        int[] srcArgb = src.awt().getRGB(0, 0, w, h, null, 0, w);
+        int[] baseArgb = base.awt().getRGB(0, 0, w, h, null, 0, w);
+        for (int i = 0; i < srcArgb.length; i++) {
+            srcArgb[i] = errorArgb(baseArgb[i], srcArgb[i]);
         }
+        src.awt().setRGB(0, 0, w, h, srcArgb, 0, w);
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
@@ -21,20 +21,26 @@ public class ErrorSpotterFilter implements Filter {
     }
 
     public int error(RGBColor rgb1, RGBColor rgb2) {
+        return errorArgb(rgb1.toARGBInt(), rgb2.toARGBInt());
+    }
+
+    private int errorArgb(int argb1, int argb2) {
         int red = 0, blue = 0, delta;
-        delta = rgb1.red - rgb2.red;
+        delta = ((argb1 >> 16) & 0xFF) - ((argb2 >> 16) & 0xFF); // red
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.blue - rgb2.blue;
+        delta = (argb1 & 0xFF) - (argb2 & 0xFF); // blue
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.green - rgb2.green;
+        delta = ((argb1 >> 8) & 0xFF) - ((argb2 >> 8) & 0xFF); // green
         if (delta > 0) red += delta;
         else blue -= delta;
-        delta = rgb1.alpha - rgb2.alpha;
+        delta = ((argb1 >>> 24) & 0xFF) - ((argb2 >>> 24) & 0xFF); // alpha
         if (delta > 0) red += delta;
         else blue -= delta;
-        return new RGBColor(Math.min(ratio * red, 255), 0, Math.min(ratio * blue, 255), 255).toARGBInt();
+        int r = Math.min(ratio * red, 255);
+        int b = Math.min(ratio * blue, 255);
+        return 0xFF000000 | (r << 16) | b;
     }
 
     @Override
@@ -42,20 +48,21 @@ public class ErrorSpotterFilter implements Filter {
         // Asserts are disabled by default in production JVMs, so the
         // previous `assert src.width == base.width` checks were no-ops
         // in practice and a dimension mismatch surfaced as a cryptic
-        // ArrayIndexOutOfBoundsException from base.awt().getRGB(x, y)
-        // deep inside the loop. Validate explicitly with a useful
-        // diagnostic.
+        // ArrayIndexOutOfBoundsException deep inside the loop. Validate
+        // explicitly with a useful diagnostic.
         if (src.width != base.width || src.height != base.height) {
             throw new IllegalArgumentException(
                 "ErrorSpotterFilter requires src and base to have the same dimensions; "
                     + "src=" + src.width + "x" + src.height
                     + ", base=" + base.width + "x" + base.height);
         }
-        for (int x = 0; x < src.width; x++) {
-            for (int y = 0; y < src.height; y++) {
-                int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)), RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
-                src.awt().setRGB(x, y, delta);
-            }
+        int w = src.width;
+        int h = src.height;
+        int[] srcArgb = src.awt().getRGB(0, 0, w, h, null, 0, w);
+        int[] baseArgb = base.awt().getRGB(0, 0, w, h, null, 0, w);
+        for (int i = 0; i < srcArgb.length; i++) {
+            srcArgb[i] = errorArgb(baseArgb[i], srcArgb[i]);
         }
+        src.awt().setRGB(0, 0, w, h, srcArgb, 0, w);
     }
 }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ErrorSpotterFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ErrorSpotterFilterTest.kt
@@ -1,0 +1,96 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pin-down tests for the bulk-int rewrite of ErrorSpotterFilter. Each
+ * channel diff is mirrored across two output channels (positive deltas
+ * pile up red, negative deltas pile up blue), then both are clamped to
+ * 255 after multiplying by ratio. Output alpha is always 255 (opaque).
+ */
+class ErrorSpotterFilterTest : FunSpec({
+
+   test("identical images produce a fully black opaque diff") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 100, 200, 50, 255),
+         Pixel(1, 0, 0, 0, 0, 0),
+         Pixel(0, 1, 255, 255, 255, 128),
+         Pixel(1, 1, 50, 100, 150, 200)
+      )
+      val base = ImmutableImage.create(2, 2, pixels.copyOf())
+      val src = ImmutableImage.create(2, 2, pixels.copyOf())
+      ErrorSpotterFilter(base, 50).apply(src)
+      // No deltas in any channel → red=0, blue=0, alpha=0xFF
+      src.pixels().forEach { p ->
+         p.red() shouldBe 0
+         p.green() shouldBe 0
+         p.blue() shouldBe 0
+         p.alpha() shouldBe 255
+      }
+   }
+
+   test("error() small positive red delta clamps via ratio") {
+      // base red = 200, src red = 199 → delta = 1 → red += 1
+      // ratio 50 → r = min(50 * 1, 255) = 50, b = 0
+      val basePix = RGBColor(200, 100, 50, 255)
+      val srcPix = RGBColor(199, 100, 50, 255)
+      val base = ImmutableImage.create(1, 1, arrayOf(Pixel(0, 0, basePix.red, basePix.green, basePix.blue, basePix.alpha)))
+      val filter = ErrorSpotterFilter(base, 50)
+      val argb = filter.error(basePix, srcPix)
+      ((argb ushr 24) and 0xFF) shouldBe 0xFF
+      ((argb ushr 16) and 0xFF) shouldBe 50
+      ((argb ushr 8) and 0xFF) shouldBe 0
+      (argb and 0xFF) shouldBe 0
+   }
+
+   test("error() saturates at 255 when ratio*delta exceeds it") {
+      // base red 200, src red 0 → delta 200 → r = min(50 * 200, 255) = 255
+      val basePix = RGBColor(200, 100, 50, 255)
+      val srcPix = RGBColor(0, 100, 50, 255)
+      val base = ImmutableImage.create(1, 1, arrayOf(Pixel(0, 0, basePix.red, basePix.green, basePix.blue, basePix.alpha)))
+      val filter = ErrorSpotterFilter(base, 50)
+      val argb = filter.error(basePix, srcPix)
+      ((argb ushr 16) and 0xFF) shouldBe 255 // red saturated
+      (argb and 0xFF) shouldBe 0
+   }
+
+   test("error() routes negative deltas into blue channel") {
+      // base red 0, src red 100 → delta -100 → blue += 100 → b = min(50*100, 255) = 255
+      val basePix = RGBColor(0, 0, 0, 255)
+      val srcPix = RGBColor(100, 0, 0, 255)
+      val base = ImmutableImage.create(1, 1, arrayOf(Pixel(0, 0, basePix.red, basePix.green, basePix.blue, basePix.alpha)))
+      val filter = ErrorSpotterFilter(base, 50)
+      val argb = filter.error(basePix, srcPix)
+      ((argb ushr 16) and 0xFF) shouldBe 0
+      (argb and 0xFF) shouldBe 255 // blue saturated
+   }
+
+   test("apply() over an image preserves dimensions and writes opaque output") {
+      val basePixels = arrayOf(
+         Pixel(0, 0, 100, 100, 100, 255),
+         Pixel(1, 0, 100, 100, 100, 255)
+      )
+      val srcPixels = arrayOf(
+         Pixel(0, 0, 110, 100, 100, 255),  // +10 red
+         Pixel(1, 0, 90, 100, 100, 255)    // -10 red
+      )
+      val base = ImmutableImage.create(2, 1, basePixels)
+      val src = ImmutableImage.create(2, 1, srcPixels)
+      ErrorSpotterFilter(base, 5).apply(src)
+      src.width shouldBe 2
+      src.height shouldBe 1
+      // Output is always opaque
+      src.pixels().forEach { it.alpha() shouldBe 255 }
+      // First pixel: src red is HIGHER than base → that's a negative delta from
+      // base→src, so error() puts it in BLUE channel (5*10=50)
+      src.pixel(0, 0).blue() shouldBe 50
+      src.pixel(0, 0).red() shouldBe 0
+      // Second pixel: src red is LOWER than base → positive delta → RED (5*10=50)
+      src.pixel(1, 0).red() shouldBe 50
+      src.pixel(1, 0).blue() shouldBe 0
+   }
+})


### PR DESCRIPTION
## Summary

- `ErrorSpotterFilter.apply` walked every pixel via two `awt.getRGB(x, y)` calls plus an `awt.setRGB(x, y, ...)` call, with two `RGBColor.fromARGBInt` allocations per pixel and a third `RGBColor` allocation inside `error()` just to call `toARGBInt()` on it. The loop was also column-major, which thrashes the row-major raster cache.
- Switch to a single bulk `getRGB` on each input, an int-only channel-diff routine (`errorArgb`) that writes directly into the source array, and a single bulk `setRGB`. The public `error(RGBColor, RGBColor)` method is preserved as a thin shim around `errorArgb`.
- Same packed-ARGB output (`0xFF000000 | (r << 16) | b`); zero per-pixel allocations.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)