### PR TITLE
Bulk-int rewrite of ImmutableImage.toGrayscale(GrayscaleMethod)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -23,6 +23,7 @@ import com.sksamuel.scrimage.canvas.drawables.FilledRect;
 import com.sksamuel.scrimage.canvas.painters.LinearGradient;
 import com.sksamuel.scrimage.canvas.painters.Painter;
 import com.sksamuel.scrimage.color.Colors;
+import com.sksamuel.scrimage.color.Grayscale;
 import com.sksamuel.scrimage.color.GrayscaleMethod;
 import com.sksamuel.scrimage.color.RGBColor;
 import com.sksamuel.scrimage.composite.Composite;
@@ -1688,6 +1689,26 @@ public class ImmutableImage extends MutableImage {
    }
 
    public ImmutableImage toGrayscale(GrayscaleMethod method) {
-      return map(pixel -> pixel.toColor().toGrayscale(method).awt());
+      // The previous map((Pixel) -> Color) routed through mapInPlace and
+      // allocated three objects per pixel: an RGBColor (toColor), a Grayscale
+      // (method.toGrayscale), and a java.awt.Color (.awt()) — plus a Pixel
+      // wrapper inside mapInPlace. Inline a bulk get/setRGB and only the
+      // RGBColor + Grayscale allocations remain (GrayscaleMethod's interface
+      // requires a Color in / Grayscale out).
+      ImmutableImage target = copy();
+      int w = target.width;
+      int h = target.height;
+      int[] argb = target.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int r = (p >> 16) & 0xFF;
+         int g = (p >> 8) & 0xFF;
+         int b = p & 0xFF;
+         int a = (p >>> 24) & 0xFF;
+         Grayscale gray = method.toGrayscale(new RGBColor(r, g, b, a));
+         argb[i] = (gray.alpha << 24) | (gray.gray << 16) | (gray.gray << 8) | gray.gray;
+      }
+      target.awt().setRGB(0, 0, w, h, argb, 0, w);
+      return target;
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToGrayscaleTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToGrayscaleTest.kt
@@ -1,0 +1,85 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.AverageGrayscale
+import com.sksamuel.scrimage.color.LumaGrayscale
+import com.sksamuel.scrimage.color.WeightedGrayscale
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pin-down tests for the bulk-int rewrite of toGrayscale(GrayscaleMethod).
+ * The rewrite must:
+ *   - dispatch to the chosen GrayscaleMethod for every pixel
+ *   - put the resulting gray into all three RGB channels
+ *   - preserve the source pixel's alpha channel via Grayscale.alpha
+ *   - leave the source ImmutableImage unchanged (operates on a copy)
+ */
+class ToGrayscaleTest : FunSpec({
+
+   // All three method tests use opaque alpha (255) because copy() goes
+   // through Graphics2D.drawImage which premultiplies internally and loses
+   // precision when alpha != 255 — that's a pre-existing behaviour, not a
+   // regression of this PR.
+   test("LumaGrayscale: 100/150/200 opaque → gray 143") {
+      // gray = round(0.2126*100 + 0.7152*150 + 0.0722*200) = round(142.98) = 143
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val out = image.toGrayscale(LumaGrayscale())
+      val p = out.pixel(0, 0)
+      p.red() shouldBe 143
+      p.green() shouldBe 143
+      p.blue() shouldBe 143
+      p.alpha() shouldBe 255
+   }
+
+   test("AverageGrayscale: 100/150/200 opaque → gray 150") {
+      // average = (100 + 150 + 200) / 3 = 150
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val out = image.toGrayscale(AverageGrayscale())
+      val p = out.pixel(0, 0)
+      p.red() shouldBe 150
+      p.green() shouldBe 150
+      p.blue() shouldBe 150
+      p.alpha() shouldBe 255
+   }
+
+   test("WeightedGrayscale: 100/150/200 opaque → gray 141") {
+      // gray = round(0.299*100 + 0.587*150 + 0.114*200) = round(140.65) = 141
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val out = image.toGrayscale(WeightedGrayscale())
+      val p = out.pixel(0, 0)
+      p.red() shouldBe 141
+      p.green() shouldBe 141
+      p.blue() shouldBe 141
+      p.alpha() shouldBe 255
+   }
+
+   test("toGrayscale leaves the source image unchanged") {
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val original = ImmutableImage.create(1, 1, pixels)
+      original.toGrayscale(LumaGrayscale())
+      // Original red is still 100, not the gray value
+      original.pixel(0, 0).red() shouldBe 100
+      original.pixel(0, 0).green() shouldBe 150
+      original.pixel(0, 0).blue() shouldBe 200
+   }
+
+   test("toGrayscale preserves row-major ordering across multi-pixel images") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),    // red    → luma 54
+         Pixel(1, 0, 0, 255, 0, 255),    // green  → luma 182
+         Pixel(0, 1, 0, 0, 255, 255),    // blue   → luma 18
+         Pixel(1, 1, 255, 255, 255, 255) // white  → luma 255
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val out = image.toGrayscale(LumaGrayscale())
+      out.pixel(0, 0).red() shouldBe 54
+      out.pixel(1, 0).red() shouldBe 182
+      out.pixel(0, 1).red() shouldBe 18
+      out.pixel(1, 1).red() shouldBe 255
+   }
+})


### PR DESCRIPTION
## Summary
The previous one-liner was:

\`\`\`java
return map(pixel -> pixel.toColor().toGrayscale(method).awt());
\`\`\`

That routed through \`map\` → \`mapInPlace\` and allocated four objects per pixel: a Pixel wrapper inside mapInPlace, an RGBColor (\`toColor\`), a Grayscale (\`method.toGrayscale\`), and a java.awt.Color (\`.awt()\`). For a 4kx4k image: ~64M short-lived objects.

Inline a bulk \`get/setRGB\` loop. Only the RGBColor + Grayscale allocations remain (GrayscaleMethod's interface still requires Color in / Grayscale out), so per-pixel allocations halve from four to two, and the \`awt.Color → getRGB → re-pack\` round-trip goes away entirely. The grayscale value is composed straight into the packed-ARGB int.

## Test plan
- [x] New \`ToGrayscaleTest\` covers all three GrayscaleMethod implementations (Luma, Average, Weighted), copy-on-call (source unchanged), and row-major ordering across a multi-pixel image
- [x] Tests use opaque alpha — \`copy()\` already loses precision through Graphics2D.drawImage's premultiply roundtrip when alpha != 255, a pre-existing behaviour
- [x] \`./gradlew :scrimage-tests:test\` green