### PR TITLE
Fix AwtImage.clone losing pixel precision when alpha != 255

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -636,9 +636,18 @@ public class AwtImage {
    public AwtImage clone(int imageType) {
       if (imageType <= 0) throw new IllegalArgumentException("Image type must be > 0");
       BufferedImage target = new BufferedImage(awt.getWidth(null), awt.getHeight(null), imageType);
-      Graphics g2 = target.getGraphics();
-      g2.drawImage(awt, 0, 0, null);
-      g2.dispose();
+      if (awt.getType() == imageType) {
+         // Same type — copy the raster data directly. Going through
+         // Graphics2D.drawImage would composite via SrcOver, which
+         // premultiplies alpha and rounds away ±1 from each colour channel
+         // when alpha doesn't divide 255 cleanly.
+         awt.copyData(target.getRaster());
+      } else {
+         // Type conversion — Graphics2D handles the colour-space conversion.
+         Graphics g2 = target.getGraphics();
+         g2.drawImage(awt, 0, 0, null);
+         g2.dispose();
+      }
       return new AwtImage(target);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyPrecisionTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyPrecisionTest.kt
@@ -1,0 +1,90 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for copy() losing channel precision when alpha != 255.
+ *
+ * The original AwtImage.clone(int) used Graphics2D.drawImage to populate
+ * the target buffer. Graphics2D.drawImage composites via SrcOver, which
+ * premultiplies alpha into each colour channel and then unpremultiplies
+ * on read-back. For alpha values that don't divide 255 cleanly, the
+ * round-trip rounds away ±1 from each channel.
+ *
+ * Concrete example: a pixel with (r=100, g=150, b=200, a=128) became
+ * (r=100, g=149, b=199, a=128) after copy().
+ *
+ * The fix uses BufferedImage.copyData when the source and target image
+ * types match — a direct raster copy that doesn't go through compositing.
+ */
+class CopyPrecisionTest : FunSpec({
+
+   test("copy preserves all channels exactly when alpha != 255 (TYPE_INT_ARGB)") {
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 128))
+      val original = ImmutableImage.create(1, 1, pixels)
+      val copy = original.copy()
+      val p = copy.pixel(0, 0)
+      p.red() shouldBe 100
+      p.green() shouldBe 150
+      p.blue() shouldBe 200
+      p.alpha() shouldBe 128
+   }
+
+   test("copy preserves channels across multiple awkward alpha values") {
+      // A spread of alphas that previously rounded channels by ±1.
+      val pixels = arrayOf(
+         Pixel(0, 0, 100, 150, 200, 1),
+         Pixel(1, 0, 100, 150, 200, 7),
+         Pixel(0, 1, 100, 150, 200, 64),
+         Pixel(1, 1, 100, 150, 200, 200)
+      )
+      val original = ImmutableImage.create(2, 2, pixels)
+      val copy = original.copy()
+      for (y in 0 until 2) for (x in 0 until 2) {
+         val src = original.pixel(x, y)
+         val dst = copy.pixel(x, y)
+         dst.red() shouldBe src.red()
+         dst.green() shouldBe src.green()
+         dst.blue() shouldBe src.blue()
+         dst.alpha() shouldBe src.alpha()
+      }
+   }
+
+   test("copy is independent of the source — mutating the copy does not affect the original") {
+      val pixels = arrayOf(Pixel(0, 0, 50, 60, 70, 200))
+      val original = ImmutableImage.create(1, 1, pixels)
+      val copy = original.copy()
+      copy.setPixel(Pixel(0, 0, 0, 0, 0, 0))
+      // Original must still hold its values
+      original.pixel(0, 0).red() shouldBe 50
+      original.pixel(0, 0).alpha() shouldBe 200
+   }
+
+   test("copy(type) into a different type still uses Graphics2D conversion") {
+      // For a TYPE_INT_RGB target the alpha channel cannot be represented;
+      // the copy collapses alpha to opaque (which is the correct semantic).
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 128))
+      val original = ImmutableImage.create(1, 1, pixels)
+      val converted = original.copy(BufferedImage.TYPE_INT_RGB)
+      converted.awt().type shouldBe BufferedImage.TYPE_INT_RGB
+      converted.pixel(0, 0).alpha() shouldBe 255
+   }
+
+   test("copy preserves channels for TYPE_4BYTE_ABGR with non-255 alpha") {
+      // Same precision invariant must hold for non-int-buffer image types.
+      val buf = BufferedImage(2, 2, BufferedImage.TYPE_4BYTE_ABGR)
+      buf.setRGB(0, 0, 0x80FF6432.toInt()) // alpha=128, r=255, g=100, b=50
+      buf.setRGB(1, 0, 0x40_64C896.toInt())
+      buf.setRGB(0, 1, 0xFF_00_FF_00.toInt())
+      buf.setRGB(1, 1, 0x01_FF_FF_FF.toInt()) // alpha=1, white
+      val original = ImmutableImage.wrapAwt(buf)
+      val copy = original.copy()
+      for (y in 0 until 2) for (x in 0 until 2) {
+         copy.pixel(x, y).argb shouldBe original.pixel(x, y).argb
+      }
+   }
+})


### PR DESCRIPTION
## Summary
\`clone(int)\` populated the target buffer via \`Graphics2D.drawImage\` **even when source and target image types matched**. Graphics2D.drawImage composites via SrcOver, which premultiplies alpha into each colour channel and unpremultiplies on read-back. For alpha values that don't divide 255 cleanly, the round-trip rounds away ±1 from each channel.

Concrete pre-fix behaviour: a pixel with \`(r=100, g=150, b=200, a=128)\` became \`(r=100, g=149, b=199, a=128)\` after \`image.copy()\` — every channel silently shifted by one.

For same-type clones, switch to \`BufferedImage.copyData(target.getRaster())\` which copies the underlying raster sample-for-sample without going through any compositing or colour-model conversion. Works for DataBufferInt, DataBufferByte, and any other buffer backing — bit-identical output, faster too (no Graphics2D rendering pipeline).

For type conversions (e.g. \`TYPE_INT_ARGB → TYPE_INT_RGB\`), keep the Graphics2D.drawImage path — it handles the colour-space conversion correctly, and the alpha collapse there is the intended semantic.

Discovered while writing tests for #413.

## Test plan
- [x] New \`CopyPrecisionTest\` covers:
  - single pixel with alpha=128 round-trips exactly through \`copy()\`
  - four awkward alpha values (1, 7, 64, 200) all round-trip exactly
  - mutating the copy doesn't affect the original (independence)
  - \`copy(TYPE_INT_RGB)\` still drops alpha as before (intended)
  - TYPE_4BYTE_ABGR round-trips exactly too (covers DataBufferByte)
- [x] Pre-fix run: 3 of 5 new tests fail
- [x] Post-fix run: all tests pass
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green