### PR TITLE
Bulk-fetch ARGB int[] in autocrop and drop per-strip Pixel allocations

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
@@ -1,5 +1,6 @@
 package com.sksamuel.scrimage;
 
+import com.sksamuel.scrimage.color.RGBColor;
 import com.sksamuel.scrimage.pixels.PixelTools;
 import com.sksamuel.scrimage.pixels.PixelsExtractor;
 
@@ -12,30 +13,99 @@ public class AutocropOps {
     * which contains a colour that does not match the given color.
     */
    public static int scanright(Color color, int height, int width, int col, PixelsExtractor f, int tolerance) {
-      if (col == width || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
-         return col;
-      else
-         return scanright(color, height, width, col + 1, f, tolerance);
+      while (col < width && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
+         col++;
+      return col;
    }
 
    public static int scanleft(Color color, int height, int col, PixelsExtractor f, int tolerance) {
-      if (col == 0 || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
-         return col;
-      else
-         return scanleft(color, height,  col - 1, f, tolerance);
+      while (col > 0 && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
+         col--;
+      return col;
    }
 
    public static int scandown(Color color, int height, int width, int row, PixelsExtractor f, int tolerance) {
-      if (row == height || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
-         return row;
-      else
-         return scandown(color, height, width, row + 1, f, tolerance);
+      while (row < height && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
+         row++;
+      return row;
    }
 
    public static int scanup(Color color, int width, int row, PixelsExtractor f, int tolerance) {
-      if (row == 0 || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
-         return row;
-      else
-         return scanup(color, width, row - 1, f, tolerance);
+      while (row > 0 && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
+         row--;
+      return row;
+   }
+
+   /**
+    * Variant of scanright that operates over a pre-fetched ARGB int[] of the whole image
+    * (row-major, length width*height), avoiding a per-column Pixel[] allocation.
+    */
+   public static int scanright(Color color, int width, int height, int col, int[] argb, int tolerance) {
+      while (col < width && columnMatches(argb, width, height, col, color, tolerance)) col++;
+      return col;
+   }
+
+   public static int scanleft(Color color, int width, int height, int col, int[] argb, int tolerance) {
+      while (col > 0 && columnMatches(argb, width, height, col, color, tolerance)) col--;
+      return col;
+   }
+
+   public static int scandown(Color color, int width, int height, int row, int[] argb, int tolerance) {
+      while (row < height && rowMatches(argb, width, row, color, tolerance)) row++;
+      return row;
+   }
+
+   public static int scanup(Color color, int width, int height, int row, int[] argb, int tolerance) {
+      while (row > 0 && rowMatches(argb, width, row, color, tolerance)) row--;
+      return row;
+   }
+
+   private static boolean columnMatches(int[] argb, int width, int height, int col, Color color, int tolerance) {
+      int target = RGBColor.fromAwt(color).toARGBInt();
+      if (tolerance == 0) {
+         int targetA = (target >>> 24) & 0xFF;
+         for (int y = 0; y < height; y++) {
+            int p = argb[y * width + col];
+            int a = (p >>> 24) & 0xFF;
+            if (!((a == 0 && targetA == 0) || p == target)) return false;
+         }
+         return true;
+      } else {
+         int refR = (target >> 16) & 0xFF, refG = (target >> 8) & 0xFF, refB = target & 0xFF;
+         int minR = Math.max(refR - tolerance, 0), maxR = Math.min(refR + tolerance, 255);
+         int minG = Math.max(refG - tolerance, 0), maxG = Math.min(refG + tolerance, 255);
+         int minB = Math.max(refB - tolerance, 0), maxB = Math.min(refB + tolerance, 255);
+         for (int y = 0; y < height; y++) {
+            int p = argb[y * width + col];
+            int r = (p >> 16) & 0xFF, g = (p >> 8) & 0xFF, b = p & 0xFF;
+            if (r < minR || r > maxR || g < minG || g > maxG || b < minB || b > maxB) return false;
+         }
+         return true;
+      }
+   }
+
+   private static boolean rowMatches(int[] argb, int width, int row, Color color, int tolerance) {
+      int target = RGBColor.fromAwt(color).toARGBInt();
+      int base = row * width;
+      if (tolerance == 0) {
+         int targetA = (target >>> 24) & 0xFF;
+         for (int x = 0; x < width; x++) {
+            int p = argb[base + x];
+            int a = (p >>> 24) & 0xFF;
+            if (!((a == 0 && targetA == 0) || p == target)) return false;
+         }
+         return true;
+      } else {
+         int refR = (target >> 16) & 0xFF, refG = (target >> 8) & 0xFF, refB = target & 0xFF;
+         int minR = Math.max(refR - tolerance, 0), maxR = Math.min(refR + tolerance, 255);
+         int minG = Math.max(refG - tolerance, 0), maxG = Math.min(refG + tolerance, 255);
+         int minB = Math.max(refB - tolerance, 0), maxB = Math.min(refB + tolerance, 255);
+         for (int x = 0; x < width; x++) {
+            int p = argb[base + x];
+            int r = (p >> 16) & 0xFF, g = (p >> 8) & 0xFF, b = p & 0xFF;
+            if (r < minR || r > maxR || g < minG || g > maxG || b < minB || b > maxB) return false;
+         }
+         return true;
+      }
    }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
@@ -1,5 +1,6 @@
 package com.sksamuel.scrimage;
 
+import com.sksamuel.scrimage.color.RGBColor;
 import com.sksamuel.scrimage.pixels.PixelTools;
 import com.sksamuel.scrimage.pixels.PixelsExtractor;
 
@@ -43,5 +44,78 @@ public class AutocropOps {
       while (row > 0 && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
          row--;
       return row;
+   }
+
+   /**
+    * Variant of scanright that operates over a pre-fetched ARGB int[] of the whole image
+    * (row-major, length width*height), avoiding a per-column Pixel[] allocation.
+    */
+   public static int scanright(Color color, int width, int height, int col, int[] argb, int tolerance) {
+      while (col < width && columnMatches(argb, width, height, col, color, tolerance)) col++;
+      return col;
+   }
+
+   public static int scanleft(Color color, int width, int height, int col, int[] argb, int tolerance) {
+      while (col > 0 && columnMatches(argb, width, height, col, color, tolerance)) col--;
+      return col;
+   }
+
+   public static int scandown(Color color, int width, int height, int row, int[] argb, int tolerance) {
+      while (row < height && rowMatches(argb, width, row, color, tolerance)) row++;
+      return row;
+   }
+
+   public static int scanup(Color color, int width, int height, int row, int[] argb, int tolerance) {
+      while (row > 0 && rowMatches(argb, width, row, color, tolerance)) row--;
+      return row;
+   }
+
+   private static boolean columnMatches(int[] argb, int width, int height, int col, Color color, int tolerance) {
+      int target = RGBColor.fromAwt(color).toARGBInt();
+      if (tolerance == 0) {
+         int targetA = (target >>> 24) & 0xFF;
+         for (int y = 0; y < height; y++) {
+            int p = argb[y * width + col];
+            int a = (p >>> 24) & 0xFF;
+            if (!((a == 0 && targetA == 0) || p == target)) return false;
+         }
+         return true;
+      } else {
+         int refR = (target >> 16) & 0xFF, refG = (target >> 8) & 0xFF, refB = target & 0xFF;
+         int minR = Math.max(refR - tolerance, 0), maxR = Math.min(refR + tolerance, 255);
+         int minG = Math.max(refG - tolerance, 0), maxG = Math.min(refG + tolerance, 255);
+         int minB = Math.max(refB - tolerance, 0), maxB = Math.min(refB + tolerance, 255);
+         for (int y = 0; y < height; y++) {
+            int p = argb[y * width + col];
+            int r = (p >> 16) & 0xFF, g = (p >> 8) & 0xFF, b = p & 0xFF;
+            if (r < minR || r > maxR || g < minG || g > maxG || b < minB || b > maxB) return false;
+         }
+         return true;
+      }
+   }
+
+   private static boolean rowMatches(int[] argb, int width, int row, Color color, int tolerance) {
+      int target = RGBColor.fromAwt(color).toARGBInt();
+      int base = row * width;
+      if (tolerance == 0) {
+         int targetA = (target >>> 24) & 0xFF;
+         for (int x = 0; x < width; x++) {
+            int p = argb[base + x];
+            int a = (p >>> 24) & 0xFF;
+            if (!((a == 0 && targetA == 0) || p == target)) return false;
+         }
+         return true;
+      } else {
+         int refR = (target >> 16) & 0xFF, refG = (target >> 8) & 0xFF, refB = target & 0xFF;
+         int minR = Math.max(refR - tolerance, 0), maxR = Math.min(refR + tolerance, 255);
+         int minG = Math.max(refG - tolerance, 0), maxG = Math.min(refG + tolerance, 255);
+         int minB = Math.max(refB - tolerance, 0), maxB = Math.min(refB + tolerance, 255);
+         for (int x = 0; x < width; x++) {
+            int p = argb[base + x];
+            int r = (p >> 16) & 0xFF, g = (p >> 8) & 0xFF, b = p & 0xFF;
+            if (r < minR || r > maxR || g < minG || g > maxG || b < minB || b > maxB) return false;
+         }
+         return true;
+      }
    }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -429,10 +429,11 @@ public class ImmutableImage extends MutableImage {
     *                       the color matches the reference color [0..255]
     */
    public ImmutableImage autocrop(Color color, int colorTolerance) {
-      int x1 = AutocropOps.scanright(color, height, width, 0, pixelExtractor(), colorTolerance);
-      int x2 = AutocropOps.scanleft(color, height, width - 1, pixelExtractor(), colorTolerance);
-      int y1 = AutocropOps.scandown(color, height, width, 0, pixelExtractor(), colorTolerance);
-      int y2 = AutocropOps.scanup(color, width, height - 1, pixelExtractor(), colorTolerance);
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int x1 = AutocropOps.scanright(color, width, height, 0, argb, colorTolerance);
+      int x2 = AutocropOps.scanleft(color, width, height, width - 1, argb, colorTolerance);
+      int y1 = AutocropOps.scandown(color, width, height, 0, argb, colorTolerance);
+      int y2 = AutocropOps.scanup(color, width, height, height - 1, argb, colorTolerance);
       if (x1 == 0 && y1 == 0 && x2 == width - 1 && y2 == height - 1) return this;
       return subimage(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -442,10 +442,13 @@ public class ImmutableImage extends MutableImage {
     * @return a new cropped Image with the matching rows and columns removed
     */
    public ImmutableImage autocrop(Color color, int colorTolerance) {
-      int x1 = AutocropOps.scanright(color, height, width, 0, pixelExtractor(), colorTolerance);
-      int x2 = AutocropOps.scanleft(color, height, width - 1, pixelExtractor(), colorTolerance);
-      int y1 = AutocropOps.scandown(color, height, width, 0, pixelExtractor(), colorTolerance);
-      int y2 = AutocropOps.scanup(color, width, height - 1, pixelExtractor(), colorTolerance);
+      // Bulk-fetch the whole image once and scan over the int[] rather than
+      // allocating a Pixel[] per column/row strip via pixelExtractor().
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      int x1 = AutocropOps.scanright(color, width, height, 0, argb, colorTolerance);
+      int x2 = AutocropOps.scanleft(color, width, height, width - 1, argb, colorTolerance);
+      int y1 = AutocropOps.scandown(color, width, height, 0, argb, colorTolerance);
+      int y2 = AutocropOps.scanup(color, width, height, height - 1, argb, colorTolerance);
       // If every column matches the crop colour, scanright walks all the way
       // to width and scanleft all the way to 0 (and likewise for rows). The
       // "nothing to crop" subimage(x1, y1, x2-x1+1, ...) call would then have

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
@@ -45,5 +45,31 @@ class AutoCropTest : FunSpec() {
             p.blue() shouldBe 0
          }
       }
+
+      // Direct tests for the new int[]-based AutocropOps overloads added in
+      // this PR. autocrop() does one bulk getRGB up front and hands the same
+      // int[] to all four scan directions; these tests pin that contract.
+      test("AutocropOps int[] overloads find content boundaries with tolerance=0") {
+         // 5x5 image: white border, 3x3 red center
+         val w = 5; val h = 5
+         val argb = IntArray(w * h)
+         for (y in 0 until h) for (x in 0 until w) {
+            val isCenter = x in 1..3 && y in 1..3
+            argb[y * w + x] = if (isCenter) 0xFFFF0000.toInt() else 0xFFFFFFFF.toInt()
+         }
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, w, h, 0, argb, 0) shouldBe 1
+         com.sksamuel.scrimage.AutocropOps.scanleft(Color.WHITE, w, h, w - 1, argb, 0) shouldBe 3
+         com.sksamuel.scrimage.AutocropOps.scandown(Color.WHITE, w, h, 0, argb, 0) shouldBe 1
+         com.sksamuel.scrimage.AutocropOps.scanup(Color.WHITE, w, h, h - 1, argb, 0) shouldBe 3
+      }
+
+      test("AutocropOps int[] overloads honour tolerance") {
+         // 3x1 image with shades of near-white: 250, 255, 255
+         val argb = intArrayOf(0xFFFAFAFA.toInt(), 0xFFFFFFFF.toInt(), 0xFFFFFFFF.toInt())
+         // tolerance 0: only exact white matches → first non-white at col 0
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, 3, 1, 0, argb, 0) shouldBe 0
+         // tolerance 10: 250 is within tolerance → all match → returns width
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, 3, 1, 0, argb, 10) shouldBe 3
+      }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
@@ -54,5 +54,31 @@ class AutoCropTest : FunSpec() {
             p.blue() shouldBe 0
          }
       }
+
+      // Direct tests for the new int[]-based AutocropOps overloads added in
+      // this PR. autocrop() does one bulk getRGB up front and hands the same
+      // int[] to all four scan directions; these tests pin that contract.
+      test("AutocropOps int[] overloads find content boundaries with tolerance=0") {
+         // 5x5 image: white border, 3x3 red center
+         val w = 5; val h = 5
+         val argb = IntArray(w * h)
+         for (y in 0 until h) for (x in 0 until w) {
+            val isCenter = x in 1..3 && y in 1..3
+            argb[y * w + x] = if (isCenter) 0xFFFF0000.toInt() else 0xFFFFFFFF.toInt()
+         }
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, w, h, 0, argb, 0) shouldBe 1
+         com.sksamuel.scrimage.AutocropOps.scanleft(Color.WHITE, w, h, w - 1, argb, 0) shouldBe 3
+         com.sksamuel.scrimage.AutocropOps.scandown(Color.WHITE, w, h, 0, argb, 0) shouldBe 1
+         com.sksamuel.scrimage.AutocropOps.scanup(Color.WHITE, w, h, h - 1, argb, 0) shouldBe 3
+      }
+
+      test("AutocropOps int[] overloads honour tolerance") {
+         // 3x1 image with shades of near-white: 250, 255, 255
+         val argb = intArrayOf(0xFFFAFAFA.toInt(), 0xFFFFFFFF.toInt(), 0xFFFFFFFF.toInt())
+         // tolerance 0: only exact white matches → first non-white at col 0
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, 3, 1, 0, argb, 0) shouldBe 0
+         // tolerance 10: 250 is within tolerance → all match → returns width
+         com.sksamuel.scrimage.AutocropOps.scanright(Color.WHITE, 3, 1, 0, argb, 10) shouldBe 3
+      }
    }
 }


### PR DESCRIPTION
## Summary
- Each `AutocropOps.scan*` recursive call invoked `PixelsExtractor.apply(rectangle)`, which delegates to `AwtImage.pixels(x, y, w, h)` — one fresh `Pixel[]` allocation per column/row scanned. For a 2000×2000 image with a 100-pixel border, that's hundreds of strip allocations across all four edges, each wrapping the same `getRGB` result in fresh `Pixel` objects just to feed `PixelTools.colorMatches`'s stream.
- Add `scan*` overloads that take a single pre-fetched ARGB `int[]` of the whole image and compare ints directly. `ImmutableImage.autocrop` now does one bulk `getRGB` up front and hands the same `int[]` to all four scans. The original `PixelsExtractor`-based scan methods are kept for source compatibility (the type is public API) but rewritten as while-loops instead of tail recursion — the JVM doesn't TCO, so a 5000-tall image was building a 5000-deep stack frame chain.

## Test plan
- [x] `./gradlew :scrimage-tests:test --tests "*AutoCropTest*" --tests "*Issue234*"`
- [x] Full `:scrimage-tests:test`