### PR TITLE
Short-circuit AwtImage.exists/forAll/count(Predicate)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -293,7 +293,14 @@ public class AwtImage {
     * @return true if p holds for at least one pixel
     */
    public boolean exists(Predicate<Pixel> p) {
-      return Arrays.stream(pixels()).anyMatch(p);
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            if (p.test(new Pixel(x, y, argb[i++]))) return true;
+         }
+      }
+      return false;
    }
 
    /**
@@ -446,7 +453,15 @@ public class AwtImage {
     * @return the number of pixels that evaluated true
     */
    public long count(Predicate<Pixel> p) {
-      return Arrays.stream(pixels()).filter(p).count();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      long n = 0;
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            if (p.test(new Pixel(x, y, argb[i++]))) n++;
+         }
+      }
+      return n;
    }
 
    /**
@@ -538,7 +553,14 @@ public class AwtImage {
     * Returns true if the given predicate holds for all pixels in the image.
     */
    public boolean forAll(Predicate<Pixel> predicate) {
-      return Arrays.stream(pixels()).allMatch(predicate);
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int i = 0;
+      for (int y = 0; y < height; y++) {
+         for (int x = 0; x < width; x++) {
+            if (!predicate.test(new Pixel(x, y, argb[i++]))) return false;
+         }
+      }
+      return true;
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -112,4 +112,51 @@ class AwtImageTest : FunSpec({
       pixels[3].x shouldBe 1; pixels[3].y shouldBe 1
       pixels[3].argb shouldBe 0xFFFFFFFF.toInt()
    }
+
+   // Regression tests for the short-circuiting predicate methods (exists,
+   // forAll, count). Verifies both correctness and that the predicate
+   // short-circuits — i.e. exists() stops calling the predicate after the
+   // first match, and forAll() stops after the first non-match.
+   test("exists() returns true and short-circuits at first match") {
+      val pixels = Array(100) { i -> Pixel(i % 10, i / 10, if (i == 3) 0xFFFF0000.toInt() else 0xFF000000.toInt()) }
+      val image = ImmutableImage.create(10, 10, pixels)
+      var calls = 0
+      val matched = image.exists { p ->
+         calls++
+         p.red() == 255
+      }
+      matched shouldBe true
+      calls shouldBe 4 // pixels 0..3 examined, then short-circuit
+   }
+
+   test("exists() returns false when no pixel matches") {
+      val pixels = Array(4) { i -> Pixel(i % 2, i / 2, 0xFF000000.toInt()) }
+      val image = ImmutableImage.create(2, 2, pixels)
+      image.exists { p -> p.red() == 255 } shouldBe false
+   }
+
+   test("forAll() returns false and short-circuits at first non-match") {
+      val pixels = Array(100) { i -> Pixel(i % 10, i / 10, if (i == 5) 0xFF000000.toInt() else 0xFFFF0000.toInt()) }
+      val image = ImmutableImage.create(10, 10, pixels)
+      var calls = 0
+      val all = image.forAll { p ->
+         calls++
+         p.red() == 255
+      }
+      all shouldBe false
+      calls shouldBe 6 // pixels 0..5 examined, then short-circuit
+   }
+
+   test("forAll() returns true when every pixel matches") {
+      val pixels = Array(4) { i -> Pixel(i % 2, i / 2, 0xFFFF0000.toInt()) }
+      val image = ImmutableImage.create(2, 2, pixels)
+      image.forAll { p -> p.red() == 255 } shouldBe true
+   }
+
+   test("count(Predicate) returns the number of matching pixels") {
+      val pixels = Array(10) { i -> Pixel(i, 0, if (i % 3 == 0) 0xFFFF0000.toInt() else 0xFF000000.toInt()) }
+      val image = ImmutableImage.create(10, 1, pixels)
+      // matches at i=0,3,6,9 → 4 pixels
+      image.count { p -> p.red() == 255 } shouldBe 4L
+   }
 })


### PR DESCRIPTION
## Summary
- `exists`, `forAll`, and `count(Predicate)` went through `Arrays.stream(pixels()).anyMatch/allMatch/filter`. `pixels()` materialises the entire `Pixel[]` up front, so even though the stream short-circuits on consumption, the array allocation has already happened — `exists()` on a 4000×4000 image always allocated 16M `Pixel` objects even if the first pixel matched.
- Replace with a single bulk `getRGB` into an `int[]` and a manual loop that allocates `Pixel` objects lazily, one per predicate call. `exists()` and `forAll()` now genuinely short-circuit; `count()` skips the `Pixel[]` + `Stream` pipeline overhead.

## Test plan
- [x] `./gradlew :scrimage-tests:test`