### PR TITLE
Fix scaleTo silently dropping image metadata for non-FastScale methods

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1387,25 +1387,24 @@ public class ImmutableImage extends MutableImage {
                return wrapAwt(fastScaleAwt(targetWidth, targetHeight), metadata);
          case Lanczos3:
             Lanczos3Filter lan = ResampleFilters.lanczos3Filter;
-            ImmutableImage s1 = op(new ResampleOp(lan, targetWidth, targetHeight));
-            return wrapAwt(s1.awt(), s1.awt().getType());
+            // op() preserves metadata; the previous code re-wrapped via
+            // wrapAwt(awt, type) which uses ImageMetadata.empty and silently
+            // dropped EXIF/etc. on every scale.
+            return op(new ResampleOp(lan, targetWidth, targetHeight));
          case BSpline:
             BSplineFilter bs = ResampleFilters.bSplineFilter;
-            ImmutableImage s2 = op(new ResampleOp(bs, targetWidth, targetHeight));
-            return wrapAwt(s2.awt(), s2.awt().getType());
+            return op(new ResampleOp(bs, targetWidth, targetHeight));
          case Bilinear:
             TriangleFilter t = ResampleFilters.triangleFilter;
-            ImmutableImage s3 = op(new ResampleOp(t, targetWidth, targetHeight));
-            return wrapAwt(s3.awt(), s3.awt().getType());
+            return op(new ResampleOp(t, targetWidth, targetHeight));
          case Progressive:
             if (targetWidth >= width || targetHeight >= height)
                return scaleTo(targetWidth, targetHeight, ScaleMethod.Bicubic);
             BufferedImage result = ProgressiveScale.scale(awt(), targetWidth, targetHeight, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-            return wrapAwt(result);
+            return wrapAwt(result, metadata);
          case Bicubic:
             BiCubicFilter b = ResampleFilters.biCubicFilter;
-            ImmutableImage s4 = op(new ResampleOp(b, targetWidth, targetHeight));
-            return wrapAwt(s4.awt());
+            return op(new ResampleOp(b, targetWidth, targetHeight));
          default:
             throw new UnsupportedOperationException();
       }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ScaleToMetadataTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ScaleToMetadataTest.kt
@@ -1,0 +1,62 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import com.sksamuel.scrimage.metadata.ImageMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression test for ImmutableImage.scaleTo silently dropping image
+ * metadata for every scale method except FastScale.
+ *
+ * The previous implementation routed Bicubic / Lanczos3 / BSpline /
+ * Bilinear / Progressive through `op(...)` (which preserves metadata)
+ * and then immediately re-wrapped via wrapAwt(awt) or wrapAwt(awt, type)
+ * — both of those overloads use ImageMetadata.empty, silently throwing
+ * the metadata away.
+ *
+ * Net effect: any user who scaled a JPEG before, say, writing it back
+ * out with another writer lost their EXIF data on the way.
+ */
+class ScaleToMetadataTest : FunSpec({
+
+   val original = ImmutableImage.loader().fromResource("/vossen.jpg")
+
+   test("source image has non-empty metadata (sanity check on the fixture)") {
+      original.metadata.tags().toList().shouldNotBeEmpty()
+      original.metadata shouldNotBe ImageMetadata.empty
+   }
+
+   test("scaleTo with Bicubic preserves metadata") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.Bicubic)
+      scaled.metadata shouldBe original.metadata
+   }
+
+   test("scaleTo with Lanczos3 preserves metadata") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.Lanczos3)
+      scaled.metadata shouldBe original.metadata
+   }
+
+   test("scaleTo with BSpline preserves metadata") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.BSpline)
+      scaled.metadata shouldBe original.metadata
+   }
+
+   test("scaleTo with Bilinear preserves metadata") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.Bilinear)
+      scaled.metadata shouldBe original.metadata
+   }
+
+   test("scaleTo with Progressive (downscale) preserves metadata") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.Progressive)
+      scaled.metadata shouldBe original.metadata
+   }
+
+   test("scaleTo with FastScale preserves metadata (already worked)") {
+      val scaled = original.scaleTo(100, 75, ScaleMethod.FastScale)
+      scaled.metadata shouldBe original.metadata
+   }
+})


### PR DESCRIPTION
## Summary
Every scale method except FastScale routed the result through one of:

\`\`\`java
wrapAwt(scaled.awt())              // Bicubic, Progressive
wrapAwt(scaled.awt(), type)        // Lanczos3, BSpline, Bilinear
\`\`\`

Both overloads use \`ImageMetadata.empty\` internally — so the metadata that \`op()\` carefully carried through to the intermediate \`ImmutableImage\` was thrown away on the very next line. **Net effect**: any user who scaled a JPEG (the common form) before writing it back out silently lost their EXIF data on the way.

For Bicubic / Lanczos3 / BSpline / Bilinear, just return the result of \`op(...)\` directly — \`op()\` already preserves metadata. For Progressive, switch \`wrapAwt(result)\` → \`wrapAwt(result, metadata)\`.

The defensive \`wrapAwt(awt, type)\` call was a no-op type-wise (the result of \`op()\` already has the type we ask for), so removing it has no functional effect besides preserving metadata.

## Test plan
- [x] New \`ScaleToMetadataTest\` covers metadata round-trip across all six scale methods using the existing \`/vossen.jpg\` fixture which already carries EXIF tags
- [x] Pre-fix: 5 of 7 tests fail (every non-FastScale method)
- [x] Post-fix: all 7 pass
- [x] Full \`./gradlew :scrimage-tests:test\` green