### PR TITLE
Drop per-pixel Pixel allocation in replaceTransparency/contrast

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -48,13 +48,8 @@ public class MutableImage extends AwtImage {
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color);
-            argb[i] = withoutTrans.toARGBInt();
-            i++;
-         }
+      for (int i = 0; i < argb.length; i++) {
+         argb[i] = PixelTools.replaceTransparencyWithColor(argb[i], color);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }
@@ -112,16 +107,16 @@ public class MutableImage extends AwtImage {
 
    public void contrastInPlace(double factor) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel pixel = new Pixel(x, y, argb[i]);
-            int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
-            int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
-            int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
-            argb[i] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();
-            i++;
-         }
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int alpha = (p >>> 24) & 0xFF;
+         int red = (p >> 16) & 0xFF;
+         int green = (p >> 8) & 0xFF;
+         int blue = p & 0xFF;
+         int r = PixelTools.truncate(factor * (red - 128) + 128);
+         int g = PixelTools.truncate(factor * (green - 128) + 128);
+         int b = PixelTools.truncate(factor * (blue - 128) + 128);
+         argb[i] = PixelTools.argb(alpha, r, g, b);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -48,13 +48,8 @@ public class MutableImage extends AwtImage {
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color);
-            argb[i] = withoutTrans.toARGBInt();
-            i++;
-         }
+      for (int i = 0; i < argb.length; i++) {
+         argb[i] = PixelTools.replaceTransparencyWithColor(argb[i], color);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }
@@ -119,16 +114,16 @@ public class MutableImage extends AwtImage {
 
    public void contrastInPlace(double factor) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel pixel = new Pixel(x, y, argb[i]);
-            int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
-            int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
-            int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
-            argb[i] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();
-            i++;
-         }
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int alpha = (p >>> 24) & 0xFF;
+         int red = (p >> 16) & 0xFF;
+         int green = (p >> 8) & 0xFF;
+         int blue = p & 0xFF;
+         int r = PixelTools.truncate(factor * (red - 128) + 128);
+         int g = PixelTools.truncate(factor * (green - 128) + 128);
+         int b = PixelTools.truncate(factor * (blue - 128) + 128);
+         argb[i] = PixelTools.argb(alpha, r, g, b);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -78,6 +78,16 @@ public class PixelTools {
    }
 
    /**
+    * Primitive-double variant of {@link #truncate(Double)} that avoids autoboxing
+    * when called in tight per-pixel loops.
+    */
+   public static int truncate(double value) {
+      if (value < 0) return 0;
+      else if (value > 255) return 255;
+      else return (int) value;
+   }
+
+   /**
     * Returns true if all pixels in the array have the same color, or both are fully transparent.
     */
    public static boolean uniform(Color color, Pixel[] pixels) {
@@ -156,5 +166,21 @@ public class PixelTools {
       int g = (p.green() * p.alpha() + color.getGreen() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
       int b = (p.blue() * p.alpha() + color.getBlue() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
       return new Pixel(p.x, p.y, r, g, b, 255);
+   }
+
+   /**
+    * Same arithmetic as {@link #replaceTransparencyWithColor(Pixel, Color)} but on a packed
+    * ARGB int rather than a Pixel. Returns the resulting packed ARGB int.
+    */
+   public static int replaceTransparencyWithColor(int srcArgb, Color color) {
+      int sa = (srcArgb >>> 24) & 0xFF;
+      int sr = (srcArgb >> 16) & 0xFF;
+      int sg = (srcArgb >> 8) & 0xFF;
+      int sb = srcArgb & 0xFF;
+      int cr = color.getRed(), cg = color.getGreen(), cb = color.getBlue(), ca = color.getAlpha();
+      int r = (sr * sa + cr * ca * (255 - sa) / 255) / 255;
+      int g = (sg * sa + cg * ca * (255 - sa) / 255) / 255;
+      int b = (sb * sa + cb * ca * (255 - sa) / 255) / 255;
+      return argb(255, r, g, b);
    }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -77,6 +77,16 @@ public class PixelTools {
    }
 
    /**
+    * Primitive-double variant of {@link #truncate(Double)} that avoids autoboxing
+    * when called in tight per-pixel loops.
+    */
+   public static int truncate(double value) {
+      if (value < 0) return 0;
+      else if (value > 255) return 255;
+      else return (int) value;
+   }
+
+   /**
     * Returns true if all pixels in the array have the same color, or both are fully transparent.
     */
    public static boolean uniform(Color color, Pixel[] pixels) {
@@ -169,5 +179,21 @@ public class PixelTools {
       int g = (p.green() * p.alpha() + color.getGreen() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
       int b = (p.blue() * p.alpha() + color.getBlue() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
       return new Pixel(p.x, p.y, r, g, b, 255);
+   }
+
+   /**
+    * Same arithmetic as {@link #replaceTransparencyWithColor(Pixel, Color)} but on a packed
+    * ARGB int rather than a Pixel. Returns the resulting packed ARGB int.
+    */
+   public static int replaceTransparencyWithColor(int srcArgb, Color color) {
+      int sa = (srcArgb >>> 24) & 0xFF;
+      int sr = (srcArgb >> 16) & 0xFF;
+      int sg = (srcArgb >> 8) & 0xFF;
+      int sb = srcArgb & 0xFF;
+      int cr = color.getRed(), cg = color.getGreen(), cb = color.getBlue(), ca = color.getAlpha();
+      int r = (sr * sa + cr * ca * (255 - sa) / 255) / 255;
+      int g = (sg * sa + cg * ca * (255 - sa) / 255) / 255;
+      int b = (sb * sa + cb * ca * (255 - sa) / 255) / 255;
+      return argb(255, r, g, b);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -85,4 +85,27 @@ class PixelToolsTest : FunSpec({
       PixelTools.approx(ref, 10, arrayOf(pixel)) shouldBe false
    }
 
+   // Test the new int overload of replaceTransparencyWithColor against the
+   // existing Pixel-based version to confirm bit-identical output.
+   test("replaceTransparencyWithColor int overload matches Pixel overload") {
+      val bg = Color(255, 200, 100, 255)
+      val cases = listOf(
+         Pixel(0, 0, 0, 0, 0, 0),         // fully transparent
+         Pixel(0, 0, 100, 50, 25, 128),   // semi-transparent
+         Pixel(0, 0, 200, 100, 50, 255),  // fully opaque
+         Pixel(0, 0, 1, 2, 3, 5)          // low values
+      )
+      cases.forEach { p ->
+         val viaPixel = PixelTools.replaceTransparencyWithColor(p, bg).toARGBInt()
+         val viaInt = PixelTools.replaceTransparencyWithColor(p.argb, bg)
+         viaInt shouldBe viaPixel
+      }
+   }
+
+   // The new primitive-double truncate overload must agree with the boxed
+   // Double overload at all classification boundaries.
+   test("truncate(double) matches truncate(Double)") {
+      val cases = listOf(-100.5, -0.5, 0.0, 0.4, 127.7, 254.9, 255.0, 256.7, 999.0)
+      cases.forEach { v -> PixelTools.truncate(v) shouldBe PixelTools.truncate(v as Double?) }
+   }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -114,4 +114,27 @@ class PixelToolsTest : FunSpec({
       PixelTools.blue(scaled) shouldBe 67
    }
 
+   // Test the new int overload of replaceTransparencyWithColor against the
+   // existing Pixel-based version to confirm bit-identical output.
+   test("replaceTransparencyWithColor int overload matches Pixel overload") {
+      val bg = Color(255, 200, 100, 255)
+      val cases = listOf(
+         Pixel(0, 0, 0, 0, 0, 0),         // fully transparent
+         Pixel(0, 0, 100, 50, 25, 128),   // semi-transparent
+         Pixel(0, 0, 200, 100, 50, 255),  // fully opaque
+         Pixel(0, 0, 1, 2, 3, 5)          // low values
+      )
+      cases.forEach { p ->
+         val viaPixel = PixelTools.replaceTransparencyWithColor(p, bg).toARGBInt()
+         val viaInt = PixelTools.replaceTransparencyWithColor(p.argb, bg)
+         viaInt shouldBe viaPixel
+      }
+   }
+
+   // The new primitive-double truncate overload must agree with the boxed
+   // Double overload at all classification boundaries.
+   test("truncate(double) matches truncate(Double)") {
+      val cases = listOf(-100.5, -0.5, 0.0, 0.4, 127.7, 254.9, 255.0, 256.7, 999.0)
+      cases.forEach { v -> PixelTools.truncate(v) shouldBe PixelTools.truncate(v as Double?) }
+   }
 })


### PR DESCRIPTION
## Summary
After the bulk get/setRGB rewrite landed (#385/#386), both methods still allocated a fresh `Pixel(x, y, argb[i])` per iteration just to call `.red()/.green()/.blue()/.alpha()` on it — pure bit-unpacking that `PixelTools` static methods already provide on the int directly. The result was then re-packed into another `Pixel(x, y, r, g, b, a)` just to call `.toARGBInt()` to write back. So a 4kx4k image was creating ~32M short-lived `Pixel` objects per call.

- Add an int-overload of `PixelTools.replaceTransparencyWithColor` (same arithmetic, packed-ARGB int in/out) and use it from `MutableImage.replaceTransparencyInPlace`.
- For `contrastInPlace`: inline the bit unpacks and use `PixelTools.argb` to re-pack.
- Add a primitive-double overload of `PixelTools.truncate` so the contrast formula no longer autoboxes a `Double` per channel per pixel — the existing `Double`-typed overload was being invoked with a primitive `double`, forcing autoboxing on every call.

## Test plan
- [x] \`./gradlew :scrimage-tests:test\`