### PR TITLE
Fix FormatDetector.detect(InputStream) breaking WEBP detection on partial reads

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/format/FormatDetector.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/format/FormatDetector.java
@@ -20,8 +20,14 @@ public class FormatDetector {
     private static byte[] webp2 = new byte[]{'W', 'E', 'B', 'P'};
 
     public static Optional<Format> detect(InputStream in) throws IOException {
-        byte[] bytes = new byte[12];
-        in.read(bytes, 0, 12);
+        // InputStream.read(byte[], int, int) is documented as "an attempt is
+        // made to read up to len bytes" — it MAY return fewer. For slow
+        // streams (network, decompressed) a single read commonly returns
+        // less than 12 bytes, leaving the tail of `bytes` zero-filled. WEBP
+        // signatures live at offset 8 ("WEBP" after RIFF + length) so a
+        // partial read silently breaks WEBP detection. readNBytes blocks
+        // until it has all the bytes (or EOF).
+        byte[] bytes = in.readNBytes(12);
         return detect(bytes);
     }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FormatDetectorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FormatDetectorTest.kt
@@ -7,6 +7,8 @@ import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 class FormatDetectorTest : WordSpec({
 
@@ -30,6 +32,37 @@ class FormatDetectorTest : WordSpec({
          shouldThrowAny {
             ImmutableImageLoader.create().fromResource("/spacedock.webp")
          }.message shouldContain "Image parsing failed for WEBP"
+      }
+   }
+
+   // Wraps a stream so each read() / read(byte[], int, int) call returns
+   // at most `chunkSize` bytes. Mimics network or decompressed streams
+   // that don't satisfy a 12-byte read in one shot.
+   class DribbleInputStream(private val source: InputStream, private val chunkSize: Int) : InputStream() {
+      override fun read(): Int = source.read()
+      override fun read(b: ByteArray, off: Int, len: Int): Int =
+         source.read(b, off, minOf(len, chunkSize))
+   }
+
+   // Regression: detect(InputStream) used in.read(byte[], 0, 12) which is
+   // documented as "an attempt is made to read up to len bytes" — so it
+   // can return fewer. WEBP signatures live at offset 8, so a partial read
+   // of just the RIFF header silently mis-detected as no format.
+   "detect(InputStream) handles partial reads (regression)" should {
+      "detect WEBP from a stream that returns 4 bytes at a time" {
+         val webpBytes = javaClass.getResourceAsStream("/com/sksamuel/scrimage/landscape.webp")!!.readBytes()
+         val drip = DribbleInputStream(ByteArrayInputStream(webpBytes), 4)
+         FormatDetector.detect(drip).get() shouldBe Format.WEBP
+      }
+      "detect JPEG from a stream that returns 1 byte at a time" {
+         val jpegBytes = javaClass.getResourceAsStream("/com/sksamuel/scrimage/bird.jpg")!!.readBytes()
+         val drip = DribbleInputStream(ByteArrayInputStream(jpegBytes), 1)
+         FormatDetector.detect(drip).get() shouldBe Format.JPEG
+      }
+      "detect PNG from a stream that returns 3 bytes at a time" {
+         val pngBytes = javaClass.getResourceAsStream("/com/sksamuel/scrimage/chip_pad.png")!!.readBytes()
+         val drip = DribbleInputStream(ByteArrayInputStream(pngBytes), 3)
+         FormatDetector.detect(drip).get() shouldBe Format.PNG
       }
    }
 


### PR DESCRIPTION
## Summary
\`InputStream.read(byte[], int, int)\` is documented as *"an attempt is made to read up to len bytes"* — it may return fewer. For slow streams (network, decompressed) a single read commonly returns less than 12 bytes, leaving the tail of the target buffer zero-filled. The \`byte[]\` overload is then asked to detect a format from a buffer where bytes beyond the first read chunk are zero.

The 4-byte signatures (GIF, JPEG, PNG) survive this because they live at offset 0, but **WEBP** signatures live at offset 8 (\`"WEBP"\` after the 4-byte \`"RIFF"\` magic and 4-byte length field), so a partial read of just the first chunk of a WEBP stream returns \`Optional.empty()\` — silently mis-detecting the file as an unknown format.

Switch to \`InputStream.readNBytes(12)\`, which blocks until 12 bytes are available (or EOF). Java 11+ API, fine since the project already targets \`JVM_11\`.

## Test plan
- [x] New tests use a \`DribbleInputStream\` that returns 1, 3, or 4 bytes per \`read()\` for JPEG, PNG, and WEBP fixtures respectively
- [x] Pre-fix: 3 of 3 new tests fail
- [x] Post-fix: all pass
- [x] Existing FormatDetector tests remain green