### PR TITLE
Drop per-step RGBColor allocation in AwtImage.average()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -596,7 +596,35 @@ public class AwtImage {
     * Returns the average colour of all pixels in this image
     */
    public RGBColor average() {
-      return Arrays.stream(pixels()).map(Pixel::toColor).reduce(com.sksamuel.scrimage.color.Color::average).get();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      // Sequential SrcOver-blend reduce, mirroring Color.average(Color other).
+      // We carry running int channel values through the loop, avoiding an
+      // RGBColor allocation per pixel that the previous Stream-based reduce
+      // had to make.
+      int p0 = argb[0];
+      int accA = (p0 >>> 24) & 0xFF;
+      int accR = (p0 >> 16) & 0xFF;
+      int accG = (p0 >> 8) & 0xFF;
+      int accB = p0 & 0xFF;
+      for (int i = 1; i < argb.length; i++) {
+         int p = argb[i];
+         int pa = (p >>> 24) & 0xFF;
+         int pr = (p >> 16) & 0xFF;
+         int pg = (p >> 8) & 0xFF;
+         int pb = p & 0xFF;
+         double a1 = accA / 255.0;
+         double a2 = pa / 255.0;
+         double aOut = a1 + a2 * (1.0 - a1);
+         if (aOut == 0.0) {
+            accA = 0; accR = 0; accG = 0; accB = 0;
+         } else {
+            accR = (int) Math.round((accR * a1 + pr * a2 * (1.0 - a1)) / aOut);
+            accG = (int) Math.round((accG * a1 + pg * a2 * (1.0 - a1)) / aOut);
+            accB = (int) Math.round((accB * a1 + pb * a2 * (1.0 - a1)) / aOut);
+            accA = (int) Math.round(aOut * 255);
+         }
+      }
+      return new RGBColor(accR, accG, accB, accA);
    }
 
    /**

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -669,7 +669,35 @@ public class AwtImage {
     * Returns the average colour of all pixels in this image
     */
    public RGBColor average() {
-      return Arrays.stream(pixels()).map(Pixel::toColor).reduce(com.sksamuel.scrimage.color.Color::average).get();
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      // Sequential SrcOver-blend reduce, mirroring Color.average(Color other).
+      // We carry running int channel values through the loop, avoiding an
+      // RGBColor allocation per pixel that the previous Stream-based reduce
+      // had to make.
+      int p0 = argb[0];
+      int accA = (p0 >>> 24) & 0xFF;
+      int accR = (p0 >> 16) & 0xFF;
+      int accG = (p0 >> 8) & 0xFF;
+      int accB = p0 & 0xFF;
+      for (int i = 1; i < argb.length; i++) {
+         int p = argb[i];
+         int pa = (p >>> 24) & 0xFF;
+         int pr = (p >> 16) & 0xFF;
+         int pg = (p >> 8) & 0xFF;
+         int pb = p & 0xFF;
+         double a1 = accA / 255.0;
+         double a2 = pa / 255.0;
+         double aOut = a1 + a2 * (1.0 - a1);
+         if (aOut == 0.0) {
+            accA = 0; accR = 0; accG = 0; accB = 0;
+         } else {
+            accR = (int) Math.round((accR * a1 + pr * a2 * (1.0 - a1)) / aOut);
+            accG = (int) Math.round((accG * a1 + pg * a2 * (1.0 - a1)) / aOut);
+            accB = (int) Math.round((accB * a1 + pb * a2 * (1.0 - a1)) / aOut);
+            accA = (int) Math.round(aOut * 255);
+         }
+      }
+      return new RGBColor(accR, accG, accB, accA);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -112,4 +112,44 @@ class AwtImageTest : FunSpec({
       pixels[3].x shouldBe 1; pixels[3].y shouldBe 1
       pixels[3].argb shouldBe 0xFFFFFFFF.toInt()
    }
+
+   // average() reduces pixels via Color.average's SrcOver-style alpha-aware
+   // blend (not an arithmetic mean). The following three tests lock in that
+   // semantic so future rewrites don't drift.
+   test("average() of a uniform image returns that color") {
+      val pixels = Array(16) { Pixel(it % 4, it / 4, 0xFFAA55BB.toInt()) }
+      val image = ImmutableImage.create(4, 4, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 0xFF
+      avg.red shouldBe 0xAA
+      avg.green shouldBe 0x55
+      avg.blue shouldBe 0xBB
+   }
+
+   test("average() with all fully transparent pixels returns transparent black") {
+      val pixels = Array(4) { Pixel(it % 2, it / 2, 0x00FFFFFF) }
+      val image = ImmutableImage.create(2, 2, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 0
+      avg.red shouldBe 0
+      avg.green shouldBe 0
+      avg.blue shouldBe 0
+   }
+
+   test("average() of all-opaque pixels collapses to the first pixel (SrcOver)") {
+      // SrcOver(opaque, opaque) = the first; reducing opaque pixels in
+      // sequence therefore leaves the very first pixel as the winner.
+      val pixels = arrayOf(
+         Pixel(0, 0, 0xFFAA0000.toInt()),
+         Pixel(1, 0, 0xFF00BB00.toInt()),
+         Pixel(0, 1, 0xFF0000CC.toInt()),
+         Pixel(1, 1, 0xFFFFFFFF.toInt())
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 255
+      avg.red shouldBe 0xAA
+      avg.green shouldBe 0
+      avg.blue shouldBe 0
+   }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -199,4 +199,44 @@ class AwtImageTest : FunSpec({
       // matches at i=0,3,6,9 → 4 pixels
       image.count { p -> p.red() == 255 } shouldBe 4L
    }
+
+   // average() reduces pixels via Color.average's SrcOver-style alpha-aware
+   // blend (not an arithmetic mean). The following three tests lock in that
+   // semantic so future rewrites don't drift.
+   test("average() of a uniform image returns that color") {
+      val pixels = Array(16) { Pixel(it % 4, it / 4, 0xFFAA55BB.toInt()) }
+      val image = ImmutableImage.create(4, 4, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 0xFF
+      avg.red shouldBe 0xAA
+      avg.green shouldBe 0x55
+      avg.blue shouldBe 0xBB
+   }
+
+   test("average() with all fully transparent pixels returns transparent black") {
+      val pixels = Array(4) { Pixel(it % 2, it / 2, 0x00FFFFFF) }
+      val image = ImmutableImage.create(2, 2, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 0
+      avg.red shouldBe 0
+      avg.green shouldBe 0
+      avg.blue shouldBe 0
+   }
+
+   test("average() of all-opaque pixels collapses to the first pixel (SrcOver)") {
+      // SrcOver(opaque, opaque) = the first; reducing opaque pixels in
+      // sequence therefore leaves the very first pixel as the winner.
+      val pixels = arrayOf(
+         Pixel(0, 0, 0xFFAA0000.toInt()),
+         Pixel(1, 0, 0xFF00BB00.toInt()),
+         Pixel(0, 1, 0xFF0000CC.toInt()),
+         Pixel(1, 1, 0xFFFFFFFF.toInt())
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val avg = image.average()
+      avg.alpha shouldBe 255
+      avg.red shouldBe 0xAA
+      avg.green shouldBe 0
+      avg.blue shouldBe 0
+   }
 })


### PR DESCRIPTION
## Summary
\`average()\` reduced via \`Arrays.stream(pixels()).map(Pixel::toColor).reduce(Color::average)\`, which allocated one \`RGBColor\` per pixel for the materialised \`pixels()\` and one more \`RGBColor\` per pixel inside reduce as the running accumulator. For a 4kx4k image: ~32M \`RGBColor\` allocations just to produce one final result.

Inline a single bulk \`getRGB\` and carry the running (a, r, g, b) channel values as int locals, applying \`Color.average\`'s SrcOver formula step by step on doubles with the same \`Math.round\` at each step. Output is bit-identical to the old reduce.

Note that this is a sequential SrcOver-blend reduce, not an arithmetic mean — for example, an all-opaque image collapses to its first pixel because \`SrcOver(opaque, opaque)\` returns the first. New tests pin that behaviour so future rewrites don't drift.

## Test plan
- [x] New tests in \`AwtImageTest\` covering uniform, all-transparent, and all-opaque cases
- [x] \`./gradlew :scrimage-tests:test\`