### PR TITLE
Fix AwtImage.iterator().next() throwing AIOOB instead of NoSuchElementException

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -170,6 +170,7 @@ public class AwtImage {
 
          @Override
          public Pixel next() {
+            if (!hasNext()) throw new java.util.NoSuchElementException();
             if (argb == null) {
                argb = awt.getRGB(0, 0, width, height, null, 0, width);
             }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/IteratorContractTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/IteratorContractTest.kt
@@ -1,0 +1,57 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.NoSuchElementException
+
+/**
+ * Regression test for AwtImage.iterator() honouring the Iterator contract.
+ *
+ * The Iterator interface specifies that next() "throws
+ * NoSuchElementException - if the iteration has no more elements". The
+ * previous implementation incremented its index unconditionally and on
+ * exhaustion threw ArrayIndexOutOfBoundsException from the int[] read.
+ *
+ * Code that catches NoSuchElementException defensively (or composes
+ * iterators with helpers that rely on the contract) would silently miss
+ * the exhaustion.
+ */
+class IteratorContractTest : FunSpec({
+
+   test("iterator().next() throws NoSuchElementException when exhausted") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),
+         Pixel(1, 0, 0, 255, 0, 255)
+      )
+      val image = ImmutableImage.create(2, 1, pixels)
+      val it = image.iterator()
+      // Drain the iterator
+      it.next(); it.next()
+      it.hasNext() shouldBe false
+      shouldThrow<NoSuchElementException> { it.next() }
+   }
+
+   test("iterator() yields the expected pixel count then reports false") {
+      val image = ImmutableImage.create(3, 2)
+      val it = image.iterator()
+      var count = 0
+      while (it.hasNext()) { it.next(); count++ }
+      count shouldBe 6
+      it.hasNext() shouldBe false
+   }
+
+   test("iterator() walks pixels in row-major order") {
+      val pixels = Array(6) { i -> Pixel(i % 3, i / 3, 0xFF000000.toInt() or i) }
+      val image = ImmutableImage.create(3, 2, pixels)
+      val collected = image.iterator().asSequence().toList()
+      collected.size shouldBe 6
+      for (i in 0 until 6) {
+         collected[i].x shouldBe (i % 3)
+         collected[i].y shouldBe (i / 3)
+         (collected[i].argb and 0xFF) shouldBe i
+      }
+   }
+})


### PR DESCRIPTION
## Summary
The \`Iterator\` interface's contract for \`next()\` is:

> Throws: \`NoSuchElementException\` - if the iteration has no more elements

The previous implementation incremented its index unconditionally and, on exhaustion, threw \`ArrayIndexOutOfBoundsException\` from the \`int[]\` read. Code that catches \`NoSuchElementException\` defensively (or composes iterators with helpers that rely on the contract — Kotlin's \`asSequence()\`, the JDK's \`Iterators\` framework, etc.) would silently miss the exhaustion or report a misleading error.

Add an explicit \`hasNext()\` guard at the top of \`next()\` that throws \`NoSuchElementException\`, matching every other well-behaved iterator in the JDK.

## Test plan
- [x] New \`IteratorContractTest\` pins: \`NoSuchElementException\` at the boundary, the right pixel count, and row-major ordering (the latter exercised via \`asSequence().toList()\` which depends on the contract being honoured)
- [x] Pre-fix run: NoSuchElementException test fails (gets AIOOB instead)
- [x] Post-fix run: all tests pass
- [x] Full \`./gradlew :scrimage-tests:test\` green