### PR TITLE
Drop per-call Point allocation in MutableImage.setColor(int offset, Color)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -89,8 +89,9 @@ public class MutableImage extends AwtImage {
    }
 
    public void setColor(int offset, com.sksamuel.scrimage.color.Color color) {
-      Point point = PixelTools.offsetToPoint(offset, width);
-      awt().setRGB(point.x, point.y, color.toRGB().toARGBInt());
+      int x = offset % width;
+      int y = offset / width;
+      awt().setRGB(x, y, color.toRGB().toARGBInt());
    }
 
    public void setColor(int x, int y, com.sksamuel.scrimage.color.Color color) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/MutableImageSetColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/MutableImageSetColorTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Pin-down tests for the offset → (x, y) mapping in MutableImage.setColor.
+ * The optimisation drops a per-call Point allocation by inlining the
+ * row-major arithmetic. The mapping must remain row-major: offset = y * w + x.
+ */
+class MutableImageSetColorTest : FunSpec({
+
+   test("setColor(offset) writes to the row-major coordinate") {
+      val w = 4; val h = 3
+      val image = ImmutableImage.create(w, h, BufferedImage.TYPE_INT_ARGB)
+      // Offset 0 → (0, 0); 1 → (1, 0); 4 → (0, 1); 7 → (3, 1); 11 → (3, 2)
+      image.setColor(0, RGBColor(255, 0, 0, 255))
+      image.setColor(1, RGBColor(0, 255, 0, 255))
+      image.setColor(4, RGBColor(0, 0, 255, 255))
+      image.setColor(7, RGBColor(255, 255, 0, 255))
+      image.setColor(11, RGBColor(255, 0, 255, 255))
+
+      image.pixel(0, 0).argb shouldBe 0xFFFF0000.toInt()
+      image.pixel(1, 0).argb shouldBe 0xFF00FF00.toInt()
+      image.pixel(0, 1).argb shouldBe 0xFF0000FF.toInt()
+      image.pixel(3, 1).argb shouldBe 0xFFFFFF00.toInt()
+      image.pixel(3, 2).argb shouldBe 0xFFFF00FF.toInt()
+   }
+
+   test("setColor(offset) and setColor(x, y) produce equivalent results") {
+      val w = 5; val h = 4
+      val a = ImmutableImage.create(w, h, BufferedImage.TYPE_INT_ARGB)
+      val b = ImmutableImage.create(w, h, BufferedImage.TYPE_INT_ARGB)
+      // Sweep every offset and write distinct colours
+      for (i in 0 until w * h) {
+         val color = RGBColor(i and 0xFF, (i * 7) and 0xFF, (i * 13) and 0xFF, 255)
+         a.setColor(i, color)
+         b.setColor(i % w, i / w, color)
+      }
+      a shouldBe b
+   }
+})


### PR DESCRIPTION
## Summary
\`setColor(int, Color)\` called \`PixelTools.offsetToPoint(offset, width)\` which allocates a fresh \`java.awt.Point\` just to derive (x, y) from the row-major offset. Inline the arithmetic — \`x = offset % width\`, \`y = offset / width\` — and skip the allocation. The per-pixel API is called in tight loops by some callers, so this removes one Point allocation per pixel set.

## Test plan
- [x] New \`MutableImageSetColorTest\` pins the row-major mapping for several offsets and proves equivalence with \`setColor(int, int, Color)\` across a full image sweep
- [x] \`./gradlew :scrimage-tests:test\` green