### PR TITLE
Bulk-int rewrite of OpacityFilter, GrayscaleFilter, BlackThresholdFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BlackThresholdFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BlackThresholdFilter.java
@@ -1,7 +1,6 @@
 package com.sksamuel.scrimage.filter;
 
 import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.color.RGBColor;
 import thirdparty.jhlabs.image.PixelUtils;
 
 /**
@@ -19,14 +18,15 @@ public class BlackThresholdFilter implements Filter {
    @Override
    public void apply(ImmutableImage image) {
       int threshold = (int) ((255 * thresholdPercentage) / 100.0);
-
-      image.mapInPlace((p) -> {
-         int brightness = PixelUtils.brightness(p.argb);
-         if (brightness < threshold) {
-            return RGBColor.fromARGBInt(p.argb & 0xff000000).awt();
-         } else {
-            return p.toColor().awt();
+      int w = image.width;
+      int h = image.height;
+      int[] argb = image.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         if (PixelUtils.brightness(p) < threshold) {
+            argb[i] = p & 0xff000000;
          }
-      });
+      }
+      image.awt().setRGB(0, 0, w, h, argb, 0, w);
    }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
@@ -16,14 +16,22 @@
 package com.sksamuel.scrimage.filter;
 
 import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.color.RGBColor;
 
 public class GrayscaleFilter implements Filter {
 
    public void apply(ImmutableImage image) {
-      image.mapInPlace((p) -> {
-         int gray = (int) Math.round(0.2126 * p.red() + 0.7152 * p.green() + 0.0722 * p.blue());
-         return new RGBColor(gray, gray, gray, p.alpha()).awt();
-      });
+      int w = image.width;
+      int h = image.height;
+      int[] argb = image.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int a = (p >>> 24) & 0xFF;
+         int r = (p >> 16) & 0xFF;
+         int g = (p >> 8) & 0xFF;
+         int b = p & 0xFF;
+         int gray = (int) Math.round(0.2126 * r + 0.7152 * g + 0.0722 * b);
+         argb[i] = (a << 24) | (gray << 16) | (gray << 8) | gray;
+      }
+      image.awt().setRGB(0, 0, w, h, argb, 0, w);
    }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
@@ -16,7 +16,6 @@
 package com.sksamuel.scrimage.filter;
 
 import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.color.RGBColor;
 
 public class OpacityFilter implements Filter {
 
@@ -27,11 +26,20 @@ public class OpacityFilter implements Filter {
    }
 
    public void apply(ImmutableImage image) {
-      image.mapInPlace(p -> {
-         int _r = (int) (p.red() + (255 - p.red()) * amount);
-         int _g = (int) (p.green() + (255 - p.green()) * amount);
-         int _b = (int) (p.blue() + (255 - p.blue()) * amount);
-         return new RGBColor(_r, _g, _b, p.alpha()).awt();
-      });
+      int w = image.width;
+      int h = image.height;
+      int[] argb = image.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int a = (p >>> 24) & 0xFF;
+         int r = (p >> 16) & 0xFF;
+         int g = (p >> 8) & 0xFF;
+         int b = p & 0xFF;
+         int nr = (int) (r + (255 - r) * amount);
+         int ng = (int) (g + (255 - g) * amount);
+         int nb = (int) (b + (255 - b) * amount);
+         argb[i] = (a << 24) | (nr << 16) | (ng << 8) | nb;
+      }
+      image.awt().setRGB(0, 0, w, h, argb, 0, w);
    }
 }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BlackThresholdFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BlackThresholdFilterTest.kt
@@ -3,6 +3,7 @@
 package com.sksamuel.scrimage.filter
 
 import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -18,6 +19,38 @@ class BlackThresholdFilterTest : FunSpec({
       val expected =
          ImmutableImage.fromStream(javaClass.getResourceAsStream("/com/sksamuel/scrimage/filters/bird_small_black_threshold.png"))
       image shouldBe expected
+   }
+
+   // Pin pixel-level behaviour after the bulk-int rewrite. brightness =
+   // (r + g + b) / 3; pixels strictly below the threshold get RGB cleared
+   // to zero while the alpha channel is preserved verbatim.
+   test("pixels below threshold are blacked out, pixels at-or-above are kept, alpha preserved") {
+      val threshold = 50.0 // 50% of 255 = 127
+      val pixels = arrayOf(
+         // brightness 50 (below) — should be blacked, alpha=200 kept
+         Pixel(0, 0, 50, 50, 50, 200),
+         // brightness 200 (above) — should be kept verbatim, alpha=128
+         Pixel(1, 0, 200, 200, 200, 128),
+         // brightness exactly 127 (boundary, NOT below) — kept
+         Pixel(0, 1, 127, 127, 127, 255),
+         // brightness 0 (below) — blacked, alpha=0 (transparent black stays transparent)
+         Pixel(1, 1, 0, 0, 0, 0)
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      BlackThresholdFilter(threshold).apply(image)
+
+      image.pixel(0, 0).let {
+         it.red() shouldBe 0; it.green() shouldBe 0; it.blue() shouldBe 0; it.alpha() shouldBe 200
+      }
+      image.pixel(1, 0).let {
+         it.red() shouldBe 200; it.green() shouldBe 200; it.blue() shouldBe 200; it.alpha() shouldBe 128
+      }
+      image.pixel(0, 1).let {
+         it.red() shouldBe 127; it.green() shouldBe 127; it.blue() shouldBe 127; it.alpha() shouldBe 255
+      }
+      image.pixel(1, 1).let {
+         it.red() shouldBe 0; it.green() shouldBe 0; it.blue() shouldBe 0; it.alpha() shouldBe 0
+      }
    }
 
 })

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GrayscaleFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GrayscaleFilterTest.kt
@@ -49,4 +49,36 @@ class GrayscaleFilterTest : FunSpec({
       p.red() shouldBe p.green()
       p.green() shouldBe p.blue()
    }
+
+   // The bulk-int rewrite must compute the same luma as the previous
+   // mapInPlace((Pixel) -> Color) implementation. Pin the exact value
+   // for a known input.
+   test("grayscale luma matches Rec. 709 weights to the integer") {
+      // gray = round(0.2126*100 + 0.7152*150 + 0.0722*200)
+      //      = round(21.26 + 107.28 + 14.44)
+      //      = round(142.98) = 143
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val result = image.filter(GrayscaleFilter())
+      val p = result.pixel(0, 0)
+      p.red() shouldBe 143
+      p.green() shouldBe 143
+      p.blue() shouldBe 143
+      p.alpha() shouldBe 255
+   }
+
+   test("grayscale leaves a multi-pixel image with row-major ordering intact") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),    // red    → gray ≈ 54
+         Pixel(1, 0, 0, 255, 0, 255),    // green  → gray ≈ 182
+         Pixel(0, 1, 0, 0, 255, 255),    // blue   → gray ≈ 18
+         Pixel(1, 1, 255, 255, 255, 255) // white  → gray = 255
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val result = image.filter(GrayscaleFilter())
+      result.pixel(0, 0).red() shouldBe 54
+      result.pixel(1, 0).red() shouldBe 182
+      result.pixel(0, 1).red() shouldBe 18
+      result.pixel(1, 1).red() shouldBe 255
+   }
 })

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/OpacityFilterValueTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/OpacityFilterValueTest.kt
@@ -1,0 +1,57 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pin the exact pixel-level math for OpacityFilter after the bulk-int
+ * rewrite. The existing OpacityFilterTest in Scala compares against a
+ * golden image; this is a smaller standalone test that catches drift
+ * to the integer.
+ */
+class OpacityFilterValueTest : FunSpec({
+
+   // Each channel: new = (int) (c + (255 - c) * amount)
+   // amount = 0.5 → channel slides halfway toward white
+   test("opacity 0.5 lifts each channel halfway toward 255") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 0, 0, 0, 255),         // black → 127, 127, 127
+         Pixel(1, 0, 100, 200, 50, 255),    // mid   → 177, 227, 152
+         Pixel(0, 1, 255, 255, 255, 255),   // white stays white
+         Pixel(1, 1, 0, 0, 0, 128)          // alpha is preserved verbatim
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      OpacityFilter(0.5f).apply(image)
+
+      image.pixel(0, 0).let {
+         it.red() shouldBe 127; it.green() shouldBe 127; it.blue() shouldBe 127
+      }
+      image.pixel(1, 0).let {
+         it.red() shouldBe 177; it.green() shouldBe 227; it.blue() shouldBe 152
+      }
+      image.pixel(0, 1).let {
+         it.red() shouldBe 255; it.green() shouldBe 255; it.blue() shouldBe 255
+      }
+      image.pixel(1, 1).alpha() shouldBe 128
+   }
+
+   test("opacity 0 leaves the image unchanged") {
+      val pixels = arrayOf(Pixel(0, 0, 12, 34, 56, 200))
+      val image = ImmutableImage.create(1, 1, pixels)
+      OpacityFilter(0f).apply(image)
+      image.pixel(0, 0).let {
+         it.red() shouldBe 12; it.green() shouldBe 34; it.blue() shouldBe 56; it.alpha() shouldBe 200
+      }
+   }
+
+   test("opacity 1 pushes every pixel to fully white (alpha intact)") {
+      val pixels = arrayOf(Pixel(0, 0, 12, 34, 56, 200))
+      val image = ImmutableImage.create(1, 1, pixels)
+      OpacityFilter(1f).apply(image)
+      image.pixel(0, 0).let {
+         it.red() shouldBe 255; it.green() shouldBe 255; it.blue() shouldBe 255; it.alpha() shouldBe 200
+      }
+   }
+})


### PR DESCRIPTION
## Summary
All three filters routed through \`MutableImage.mapInPlace((Pixel) -> Color)\`, which means even after the bulk get/setRGB scaffolding (#385), the mapper lambda was still allocating per pixel:

- \`OpacityFilter\`: \`new RGBColor(...).awt()\` per pixel
- \`GrayscaleFilter\`: \`new RGBColor(...).awt()\` per pixel
- \`BlackThresholdFilter\`: \`RGBColor.fromARGBInt(...).awt()\` or \`p.toColor().awt()\` per pixel

Each was producing one \`RGBColor\` and one \`java.awt.Color\` per pixel — ~32M short-lived objects on a 4kx4k image, with \`.getRGB()\` called on the Color afterwards just to extract the ARGB int that \`RGBColor\` already held internally.

Replace each filter's body with a direct bulk \`getRGB\` → in-place int loop → bulk \`setRGB\`. No per-pixel object allocation, identical math (preserves the merged #372 luma weights for Grayscale), identical output.

## Test plan
- [x] \`./gradlew :scrimage-tests:test\`