### PR TITLE
Hand-code hashCode for Grayscale/CMYK/HSL/HSV to avoid varargs boxing

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
@@ -1,7 +1,5 @@
 package com.sksamuel.scrimage.color;
 
-import java.util.Objects;
-
 public class CMYKColor implements Color {
 
     public final float c;
@@ -53,6 +51,11 @@ public class CMYKColor implements Color {
 
     @Override
     public int hashCode() {
-        return Objects.hash(c, m, y, k, alpha);
+        int result = Float.floatToIntBits(c);
+        result = 31 * result + Float.floatToIntBits(m);
+        result = 31 * result + Float.floatToIntBits(y);
+        result = 31 * result + Float.floatToIntBits(k);
+        result = 31 * result + Float.floatToIntBits(alpha);
+        return result;
     }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
@@ -1,7 +1,5 @@
 package com.sksamuel.scrimage.color;
 
-import java.util.Objects;
-
 public class Grayscale implements Color {
 
     public final int gray;
@@ -31,6 +29,6 @@ public class Grayscale implements Color {
 
     @Override
     public int hashCode() {
-        return Objects.hash(gray, alpha);
+        return 31 * gray + alpha;
     }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
@@ -1,7 +1,5 @@
 package com.sksamuel.scrimage.color;
 
-import java.util.Objects;
-
 /**
  * Hue/Saturation/Lightness
  * <p>
@@ -86,6 +84,10 @@ public class HSLColor implements Color {
 
     @Override
     public int hashCode() {
-        return Objects.hash(hue, saturation, lightness, alpha);
+        int result = Float.floatToIntBits(hue);
+        result = 31 * result + Float.floatToIntBits(saturation);
+        result = 31 * result + Float.floatToIntBits(lightness);
+        result = 31 * result + Float.floatToIntBits(alpha);
+        return result;
     }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
@@ -1,7 +1,5 @@
 package com.sksamuel.scrimage.color;
 
-import java.util.Objects;
-
 /**
  * Hue/Saturation/Value
  * <p>
@@ -52,7 +50,11 @@ public class HSVColor implements Color {
 
    @Override
    public int hashCode() {
-      return Objects.hash(hue, saturation, value, alpha);
+      int result = Float.floatToIntBits(hue);
+      result = 31 * result + Float.floatToIntBits(saturation);
+      result = 31 * result + Float.floatToIntBits(value);
+      result = 31 * result + Float.floatToIntBits(alpha);
+      return result;
    }
 
    @Override

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorHashCodeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/ColorHashCodeTest.kt
@@ -1,0 +1,87 @@
+package com.sksamuel.scrimage.core.color
+
+import com.sksamuel.scrimage.color.CMYKColor
+import com.sksamuel.scrimage.color.Grayscale
+import com.sksamuel.scrimage.color.HSLColor
+import com.sksamuel.scrimage.color.HSVColor
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Pins down the hashCode contract for Grayscale/CMYK/HSL/HSV after the
+ * hand-coded hashCode replaced Objects.hash(varargs...) to avoid
+ * per-call Object[] allocation (with autoboxing of int and float fields).
+ */
+class ColorHashCodeTest : StringSpec({
+
+   "Grayscale hashCode is consistent with equals" {
+      val a = Grayscale(128, 200)
+      val b = Grayscale(128, 200)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "Grayscale hashCode distinguishes by gray and alpha" {
+      Grayscale(128, 200).hashCode() shouldNotBe Grayscale(129, 200).hashCode()
+      Grayscale(128, 200).hashCode() shouldNotBe Grayscale(128, 201).hashCode()
+   }
+
+   "CMYKColor hashCode is consistent with equals" {
+      val a = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f, 0.5f)
+      val b = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f, 0.5f)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "CMYKColor hashCode distinguishes by every channel" {
+      val base = CMYKColor(0.1f, 0.2f, 0.3f, 0.4f, 0.5f)
+      val all = setOf(
+         base.hashCode(),
+         CMYKColor(0.11f, 0.2f, 0.3f, 0.4f, 0.5f).hashCode(),
+         CMYKColor(0.1f, 0.21f, 0.3f, 0.4f, 0.5f).hashCode(),
+         CMYKColor(0.1f, 0.2f, 0.31f, 0.4f, 0.5f).hashCode(),
+         CMYKColor(0.1f, 0.2f, 0.3f, 0.41f, 0.5f).hashCode(),
+         CMYKColor(0.1f, 0.2f, 0.3f, 0.4f, 0.51f).hashCode()
+      )
+      all.size shouldBe 6
+   }
+
+   "HSLColor hashCode is consistent with equals" {
+      val a = HSLColor(180f, 0.5f, 0.5f, 1f)
+      val b = HSLColor(180f, 0.5f, 0.5f, 1f)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "HSLColor hashCode distinguishes by every channel" {
+      val base = HSLColor(180f, 0.5f, 0.5f, 1f)
+      val all = setOf(
+         base.hashCode(),
+         HSLColor(181f, 0.5f, 0.5f, 1f).hashCode(),
+         HSLColor(180f, 0.6f, 0.5f, 1f).hashCode(),
+         HSLColor(180f, 0.5f, 0.6f, 1f).hashCode(),
+         HSLColor(180f, 0.5f, 0.5f, 0.9f).hashCode()
+      )
+      all.size shouldBe 5
+   }
+
+   "HSVColor hashCode is consistent with equals" {
+      val a = HSVColor(180f, 0.5f, 0.5f, 1f)
+      val b = HSVColor(180f, 0.5f, 0.5f, 1f)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   "HSVColor hashCode distinguishes by every channel" {
+      val base = HSVColor(180f, 0.5f, 0.5f, 1f)
+      val all = setOf(
+         base.hashCode(),
+         HSVColor(181f, 0.5f, 0.5f, 1f).hashCode(),
+         HSVColor(180f, 0.6f, 0.5f, 1f).hashCode(),
+         HSVColor(180f, 0.5f, 0.6f, 1f).hashCode(),
+         HSVColor(180f, 0.5f, 0.5f, 0.9f).hashCode()
+      )
+      all.size shouldBe 5
+   }
+})


### PR DESCRIPTION
## Summary
Companion to #400 (Pixel/RGBColor hand-coded hashCode). Same `Objects.hash(varargs...)` issue: each call allocates a fresh boxed `Object[]` (each int auto-boxed to `Integer`, each float to `Float`).

Replace with the standard \`31 * hash + field\` pattern:
- \`Grayscale\` (two int fields): \`31 * gray + alpha\`
- \`CMYK / HSL / HSV\` (float fields): \`31 * hash + Float.floatToIntBits(field)\`

These types are less hot than RGBColor but the change is mechanical and keeps the convention uniform across all Color subclasses.

## Test plan
- [x] \`./gradlew :scrimage-tests:test\`