### PR TITLE
Fix AwtImage.toNewBufferedImage losing pixel precision when alpha != 255

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -474,9 +474,18 @@ public class AwtImage {
     */
    public BufferedImage toNewBufferedImage(int type) {
       BufferedImage target = new BufferedImage(width, height, type);
-      Graphics2D g2 = (Graphics2D) target.getGraphics();
-      g2.drawImage(awt, 0, 0, null);
-      g2.dispose();
+      if (awt.getType() == type) {
+         // Same type — copy the raster data directly. Going through
+         // Graphics2D.drawImage would composite via SrcOver, which
+         // premultiplies alpha and rounds away ±1 from each colour channel
+         // when alpha doesn't divide 255 cleanly.
+         awt.copyData(target.getRaster());
+      } else {
+         // Type conversion — Graphics2D handles the colour-space conversion.
+         Graphics2D g2 = (Graphics2D) target.getGraphics();
+         g2.drawImage(awt, 0, 0, null);
+         g2.dispose();
+      }
       return target;
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToNewBufferedImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToNewBufferedImageTest.kt
@@ -1,0 +1,59 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.AwtImage
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for AwtImage.toNewBufferedImage(int) losing channel
+ * precision when the requested type matches the source type. The previous
+ * implementation always populated the target via Graphics2D.drawImage,
+ * which composites via SrcOver and premultiplies alpha — losing ±1 per
+ * channel when alpha doesn't divide 255 cleanly. Same root cause as the
+ * clone(int) fix in #414.
+ */
+class ToNewBufferedImageTest : FunSpec({
+
+   test("toNewBufferedImage(sameType) preserves channels exactly when alpha != 255") {
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 128))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val target = image.toNewBufferedImage(BufferedImage.TYPE_INT_ARGB)
+      val argb = target.getRGB(0, 0)
+      ((argb ushr 24) and 0xFF) shouldBe 128
+      ((argb ushr 16) and 0xFF) shouldBe 100
+      ((argb ushr 8) and 0xFF) shouldBe 150
+      (argb and 0xFF) shouldBe 200
+   }
+
+   test("toNewBufferedImage(sameType) returns a non-shared buffer") {
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 255))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val target = image.toNewBufferedImage(BufferedImage.TYPE_INT_ARGB)
+      target shouldNotBe image.awt()
+      // Mutating the new buffer must not affect the original
+      target.setRGB(0, 0, 0)
+      image.pixel(0, 0).red() shouldBe 100
+   }
+
+   test("toNewBufferedImage with a different type still converts via Graphics2D") {
+      val pixels = arrayOf(Pixel(0, 0, 100, 150, 200, 128))
+      val image = ImmutableImage.create(1, 1, pixels)
+      val target = image.toNewBufferedImage(BufferedImage.TYPE_INT_RGB)
+      target.type shouldBe BufferedImage.TYPE_INT_RGB
+      // TYPE_INT_RGB has no alpha channel — it always reports 255 on getRGB
+      val argb = target.getRGB(0, 0)
+      ((argb ushr 24) and 0xFF) shouldBe 255
+   }
+
+   test("toNewBufferedImage(sameType) preserves channels for TYPE_4BYTE_ABGR") {
+      val src = BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR)
+      src.setRGB(0, 0, 0x80FF6432.toInt()) // alpha=128, r=255, g=100, b=50
+      val image = AwtImage(src)
+      val target = image.toNewBufferedImage(BufferedImage.TYPE_4BYTE_ABGR)
+      target.getRGB(0, 0) shouldBe 0x80FF6432.toInt()
+   }
+})


### PR DESCRIPTION
## Summary
Same root cause as #414 (\`clone(int)\`): \`toNewBufferedImage(int)\` populated the target buffer via \`Graphics2D.drawImage\` **even when the requested type matched the source type**. Graphics2D.drawImage composites via SrcOver, which premultiplies alpha and rounds away ±1 from each colour channel when alpha doesn't divide 255 cleanly.

Concrete pre-fix behaviour for \`(r=100, g=150, b=200, a=128)\` round-tripped through \`toNewBufferedImage(TYPE_INT_ARGB)\` on a TYPE_INT_ARGB source: green came out as 149 (was 150).

For matching source/target types, switch to \`BufferedImage.copyData\`, which copies the underlying raster sample-for-sample without going through any compositing or colour-model conversion. For genuine type conversions (e.g. \`TYPE_INT_ARGB → TYPE_INT_RGB\`, the form \`JpegWriter\` uses) keep the Graphics2D path — it handles the conversion correctly.

## Test plan
- [x] New \`ToNewBufferedImageTest\` pins: alpha=128 round-trips exactly, the result is a non-shared buffer, type-conversion still happens for differing types, and the DataBufferByte path (TYPE_4BYTE_ABGR) is also exact
- [x] Pre-fix run: 1 test fails (\`expected:<150> but was:<149>\`)
- [x] Post-fix run: all tests pass
- [x] Full \`./gradlew :scrimage-tests:test\` green