### PR TITLE
Fix copy() silently dropping metadata, cascading to map/contrast/brightness/etc

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -496,7 +496,12 @@ public class ImmutableImage extends MutableImage {
     * @return A copy of this image.
     */
    public ImmutableImage copy() {
-      return fromAwt(awt());
+      // fromAwt(BufferedImage) intentionally uses ImageMetadata.empty
+      // because it doesn't know the source's metadata association — but
+      // copy() does, so re-attach it. Without this, every method that
+      // routes through copy() (map, filter, contrast, brightness,
+      // removeTransparency, composite, overlay, ...) silently strips EXIF.
+      return fromAwt(awt()).associateMetadata(metadata);
    }
 
    /**
@@ -504,7 +509,7 @@ public class ImmutableImage extends MutableImage {
     * The type value is one of the AWT standard image types, taken from BufferedImage.
     */
    public ImmutableImage copy(int type) {
-      return fromAwt(awt(), type);
+      return fromAwt(awt(), type).associateMetadata(metadata);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyMetadataTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyMetadataTest.kt
@@ -1,0 +1,76 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.composite.AlphaComposite
+import com.sksamuel.scrimage.metadata.ImageMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for ImmutableImage.copy() silently dropping image
+ * metadata, plus the cascade of methods that route through copy()
+ * internally.
+ *
+ * The previous copy() implementation:
+ *
+ *   public ImmutableImage copy() {
+ *      return fromAwt(awt());
+ *   }
+ *
+ * fromAwt(BufferedImage) intentionally uses ImageMetadata.empty (it
+ * doesn't know the source's metadata association), so copy() inherited
+ * that — every method built on copy() (map, filter, contrast, brightness,
+ * removeTransparency, composite, overlay, ...) silently stripped EXIF.
+ *
+ * This is observed for example with: load JPEG with EXIF → contrast(2)
+ * → write JPEG: EXIF gone.
+ */
+class CopyMetadataTest : FunSpec({
+
+   val original = ImmutableImage.loader().fromResource("/vossen.jpg")
+
+   test("source image has non-empty metadata (sanity check on the fixture)") {
+      original.metadata.tags().toList().shouldNotBeEmpty()
+      original.metadata shouldNotBe ImageMetadata.empty
+   }
+
+   test("copy() preserves metadata") {
+      original.copy().metadata shouldBe original.metadata
+   }
+
+   test("copy(type) preserves metadata") {
+      original.copy(BufferedImage.TYPE_INT_ARGB).metadata shouldBe original.metadata
+   }
+
+   test("map() preserves metadata (uses copy internally)") {
+      original.map { p -> p.toColor().awt() }.metadata shouldBe original.metadata
+   }
+
+   test("contrast() preserves metadata (uses copy internally)") {
+      original.contrast(1.5).metadata shouldBe original.metadata
+   }
+
+   test("brightness() preserves metadata (uses copy internally)") {
+      original.brightness(1.2).metadata shouldBe original.metadata
+   }
+
+   test("removeTransparency() preserves metadata (uses copy internally)") {
+      original.removeTransparency(java.awt.Color.WHITE).metadata shouldBe original.metadata
+   }
+
+   test("overlay(image) preserves metadata (uses copy internally)") {
+      val overlay = ImmutableImage.create(10, 10, BufferedImage.TYPE_INT_ARGB)
+      overlay.fillInPlace(RGBColor(255, 0, 0, 128).awt())
+      original.overlay(overlay, 0, 0).metadata shouldBe original.metadata
+   }
+
+   test("composite() preserves metadata (uses copy internally)") {
+      val applicative = ImmutableImage.create(original.width, original.height, BufferedImage.TYPE_INT_ARGB)
+      applicative.fillInPlace(RGBColor(0, 0, 255, 64).awt())
+      original.composite(AlphaComposite(0.5), applicative).metadata shouldBe original.metadata
+   }
+})


### PR DESCRIPTION
## Summary
\`ImmutableImage.copy()\` was:

\`\`\`java
public ImmutableImage copy() {
   return fromAwt(awt());
}
\`\`\`

\`fromAwt(BufferedImage)\` intentionally uses \`ImageMetadata.empty\` (it doesn't know the source's metadata association). \`copy()\` inherited that — so the entire family of methods built on \`copy()\` silently stripped EXIF / XMP / IPTC metadata:

- \`map(Function<Pixel, Color>)\`
- \`filter(Filter)\` / \`filter(Filter...)\`
- \`contrast(double)\`
- \`brightness(double)\`
- \`removeTransparency(Color)\`
- \`composite(Composite, ImmutableImage)\`
- \`overlay(AwtImage, int, int)\` / \`overlay(ImmutableImage, Position)\`

Re-attach this image's metadata onto the result of \`fromAwt\`. Same fix for \`copy(int type)\`. The \`fromAwt → wrapAwt → ImageMetadata.empty\` chain stays as-is (it's correct for that entry point), but \`copy()\` now covers up the loss.

## Test plan
- [x] New \`CopyMetadataTest\` pins metadata round-trip across \`copy()\`, \`copy(type)\`, and the seven derived methods listed above using the existing \`/vossen.jpg\` fixture which carries EXIF tags
- [x] **Pre-fix: 8 of 9 tests fail** (only the sanity check on the source passes)
- [x] Post-fix: all 9 pass
- [x] Full \`./gradlew :scrimage-tests:test\` green

## Note
This fix is complementary to #420 (\`scaleTo\` metadata loss). The remaining family of "canvas resize" methods — \`resizeTo\`, \`padWith\`, \`padTo\`, \`translate\`, \`cover\`, \`fit\` — still drop metadata via \`filled()\` / \`blank()\`; those are out of scope for this PR.