### PR TITLE
Write ARGB ints directly in ImmutableImage.create(int, int, Pixel[], int)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -359,7 +359,11 @@ public class ImmutableImage extends MutableImage {
    public static ImmutableImage create(int w, int h, Pixel[] pixels, int type) {
       assert w * h == pixels.length;
       ImmutableImage image = ImmutableImage.create(w, h, type);
-      image.mapInPlace((pixel) -> pixels[PixelTools.coordsToOffset(pixel.x, pixel.y, w)].toColor().awt());
+      int[] argb = new int[pixels.length];
+      for (int i = 0; i < pixels.length; i++) {
+         argb[i] = pixels[i].toARGBInt();
+      }
+      image.awt().setRGB(0, 0, w, h, argb, 0, w);
       return image;
    }
 


### PR DESCRIPTION
## Summary
- `create(w, h, Pixel[], type)` routed through `MutableImage.mapInPlace` with a `Function<Pixel, Color>` lambda that called `pixels[offset].toColor().awt()` per pixel — allocating an `RGBColor` and a `java.awt.Color` for every pixel, just to hand back to `mapInPlace`, which then re-encodes to a packed ARGB int before writing.
- `mapInPlace` also begins with a bulk `getRGB` of the freshly-zeroed target buffer — wasted work since we are about to overwrite every pixel anyway.
- Pack each pixel's ARGB int directly into a single `int[]` and bulk `setRGB` once. Same row-major layout, no per-pixel object allocation, no read of the source buffer.

## Test plan
- [x] `./gradlew :scrimage-tests:test`