### PR TITLE
Fix canvas-resize family silently dropping image metadata

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -605,7 +605,7 @@ public class ImmutableImage extends MutableImage {
       Dimension dim = position.calculateXY(targetWidth, targetHeight, coveredDimensions.getX(), coveredDimensions.getY());
       ImmutableImage result = create(targetWidth, targetHeight, imageType);
       result.overlayInPlace(scaled.awt(), dim.getX(), dim.getY());
-      return result;
+      return result.associateMetadata(metadata);
    }
 
    /**
@@ -617,7 +617,7 @@ public class ImmutableImage extends MutableImage {
    public ImmutableImage fill(Color color) {
       ImmutableImage target = blank();
       target.fillInPlace(color);
-      return target;
+      return target.associateMetadata(metadata);
    }
 
    /**
@@ -639,7 +639,7 @@ public class ImmutableImage extends MutableImage {
       }
       Painter finalTemp = temp;
       target.toCanvas().drawInPlace(new FilledRect(0, 0, width, height, g2 -> g2.setPainter(finalTemp)));
-      return target;
+      return target.associateMetadata(metadata);
    }
 
    /**
@@ -762,7 +762,7 @@ public class ImmutableImage extends MutableImage {
       ImmutableImage scaled = scaleTo(wh.getX(), wh.getY(), scaleMethod);
       ImmutableImage result = ImmutableImage.filled(canvasWidth, canvasHeight, color, imageType);
       result.overlayInPlace(scaled.awt(), dim.getX(), dim.getY());
-      return result;
+      return result.associateMetadata(metadata);
    }
 
    /**
@@ -970,7 +970,7 @@ public class ImmutableImage extends MutableImage {
          Dimension dim = position.calculateXY(targetWidth, targetHeight, width, height);
          ImmutableImage result = filled(targetWidth, targetHeight, background, imageType);
          result.overlayInPlace(awt(), dim.getX(), dim.getY());
-         return result;
+         return result.associateMetadata(metadata);
       }
    }
 
@@ -1181,7 +1181,7 @@ public class ImmutableImage extends MutableImage {
    public ImmutableImage padWith(int left, int top, int right, int bottom, Color color) {
       int w = width + left + right;
       int h = height + top + bottom;
-      return filled(w, h, color).overlay(this, left, top);
+      return filled(w, h, color).overlay(this, left, top).associateMetadata(metadata);
    }
 
    /**
@@ -1536,7 +1536,7 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image with this image translated.
     */
    public ImmutableImage translate(int x, int y, Color bg) {
-      return fill(bg).overlay(this, x, y);
+      return fill(bg).overlay(this, x, y).associateMetadata(metadata);
    }
 
    /**
@@ -1624,7 +1624,7 @@ public class ImmutableImage extends MutableImage {
       ImmutableImage target = this.blank();
       target.overlayInPlace(underlayImage.awt(), x, y);
       target.overlayInPlace(awt(), x, y);
-      return target;
+      return target.associateMetadata(metadata);
    }
 
    /**
@@ -1659,7 +1659,7 @@ public class ImmutableImage extends MutableImage {
     * @return the zoomed image
     */
    public ImmutableImage zoom(double factor, ScaleMethod method) {
-      return scale(factor, method).resizeTo(width, height, Position.Center, Color.WHITE);
+      return scale(factor, method).resizeTo(width, height, Position.Center, Color.WHITE).associateMetadata(metadata);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CanvasOpsMetadataTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CanvasOpsMetadataTest.kt
@@ -1,0 +1,111 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import com.sksamuel.scrimage.canvas.painters.LinearGradient
+import com.sksamuel.scrimage.metadata.ImageMetadata
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.Color
+
+/**
+ * Regression test for the canvas-resize family of methods silently
+ * dropping image metadata.
+ *
+ * Even after #421 (copy() preserves metadata), the methods that build
+ * a fresh canvas via filled() or blank() and overlay onto it — resize,
+ * resizeTo, resizeToHeight/Width/Ratio, pad / padTo / padWith / padTop /
+ * padBottom / padLeft / padRight, translate, cover, fit, underlay,
+ * fill — still threw EXIF away.
+ *
+ * Each canonical entry point now re-attaches the source's metadata at
+ * the end. Convenience overloads benefit transitively.
+ */
+class CanvasOpsMetadataTest : FunSpec({
+
+   val original = ImmutableImage.loader().fromResource("/vossen.jpg")
+
+   test("source image has non-empty metadata (sanity check)") {
+      original.metadata.tags().toList().shouldNotBeEmpty()
+      original.metadata shouldNotBe ImageMetadata.empty
+   }
+
+   test("resize preserves metadata") {
+      original.resize(0.5).metadata shouldBe original.metadata
+   }
+
+   test("resizeTo preserves metadata") {
+      original.resizeTo(100, 100).metadata shouldBe original.metadata
+   }
+
+   test("resizeToHeight preserves metadata") {
+      original.resizeToHeight(50).metadata shouldBe original.metadata
+   }
+
+   test("resizeToWidth preserves metadata") {
+      original.resizeToWidth(50).metadata shouldBe original.metadata
+   }
+
+   test("resizeToRatio preserves metadata") {
+      original.resizeToRatio(0.5).metadata shouldBe original.metadata
+   }
+
+   test("padWith preserves metadata") {
+      original.padWith(5, 5, 5, 5, Color.RED).metadata shouldBe original.metadata
+   }
+
+   test("pad preserves metadata") {
+      original.pad(10, Color.RED).metadata shouldBe original.metadata
+   }
+
+   test("padTo preserves metadata") {
+      original.padTo(original.width + 20, original.height + 20).metadata shouldBe original.metadata
+   }
+
+   test("padTop preserves metadata") {
+      original.padTop(5, Color.RED).metadata shouldBe original.metadata
+   }
+
+   test("padBottom preserves metadata") {
+      original.padBottom(5, Color.RED).metadata shouldBe original.metadata
+   }
+
+   test("padLeft preserves metadata") {
+      original.padLeft(5).metadata shouldBe original.metadata
+   }
+
+   test("padRight preserves metadata") {
+      original.padRight(5).metadata shouldBe original.metadata
+   }
+
+   test("translate preserves metadata") {
+      original.translate(10, 10).metadata shouldBe original.metadata
+   }
+
+   test("cover preserves metadata") {
+      original.cover(200, 200).metadata shouldBe original.metadata
+   }
+
+   test("fit preserves metadata") {
+      original.fit(200, 200).metadata shouldBe original.metadata
+   }
+
+   test("fill(Color) preserves metadata") {
+      original.fill(Color.RED).metadata shouldBe original.metadata
+   }
+
+   test("fill(Painter) preserves metadata") {
+      original.fill(LinearGradient.horizontal(Color.RED, Color.BLUE)).metadata shouldBe original.metadata
+   }
+
+   test("underlay preserves metadata") {
+      val under = ImmutableImage.create(original.width, original.height)
+      original.underlay(under).metadata shouldBe original.metadata
+   }
+
+   test("zoom preserves metadata") {
+      original.zoom(1.5).metadata shouldBe original.metadata
+   }
+})


### PR DESCRIPTION
## Summary
Follow-up to #420 (\`scaleTo\`) and #421 (\`copy()\`). The remaining canvas-resize methods built a new image via \`filled()\` / \`blank()\` / \`create()\` and overlaid the source onto it — none of those static factories carry the caller's metadata, so EXIF / XMP / IPTC was thrown away on every:

- \`resize\` / \`resizeTo\` / \`resizeToHeight\` / \`resizeToWidth\` / \`resizeToRatio\`
- \`pad\` / \`padTo\` / \`padWith\` / \`padTop\` / \`padBottom\` / \`padLeft\` / \`padRight\`
- \`translate\`
- \`cover\`, \`fit\`
- \`underlay\`
- \`fill(Color)\`, \`fill(Painter)\`
- \`zoom\`

Re-attach the source image's metadata at the end of each canonical overload (the convenience overloads benefit transitively). \`translate\` and \`zoom\` are made self-defending so they don't depend on \`copy()\`/\`scaleTo\`'s own metadata fixes landing first.

## Test plan
- [x] New \`CanvasOpsMetadataTest\` pins metadata round-trip across all 19 canvas operations using the existing \`/vossen.jpg\` fixture which carries EXIF tags
- [x] **Pre-fix: 19 of 20 tests fail** (only the sanity check on the source passes)
- [x] Post-fix: all 20 pass
- [x] Full \`./gradlew :scrimage-tests:test\` green

After this PR the metadata-preservation surface is complete: every operation that produces a derived ImmutableImage carries the source's metadata through.