### PR TITLE
Drop per-pixel Point allocation in AwtImage.pixels()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -117,32 +117,33 @@ public class AwtImage {
    public Pixel[] pixels() {
       DataBuffer buffer = awt().getRaster().getDataBuffer();
       if (buffer instanceof DataBufferInt) {
-         DataBufferInt intbuffer = (DataBufferInt) buffer;
-         int[] data = intbuffer.getData();
-         int index = 0;
+         int[] data = ((DataBufferInt) buffer).getData();
          Pixel[] pixels = new Pixel[data.length];
-         if (awt().getType() == BufferedImage.TYPE_INT_ARGB) {
-            while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index]);
-               index++;
-            }
-         } else if (awt().getType() == BufferedImage.TYPE_INT_RGB) {
-            while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index] | 0xFF000000);
-               index++;
-            }
+         int type = awt().getType();
+         int alphaMask;
+         if (type == BufferedImage.TYPE_INT_ARGB) {
+            alphaMask = 0;
+         } else if (type == BufferedImage.TYPE_INT_RGB) {
+            alphaMask = 0xFF000000;
          } else {
-            throw new RuntimeException("Unsupported image type " + awt().getType());
+            throw new RuntimeException("Unsupported image type " + type);
          }
-         return pixels;
-      } else {
-         Pixel[] pixels = new Pixel[count()];
          int index = 0;
          for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-               pixels[index++] = new Pixel(x, y, awt().getRGB(x, y));
+               pixels[index] = new Pixel(x, y, data[index] | alphaMask);
+               index++;
+            }
+         }
+         return pixels;
+      } else {
+         int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+         Pixel[] pixels = new Pixel[argb.length];
+         int index = 0;
+         for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+               pixels[index] = new Pixel(x, y, argb[index]);
+               index++;
             }
          }
          return pixels;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -112,32 +112,33 @@ public class AwtImage {
    public Pixel[] pixels() {
       DataBuffer buffer = awt().getRaster().getDataBuffer();
       if (buffer instanceof DataBufferInt) {
-         DataBufferInt intbuffer = (DataBufferInt) buffer;
-         int[] data = intbuffer.getData();
-         int index = 0;
+         int[] data = ((DataBufferInt) buffer).getData();
          Pixel[] pixels = new Pixel[data.length];
-         if (awt().getType() == BufferedImage.TYPE_INT_ARGB) {
-            while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index]);
-               index++;
-            }
-         } else if (awt().getType() == BufferedImage.TYPE_INT_RGB) {
-            while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index] | 0xFF000000);
-               index++;
-            }
+         int type = awt().getType();
+         int alphaMask;
+         if (type == BufferedImage.TYPE_INT_ARGB) {
+            alphaMask = 0;
+         } else if (type == BufferedImage.TYPE_INT_RGB) {
+            alphaMask = 0xFF000000;
          } else {
-            throw new RuntimeException("Unsupported image type " + awt().getType());
+            throw new RuntimeException("Unsupported image type " + type);
          }
-         return pixels;
-      } else {
-         Pixel[] pixels = new Pixel[count()];
          int index = 0;
          for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-               pixels[index++] = new Pixel(x, y, awt().getRGB(x, y));
+               pixels[index] = new Pixel(x, y, data[index] | alphaMask);
+               index++;
+            }
+         }
+         return pixels;
+      } else {
+         int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+         Pixel[] pixels = new Pixel[argb.length];
+         int index = 0;
+         for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+               pixels[index] = new Pixel(x, y, argb[index]);
+               index++;
             }
          }
          return pixels;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -112,4 +112,29 @@ class AwtImageTest : FunSpec({
       pixels[3].x shouldBe 1; pixels[3].y shouldBe 1
       pixels[3].argb shouldBe 0xFFFFFFFF.toInt()
    }
+
+   // Regression: pixels() previously called PixelTools.offsetToPoint(index, w)
+   // inside the DataBufferInt fast-path loop, allocating one Point per pixel
+   // just to derive (x, y). The optimisation replaced that with running x/y
+   // counters. These tests pin the row-major (x, y) ordering for the
+   // TYPE_INT_ARGB fast path so a future regression that mis-derives
+   // coordinates would be caught.
+   test("pixels() on TYPE_INT_ARGB carries correct row-major (x, y) coordinates") {
+      val w = 4; val h = 3
+      val buf = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+      // distinct ARGB per pixel so every Pixel is unique
+      for (y in 0 until h) for (x in 0 until w) {
+         buf.setRGB(x, y, 0xFF000000.toInt() or (((y * w + x) and 0xFF) shl 16))
+      }
+      val image = AwtImage(buf)
+      val pixels = image.pixels()
+      pixels.size shouldBe w * h
+      var i = 0
+      for (y in 0 until h) for (x in 0 until w) {
+         pixels[i].x shouldBe x
+         pixels[i].y shouldBe y
+         pixels[i].argb shouldBe (0xFF000000.toInt() or ((i and 0xFF) shl 16))
+         i++
+      }
+   }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -199,4 +199,29 @@ class AwtImageTest : FunSpec({
       // matches at i=0,3,6,9 → 4 pixels
       image.count { p -> p.red() == 255 } shouldBe 4L
    }
+
+   // Regression: pixels() previously called PixelTools.offsetToPoint(index, w)
+   // inside the DataBufferInt fast-path loop, allocating one Point per pixel
+   // just to derive (x, y). The optimisation replaced that with running x/y
+   // counters. These tests pin the row-major (x, y) ordering for the
+   // TYPE_INT_ARGB fast path so a future regression that mis-derives
+   // coordinates would be caught.
+   test("pixels() on TYPE_INT_ARGB carries correct row-major (x, y) coordinates") {
+      val w = 4; val h = 3
+      val buf = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+      // distinct ARGB per pixel so every Pixel is unique
+      for (y in 0 until h) for (x in 0 until w) {
+         buf.setRGB(x, y, 0xFF000000.toInt() or (((y * w + x) and 0xFF) shl 16))
+      }
+      val image = AwtImage(buf)
+      val pixels = image.pixels()
+      pixels.size shouldBe w * h
+      var i = 0
+      for (y in 0 until h) for (x in 0 until w) {
+         pixels[i].x shouldBe x
+         pixels[i].y shouldBe y
+         pixels[i].argb shouldBe (0xFF000000.toInt() or ((i and 0xFF) shl 16))
+         i++
+      }
+   }
 })


### PR DESCRIPTION
## Summary

- The `DataBufferInt` branches of `pixels()` (the hot path for `TYPE_INT_ARGB` / `TYPE_INT_RGB`) called `PixelTools.offsetToPoint(index, width)` inside the loop, allocating one `Point` per pixel just to derive `(x, y)`. For an N-pixel image that's N transient Point allocations on top of the N Pixel allocations.
- Replace with running `x`/`y` counters across nested `for` loops. Also fold the two int-buffer branches by selecting an alpha mask (`0` for ARGB, `0xFF000000` for RGB) once before the loop, instead of duplicating the body.
- The non-`DataBufferInt` fallback called `awt.getRGB(x, y)` per pixel — swap for a single bulk `getRGB(0, 0, w, h, ...)` and walk the resulting `int[]`.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (covers `TYPE_INT_ARGB`, `TYPE_INT_RGB`, and `TYPE_4BYTE_ABGR` paths via `AwtImageTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)