### PR TITLE
Hand-code Pixel.hashCode and RGBColor.hashCode to avoid varargs boxing

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -2,8 +2,6 @@ package com.sksamuel.scrimage.color;
 
 import com.sksamuel.scrimage.pixels.PixelTools;
 
-import java.util.Objects;
-
 /**
  * Red/Green/Blue
  * <p>
@@ -200,7 +198,11 @@ public class RGBColor implements Color {
 
    @Override
    public int hashCode() {
-      return Objects.hash(red, green, blue, alpha);
+      int result = red;
+      result = 31 * result + green;
+      result = 31 * result + blue;
+      result = 31 * result + alpha;
+      return result;
    }
 
    @Override

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
@@ -3,7 +3,6 @@ package com.sksamuel.scrimage.pixels;
 import com.sksamuel.scrimage.color.Grayscale;
 import com.sksamuel.scrimage.color.RGBColor;
 
-import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -157,7 +156,10 @@ public class Pixel {
 
    @Override
    public int hashCode() {
-      return Objects.hash(argb, x, y);
+      int result = argb;
+      result = 31 * result + x;
+      result = 31 * result + y;
+      return result;
    }
 
    @Override

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PixelHashCodeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PixelHashCodeTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins down the hashCode contract for Pixel after the hand-coded
+ * hashCode replaced Objects.hash(varargs...) to avoid per-call
+ * Integer[] allocation.
+ */
+class PixelHashCodeTest : StringSpec({
+
+   "hashCode is consistent with equals" {
+      val a = Pixel(3, 4, 0xFF112233.toInt())
+      val b = Pixel(3, 4, 0xFF112233.toInt())
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "hashCode distinguishes pixels that differ in any field" {
+      val base = Pixel(3, 4, 0xFF112233.toInt())
+      val differArgb = Pixel(3, 4, 0xFF112234.toInt())
+      val differX = Pixel(2, 4, 0xFF112233.toInt())
+      val differY = Pixel(3, 5, 0xFF112233.toInt())
+      val all = setOf(base.hashCode(), differArgb.hashCode(), differX.hashCode(), differY.hashCode())
+      all.size shouldBe 4
+   }
+
+   "hashCode is stable across repeated calls" {
+      val p = Pixel(7, 8, 0xCAFEBABE.toInt())
+      val h = p.hashCode()
+      p.hashCode() shouldBe h
+      p.hashCode() shouldBe h
+   }
+})

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/RGBColorTest.kt
@@ -91,4 +91,33 @@ class RGBColorTest : StringSpec({
       val paint = opaque.paint() as java.awt.Color
       paint.alpha shouldBe 255
    }
+
+   // hashCode contract: equal objects must produce equal hash codes.
+   // The optimised hand-coded hashCode replaces Objects.hash(varargs...)
+   // to avoid per-call Integer[] allocation; the contract must still hold.
+   "hashCode is consistent with equals" {
+      val a = RGBColor(10, 20, 30, 40)
+      val b = RGBColor(10, 20, 30, 40)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "hashCode distinguishes colors that differ in any channel" {
+      val base = RGBColor(10, 20, 30, 40)
+      // Not a strict requirement of the contract, but the 31*hash+field
+      // pattern over four small ints does produce distinct values here.
+      val differR = RGBColor(11, 20, 30, 40)
+      val differG = RGBColor(10, 21, 30, 40)
+      val differB = RGBColor(10, 20, 31, 40)
+      val differA = RGBColor(10, 20, 30, 41)
+      val all = setOf(base.hashCode(), differR.hashCode(), differG.hashCode(), differB.hashCode(), differA.hashCode())
+      all.size shouldBe 5
+   }
+
+   "hashCode is stable across repeated calls" {
+      val c = RGBColor(123, 45, 67, 89)
+      val h = c.hashCode()
+      c.hashCode() shouldBe h
+      c.hashCode() shouldBe h
+   }
 })


### PR DESCRIPTION
## Summary
- `Objects.hash(int...)` takes int varargs, so each call allocates a fresh `Integer[]` (each element auto-boxed to `Integer`) on every invocation.
- `Pixel` and `RGBColor` are the two types that show up as `HashMap`/`HashSet` keys on hot pixel-iteration paths — most prominently `AwtImage.colours()` which collects an `RGBColor` per pixel into a `Set`.
- Replace with the standard `31 * hash + field` pattern over the raw int fields. Same hash distribution quality, no per-call allocation. Other Color subclasses (CMYK, HSL, HSV, Grayscale) keep their `Objects.hash` bodies — they aren't on the per-pixel allocation path.

## Test plan
- [x] `./gradlew :scrimage-tests:test`