### PR TITLE
Remove leftover debug println from SnowFilter.apply

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SnowFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SnowFilter.java
@@ -41,7 +41,6 @@ public class SnowFilter implements IntFilter {
       Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
       g2.setComposite(new BlendComposite(BlendingMode.SCREEN, 1.0f));
       g2.drawImage(scaled.awt(), 0, 0, null);
-      System.out.println(System.currentTimeMillis());
       g2.dispose();
    }
 }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SnowFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SnowFilterTest.kt
@@ -5,6 +5,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 
 class SnowFilterTest : FunSpec() {
    init {
@@ -34,6 +36,21 @@ class SnowFilterTest : FunSpec() {
          image.copy(BufferedImage.TYPE_4BYTE_ABGR)
          image.filter(filter).width shouldBe 388
          image.filter(filter).pixel(0, 0) shouldNotBe image.pixel(0, 0)
+      }
+
+      // Regression: apply() ended with `System.out.println(System.currentTimeMillis())` —
+      // leftover debug code that printed a timestamp on every filter application.
+      test("apply does not print to stdout") {
+         val image = ImmutableImage.create(64, 64, BufferedImage.TYPE_INT_ARGB)
+         val originalOut = System.out
+         val captured = ByteArrayOutputStream()
+         try {
+            System.setOut(PrintStream(captured))
+            filter.apply(image)
+         } finally {
+            System.setOut(originalOut)
+         }
+         captured.toByteArray().size shouldBe 0
       }
    }
 }


### PR DESCRIPTION
## Summary
\`SnowFilter.apply\` was emitting \`System.out.println(System.currentTimeMillis())\` between \`drawImage\` and \`dispose\` — almost certainly a leftover from a local timing experiment that never got removed. Every application of SnowFilter polluted the calling program's stdout with a millisecond timestamp.

## Test plan
- [x] New \`apply does not print to stdout\` test in \`SnowFilterTest\` swaps \`System.out\` for a \`ByteArrayOutputStream\` during the call and asserts nothing was written
- [x] Pre-fix: new test fails (16 bytes captured — the timestamp + newline)
- [x] Post-fix: passes
- [x] Existing SnowFilter type-coverage tests remain green

Found during a wider audit of Graphics2D usages (follow-up to #414/#416/#425).