### PR TITLE
Fast-path StreamingGifWriter compressed-mode diff for DataBufferInt

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -12,6 +12,7 @@ import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferInt;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -138,9 +139,20 @@ public class StreamingGifWriter extends AbstractGifWriter {
                ImmutableImage work = image.copy();
                DataBuffer workBuffer = work.awt().getRaster().getDataBuffer();
                DataBuffer lastBuffer = last.awt().getRaster().getDataBuffer();
-               for (int i = 0; i < workBuffer.getSize(); i++) {
-                  if (workBuffer.getElem(i) == lastBuffer.getElem(i)) {
-                     workBuffer.setElem(i, 0);
+               if (workBuffer instanceof DataBufferInt && lastBuffer instanceof DataBufferInt) {
+                  int[] workData = ((DataBufferInt) workBuffer).getData();
+                  int[] lastData = ((DataBufferInt) lastBuffer).getData();
+                  int n = Math.min(workData.length, lastData.length);
+                  for (int i = 0; i < n; i++) {
+                     if (workData[i] == lastData[i]) {
+                        workData[i] = 0;
+                     }
+                  }
+               } else {
+                  for (int i = 0; i < workBuffer.getSize(); i++) {
+                     if (workBuffer.getElem(i) == lastBuffer.getElem(i)) {
+                        workBuffer.setElem(i, 0);
+                     }
                   }
                }
                last = image.copy();

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
@@ -52,6 +52,37 @@ class StreamingGifWriterTest : WordSpec({
          bytes shouldBe IOUtils.toByteArray(javaClass.getResourceAsStream("/gif/fallingroof_scaled.gif"))
       }
 
+      "compressed-mode write of DataBufferInt frames round-trips through reader" {
+         // Hits the new DataBufferInt fast path: two TYPE_INT_ARGB frames
+         // differing on a single pixel. The first frame is written verbatim;
+         // the second has matching pixels zeroed before being encoded with
+         // the GIF transparency mechanism. Decoding back must reconstruct
+         // both frames at the original dimensions.
+         val w = 8; val h = 8
+         val frame1 = ImmutableImage.create(w, h, BufferedImage.TYPE_INT_ARGB)
+         val frame2 = ImmutableImage.create(w, h, BufferedImage.TYPE_INT_ARGB)
+         for (y in 0 until h) for (x in 0 until w) {
+            val color = RGBColor(x * 30, y * 30, 128, 255)
+            frame1.setColor(x, y, color)
+            frame2.setColor(x, y, color)
+         }
+         frame2.setColor(3, 3, RGBColor(255, 0, 0, 255))
+
+         val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(frame1)
+         stream.writeFrame(frame2)
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 2
+         decoded.getFrame(0).width shouldBe w
+         decoded.getFrame(0).height shouldBe h
+         decoded.getFrame(1).width shouldBe w
+         decoded.getFrame(1).height shouldBe h
+      }
+
       "not mutate caller's ImmutableImage in compressed mode" {
          // Two 8x8 images where most pixels match, so the compressed diff path
          // will attempt to zero-fill matching cells.


### PR DESCRIPTION
## Summary

- When `compressed` is enabled, every pixel of every frame went through `DataBuffer.getElem(i)` and (if matched) `setElem(i, 0)` — virtual dispatch on the `DataBuffer` subclass plus an internal bounds check per call.
- The common case (any `ImmutableImage` with `TYPE_INT_ARGB` / `TYPE_INT_RGB`) is a `DataBufferInt`; in that case we can operate on the underlying `int[]` directly.
- Keep the `getElem`/`setElem` path as a fallback for non-int buffers so any custom GIF frame still works.

## Test plan

- [x] `./gradlew :scrimage-tests:test` passes (covers the compressed-mode path through `StreamingGifWriter` regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)