### PR TITLE
Skip Pixel intermediate when materialising AwtImage.colors()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -103,7 +103,12 @@ public class AwtImage {
     * Returns the colors of this image represented as an array of RGBColor.
     */
    public RGBColor[] colors() {
-      return Arrays.stream(pixels()).map(Pixel::toColor).toArray(RGBColor[]::new);
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      RGBColor[] colors = new RGBColor[argb.length];
+      for (int i = 0; i < argb.length; i++) {
+         colors[i] = RGBColor.fromARGBInt(argb[i]);
+      }
+      return colors;
    }
 
    /**


### PR DESCRIPTION
## Summary

- `colors()` previously called `pixels()` (allocating an N-element `Pixel[]`) and mapped each `Pixel` to an `RGBColor`, even though the `(x, y)` coordinates the `Pixel` carries are immediately discarded by `Pixel::toColor`. That doubles allocations: `N` Pixel + `N` RGBColor per call.
- Build the `RGBColor[]` directly from a single bulk `getRGB` `int[]` via `RGBColor.fromARGBInt`. Allocations drop to one int array plus the result `RGBColor[]`.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)