### PR TITLE
Write int[] directly in subpixelSubimage instead of Pixel[] round-trip

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1416,14 +1416,21 @@ public class ImmutableImage extends MutableImage {
       assert y >= 0;
       assert y + subHeight < height;
 
-      Pixel[] matrix = new Pixel[subWidth * subHeight];
-      // Simply copy the pixels over, one by one.
+      // Walk the output grid and write each interpolated ARGB int directly
+      // into a row-major buffer. The previous implementation allocated a
+      // Pixel per output cell and routed through wrapPixels → create(Pixel[]),
+      // which itself re-extracted the argb from each Pixel — a wasted round
+      // trip now that subpixel() already returns a packed ARGB int.
+      int[] argb = new int[subWidth * subHeight];
+      int k = 0;
       for (int yIndex = 0; yIndex < subHeight; yIndex++) {
          for (int xIndex = 0; xIndex < subWidth; xIndex++) {
-            matrix[PixelTools.coordsToOffset(xIndex, yIndex, subWidth)] = new Pixel(xIndex, yIndex, subpixel(xIndex + x, yIndex + y));
+            argb[k++] = subpixel(xIndex + x, yIndex + y);
          }
       }
-      return wrapPixels(subWidth, subHeight, matrix, metadata);
+      ImmutableImage result = ImmutableImage.create(subWidth, subHeight, DEFAULT_DATA_TYPE);
+      result.awt().setRGB(0, 0, subWidth, subHeight, argb, 0, subWidth);
+      return result.associateMetadata(metadata);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/subpixel/LinearSubpixelInterpolatorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/subpixel/LinearSubpixelInterpolatorTest.kt
@@ -21,4 +21,18 @@ class LinearSubpixelInterpolatorTest : FunSpec({
       100 shouldBe subimage.height
    }
 
+   // The int[]-direct rewrite of subpixelSubimage must produce the same
+   // pixel grid as the Pixel[]-roundtrip implementation. Pin it to the
+   // existing happy-path subpixel values for an extracted region.
+   test("subpixelSubimage at integer offsets returns the expected pixels") {
+      // Same image and same coordinates as 'subpixel happy path', so the
+      // output of the (1, 1) pixel of subpixelSubimage(2.0, 3.0, 3, 3)
+      // should equal subpixel(3.0, 4.0).
+      val sub = image.subpixelSubimage(2.0, 3.0, 3, 3)
+      sub.width shouldBe 3
+      sub.height shouldBe 3
+      sub.pixel(1, 1).argb shouldBe image.subpixel(3.0, 4.0)
+      sub.pixel(0, 0).argb shouldBe image.subpixel(2.0, 3.0)
+      sub.pixel(2, 2).argb shouldBe image.subpixel(4.0, 5.0)
+   }
 })


### PR DESCRIPTION
## Summary
\`subpixelSubimage\` allocated a \`Pixel[subWidth * subHeight]\`, walked the output grid wrapping each \`subpixel()\` result in a fresh \`Pixel(x, y, argb)\`, then handed the array to \`wrapPixels\` → \`ImmutableImage.create(int, int, Pixel[], int)\` — which (after #399) re-extracts the argb int from each Pixel and bulk \`setRGB\`s it into the target buffer. So the \`Pixel[]\` was a pure intermediate that got built just to be unwrapped immediately.

Walk the output grid into a row-major \`int[]\` directly and bulk \`setRGB\` once at the end. No per-cell Pixel allocation, no second pass to unpack. Output is bit-identical because \`subpixel()\` already returns the packed ARGB int that the round-trip would have produced.

## Test plan
- [x] New \`subpixelSubimage at integer offsets returns the expected pixels\` test in \`LinearSubpixelInterpolatorTest\` cross-checks corner and centre cells against independent \`subpixel()\` calls at the corresponding source coordinates
- [x] \`./gradlew :scrimage-tests:test\` green