### PR TITLE
Fix off-by-one boundary assertions in subpixelSubimage

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1418,10 +1418,15 @@ public class ImmutableImage extends MutableImage {
                                           double y,
                                           int subWidth,
                                           int subHeight) {
+      // The loop reads subpixel(xIndex + x) for xIndex in [0, subWidth),
+      // so the maximum sub-pixel x argument is (subWidth - 1) + x. The
+      // subpixel() contract requires arg < width, hence x + subWidth ≤ width.
+      // Same applies to y / subHeight / height. The previous bounds used
+      // strict < and rejected valid full-width / full-height extractions.
       assert x >= 0;
-      assert x + subWidth < width;
+      assert x + subWidth <= width;
       assert y >= 0;
-      assert y + subHeight < height;
+      assert y + subHeight <= height;
 
       // Walk the output grid and write each interpolated ARGB int directly
       // into a row-major buffer. The previous implementation allocated a

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubpixelSubimageBoundsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubpixelSubimageBoundsTest.kt
@@ -1,0 +1,56 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for ImmutableImage.subpixelSubimage's boundary
+ * assertions. The previous implementation asserted strict inequality:
+ *
+ *   assert x + subWidth < width;
+ *
+ * but the loop reads subpixel(xIndex + x) for xIndex in [0, subWidth),
+ * giving a maximum x argument of (subWidth - 1) + x. Subpixel only
+ * requires arg < width, so the actual constraint is x + subWidth ≤ width
+ * — the strict inequality rejected legitimate full-width extractions.
+ *
+ * Concrete pre-fix: subpixelSubimage(0.0, 0.0, width, height) on any
+ * image throws AssertionError when run under -ea (Gradle's default).
+ */
+class SubpixelSubimageBoundsTest : FunSpec({
+
+   test("subpixelSubimage with x + subWidth == width succeeds") {
+      val pixels = Array(16) { i -> Pixel(i % 4, i / 4, i, 0, 0, 255) }
+      val image = ImmutableImage.create(4, 4, pixels)
+      // Full width / full height — boundary case.
+      val sub = image.subpixelSubimage(0.0, 0.0, 4, 4)
+      sub.width shouldBe 4
+      sub.height shouldBe 4
+   }
+
+   test("subpixelSubimage with x + subWidth == width and offset start succeeds") {
+      val pixels = Array(16) { i -> Pixel(i % 4, i / 4, i, 0, 0, 255) }
+      val image = ImmutableImage.create(4, 4, pixels)
+      // x = 1, subWidth = 3, width = 4 — boundary on the right edge
+      val sub = image.subpixelSubimage(1.0, 1.0, 3, 3)
+      sub.width shouldBe 3
+      sub.height shouldBe 3
+   }
+
+   test("subpixelSubimage with x + subWidth > width still asserts") {
+      val image = ImmutableImage.create(4, 4)
+      shouldThrow<AssertionError> {
+         image.subpixelSubimage(0.0, 0.0, 5, 4)
+      }
+   }
+
+   test("subpixelSubimage with negative x still asserts") {
+      val image = ImmutableImage.create(4, 4)
+      shouldThrow<AssertionError> {
+         image.subpixelSubimage(-0.1, 0.0, 2, 2)
+      }
+   }
+})


### PR DESCRIPTION
## Summary
The previous assertions used strict inequality:

\`\`\`java
assert x + subWidth < width;
assert y + subHeight < height;
\`\`\`

…but the loop reads \`subpixel(xIndex + x)\` for \`xIndex\` in \`[0, subWidth)\`, so the maximum sub-pixel x argument is \`(subWidth - 1) + x\`. The \`subpixel()\` contract only requires \`arg < width\`, so the actual constraint is \`x + subWidth ≤ width\`. The strict inequality rejected legitimate full-width / full-height extractions.

Concrete pre-fix behaviour: \`subpixelSubimage(0.0, 0.0, width, height)\` on any image throws \`AssertionError\` when run with assertions enabled (Gradle's default for the \`Test\` task). The non-asserted code path underneath would have worked correctly.

## Test plan
- [x] New \`SubpixelSubimageBoundsTest\` covers: full-width / full-height extraction succeeds, off-edge extraction (start non-zero, end at edge) succeeds, out-of-bounds sizes still fail, negative coordinates still fail
- [x] Pre-fix run: 2 of 4 tests fail
- [x] Post-fix run: all tests pass