### PR TITLE
Compare AwtImage pixel buffers via Arrays.equals on bulk getRGB int[]s

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -495,23 +495,13 @@ public class AwtImage {
       return imageState().hashCode();
    }
 
-   private <T> boolean sameElements(Iterator<T> a, Iterator<T> b) {
-      boolean same = true;
-      while (a.hasNext()) {
-         if (!a.next().equals(b.next())) {
-            same = false;
-            break;
-         }
-      }
-      return same;
-   }
-
    public boolean equals(Object other) {
       if (other instanceof AwtImage) {
          AwtImage that = (AwtImage) other;
-         return this.width == that.width &&
-            this.height == that.height &&
-            sameElements(iterator(), ((AwtImage) other).iterator());
+         if (this.width != that.width || this.height != that.height) return false;
+         int[] a = this.awt().getRGB(0, 0, width, height, null, 0, width);
+         int[] b = that.awt().getRGB(0, 0, that.width, that.height, null, 0, that.width);
+         return Arrays.equals(a, b);
       }
       return false;
    }


### PR DESCRIPTION
## Summary
\`equals()\` walked both images via paired iterators (\`sameElements\` over \`iterator()\`/\`iterator()\`). Each \`.next()\` on each side allocates a new \`Pixel\`, then \`Pixel.equals\` does field comparisons. For a 4kx4k image that's ~32M Pixel allocations and ~16M equals calls per equality check.

Pull both images into \`int[]\` via a single bulk \`getRGB\` and call \`Arrays.equals(int[], int[])\` — JNI hits twice, the comparison is a tight intrinsic loop, no per-pixel object allocation. Iteration order is identical (row-major from 0,0 to w-1,h-1) so the (x, y) component of the old \`Pixel.equals\` comparison is implicit in array index.

## Test plan
- [x] \`./gradlew :scrimage-tests:test\`