### PR TITLE
Fix empty()/blank() crashing on TYPE_CUSTOM source images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -483,9 +483,15 @@ public class AwtImage {
    /**
     * Returns a new AWTImage with the same dimensions and same AWT type.
     * The data is uninitialized.
+    * <p>
+    * If the source has BufferedImage.TYPE_CUSTOM (type 0) — which can't be
+    * fed back into the BufferedImage(width, height, type) constructor —
+    * falls back to TYPE_INT_ARGB, matching ImmutableImage.fromAwt's policy.
     */
    public AwtImage empty() {
-      return new AwtImage(new BufferedImage(width, height, awt.getType()));
+      int type = awt.getType();
+      if (type == 0) type = BufferedImage.TYPE_INT_ARGB;
+      return new AwtImage(new BufferedImage(width, height, type));
    }
 
    // See this Stack Overflow question to see why this is implemented this way.

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -447,11 +447,17 @@ public class ImmutableImage extends MutableImage {
     * the same dimensions.
     * <p>
     * The underlying pixels will not be initialized.
+    * <p>
+    * If the source has BufferedImage.TYPE_CUSTOM (type 0) — which can't be
+    * fed into a BufferedImage(width, height, type) constructor — falls back
+    * to DEFAULT_DATA_TYPE, matching fromAwt's policy.
     *
     * @return a new Image that is a clone of this image but with uninitialized data
     */
    public ImmutableImage blank() {
-      return create(width, height, getType());
+      int type = getType();
+      if (type == 0) type = DEFAULT_DATA_TYPE;
+      return create(width, height, type);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/EmptyBlankTypeCustomTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/EmptyBlankTypeCustomTest.kt
@@ -1,0 +1,71 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.color.ColorSpace
+import java.awt.image.BufferedImage
+import java.awt.image.ComponentColorModel
+import java.awt.image.DataBuffer
+
+/**
+ * Regression test for empty() and blank() crashing on TYPE_CUSTOM sources.
+ *
+ * BufferedImage.getType() returns 0 (TYPE_CUSTOM) for any image
+ * constructed from a custom Raster + ColorModel that doesn't match a
+ * predefined type. The previous implementations of empty() and blank()
+ * passed that 0 into the BufferedImage(int, int, int) constructor, which
+ * throws "Unknown image type 0".
+ *
+ * The fix falls back to TYPE_INT_ARGB (matching fromAwt's existing
+ * policy) so empty() / blank() never crash on a valid input image.
+ */
+class EmptyBlankTypeCustomTest : FunSpec({
+
+   // Build a TYPE_CUSTOM BufferedImage. 16-bit-per-channel RGB has no
+   // predefined BufferedImage type, so wrapping a USHORT-based RGB raster
+   // in a ComponentColorModel produces TYPE_CUSTOM.
+   fun customTypeImage(w: Int, h: Int): BufferedImage {
+      val cs = ColorSpace.getInstance(ColorSpace.CS_sRGB)
+      val cm = ComponentColorModel(cs, intArrayOf(16, 16, 16), false, false,
+         java.awt.Transparency.OPAQUE, DataBuffer.TYPE_USHORT)
+      val raster = cm.createCompatibleWritableRaster(w, h)
+      return BufferedImage(cm, raster, false, null)
+   }
+
+   test("source has type 0 (TYPE_CUSTOM) — sanity check fixture") {
+      customTypeImage(2, 2).type shouldBe BufferedImage.TYPE_CUSTOM
+   }
+
+   test("empty() does not throw on a TYPE_CUSTOM source") {
+      val image = ImmutableImage.wrapAwt(customTypeImage(3, 4))
+      val blank = image.empty()
+      blank.width shouldBe 3
+      blank.height shouldBe 4
+      // Falls back to TYPE_INT_ARGB rather than dying with
+      // "Unknown image type 0"
+      blank.awt().type shouldBe BufferedImage.TYPE_INT_ARGB
+   }
+
+   test("blank() does not throw on a TYPE_CUSTOM source") {
+      val image = ImmutableImage.wrapAwt(customTypeImage(2, 5))
+      val blank = image.blank()
+      blank.width shouldBe 2
+      blank.height shouldBe 5
+      blank.awt().type shouldBe BufferedImage.TYPE_INT_ARGB
+   }
+
+   test("empty() preserves dimensions and AWT type for non-custom sources") {
+      val image = ImmutableImage.create(7, 4, BufferedImage.TYPE_INT_ARGB)
+      val blank = image.empty()
+      blank.width shouldBe 7
+      blank.height shouldBe 4
+      blank.awt().type shouldBe BufferedImage.TYPE_INT_ARGB
+   }
+
+   test("blank() preserves the source's AWT type for non-custom sources") {
+      val image = ImmutableImage.create(2, 2, BufferedImage.TYPE_INT_RGB)
+      val blank = image.blank()
+      blank.awt().type shouldBe BufferedImage.TYPE_INT_RGB
+   }
+})


### PR DESCRIPTION
## Summary
\`BufferedImage.getType()\` returns 0 (TYPE_CUSTOM) for any image constructed from a custom Raster + ColorModel that doesn't match a predefined type — for example a 16-bit-per-channel RGB image. Both \`AwtImage.empty()\` and \`ImmutableImage.blank()\` forwarded that 0 into the \`BufferedImage(int, int, int)\` constructor, which throws:

\`\`\`
java.lang.IllegalArgumentException: Unknown image type 0
\`\`\`

\`ImmutableImage.fromAwt(BufferedImage, int)\` already handles this: it falls back to TYPE_INT_ARGB when the requested type is 0. Apply the same policy to \`empty()\` and \`blank()\` so they never crash on a valid input image.

## Test plan
- [x] New \`EmptyBlankTypeCustomTest\` covers:
  - sanity check that the test fixture (USHORT-based ComponentColorModel) is genuinely TYPE_CUSTOM
  - \`empty()\` returns a TYPE_INT_ARGB image with the same dimensions
  - \`blank()\` returns a TYPE_INT_ARGB image with the same dimensions
  - non-custom sources still preserve their AWT type through both methods
- [x] Pre-fix: 2 of 5 fail with "Unknown image type 0"
- [x] Post-fix: all 5 pass