### PR TITLE
Drop Integer boxing in ImmutableImage.filter type dispatch

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -664,13 +664,19 @@ public class ImmutableImage extends MutableImage {
     * @return A new image with the given filter applied.
     */
    public ImmutableImage filter(Filter filter) throws IOException {
-      List<Integer> types = Arrays.stream(filter.types()).boxed().collect(Collectors.toList());
-      ImmutableImage target;
-      if (types.isEmpty() || types.contains(getType())) {
-         target = copy();
-      } else {
-         target = copy(types.get(0));
+      int[] types = filter.types();
+      // Empty types[] means "any type works"; otherwise copy in our current
+      // type if it's listed, else convert to types[0]. The previous
+      // implementation boxed every int into Integer and built an ArrayList
+      // just to call .contains() with another autoboxed lookup.
+      int currentType = getType();
+      boolean canUseCurrent = types.length == 0;
+      if (!canUseCurrent) {
+         for (int t : types) {
+            if (t == currentType) { canUseCurrent = true; break; }
+         }
       }
+      ImmutableImage target = canUseCurrent ? copy() : copy(types[0]);
       filter.apply(target);
       return target;
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FilterTypesDispatchTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FilterTypesDispatchTest.kt
@@ -1,0 +1,65 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.filter.Filter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Pin-down tests for ImmutableImage.filter(Filter)'s type-dispatch logic
+ * after the de-boxing rewrite. The new implementation iterates the int[]
+ * returned by Filter.types() directly instead of materialising a List<Integer>.
+ *
+ * Three cases must hold:
+ *  1. types() == [] → use current type
+ *  2. types() contains current type → use current type
+ *  3. types() does NOT contain current type → convert to types[0]
+ */
+class FilterTypesDispatchTest : FunSpec({
+
+   class TypeRecordingFilter(private val supported: IntArray) : Filter {
+      var observedType: Int = -1
+      override fun types(): IntArray = supported
+      override fun apply(image: ImmutableImage) {
+         observedType = image.awt().type
+      }
+   }
+
+   test("filter with empty types() runs against the current image type") {
+      val image = ImmutableImage.create(2, 2, BufferedImage.TYPE_INT_ARGB)
+      val f = TypeRecordingFilter(intArrayOf())
+      image.filter(f)
+      f.observedType shouldBe BufferedImage.TYPE_INT_ARGB
+   }
+
+   test("filter with matching type in types() runs against the current image type") {
+      val image = ImmutableImage.create(2, 2, BufferedImage.TYPE_INT_ARGB)
+      val f = TypeRecordingFilter(intArrayOf(BufferedImage.TYPE_INT_RGB, BufferedImage.TYPE_INT_ARGB))
+      image.filter(f)
+      f.observedType shouldBe BufferedImage.TYPE_INT_ARGB
+   }
+
+   test("filter with non-matching types() converts the image to types[0]") {
+      val image = ImmutableImage.create(2, 2, BufferedImage.TYPE_INT_ARGB)
+      val f = TypeRecordingFilter(intArrayOf(BufferedImage.TYPE_INT_RGB, BufferedImage.TYPE_3BYTE_BGR))
+      image.filter(f)
+      f.observedType shouldBe BufferedImage.TYPE_INT_RGB
+   }
+
+   test("filter returns a copy: original image is unchanged") {
+      val original = ImmutableImage.create(2, 2, BufferedImage.TYPE_INT_ARGB)
+      original.setColor(0, 0, RGBColor(255, 0, 0, 255))
+      val mutating = object : Filter {
+         override fun apply(image: ImmutableImage) {
+            image.setColor(0, 0, RGBColor(0, 255, 0, 255))
+         }
+      }
+      val out = original.filter(mutating)
+      // original untouched
+      original.pixel(0, 0).red() shouldBe 255
+      // result reflects the filter's mutation
+      out.pixel(0, 0).green() shouldBe 255
+   }
+})


### PR DESCRIPTION
## Summary
The single-filter entry point ran:

\`\`\`java
List<Integer> types = Arrays.stream(filter.types()).boxed().collect(toList());
if (types.isEmpty() || types.contains(getType())) ...
\`\`\`

per \`filter()\` invocation. That allocated an IntStream, a Stream<Integer> with one boxed Integer per type, and an ArrayList<Integer> — and then \`List.contains(Integer)\` auto-boxed the lookup value too. \`filter(Filter...)\` chains compound this overhead by re-running it for every filter in the pipeline.

Replace with a tight \`int[]\` loop that walks \`filter.types()\` once, checking against the current type with primitive == comparison. Same dispatch semantics — empty list means "any type", non-empty list means "convert to \`types[0]\` unless current type is listed" — but no per-call boxing or list allocation.

## Test plan
- [x] New \`FilterTypesDispatchTest\` covers all three dispatch branches (empty types, current type listed, current type not listed) plus the "original image is unchanged" copy-on-filter contract
- [x] \`./gradlew :scrimage-tests:test\` green