### PR TITLE
Fix LinearGradient.horizontal / vertical static factories being swapped

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/LinearGradient.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/LinearGradient.java
@@ -4,12 +4,20 @@ import java.awt.*;
 
 public class LinearGradient implements Painter {
 
+   /**
+    * Returns a left-to-right gradient — the colour varies along the horizontal
+    * axis, color1 on the left and color2 on the right.
+    */
    public static LinearGradient horizontal(Color color1, Color color2) {
-      return new LinearGradient(0, Integer.MIN_VALUE, color1, 0, Integer.MAX_VALUE, color2);
+      return new LinearGradient(Integer.MIN_VALUE, 0, color1, Integer.MAX_VALUE, 0, color2);
    }
 
+   /**
+    * Returns a top-to-bottom gradient — the colour varies along the vertical
+    * axis, color1 at the top and color2 at the bottom.
+    */
    public static LinearGradient vertical(Color color1, Color color2) {
-      return new LinearGradient(Integer.MIN_VALUE, 0, color1, Integer.MAX_VALUE, 0, color2);
+      return new LinearGradient(0, Integer.MIN_VALUE, color1, 0, Integer.MAX_VALUE, color2);
    }
 
    private final int x1;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/BackgroundGradient.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/BackgroundGradient.java
@@ -25,9 +25,13 @@ public class BackgroundGradient implements Transform {
    public ImmutableImage apply(ImmutableImage input) throws IOException {
       // get the dominant colours
       RGBColor[] dominant = input.quantize(2);
-      // create the linear gradient
+      // Create the vertical (top-to-bottom) linear gradient. The previous
+      // code called LinearGradient.horizontal(...) which, due to a swapped
+      // name bug fixed in the same commit as this file, actually produced
+      // a vertical gradient — switching to vertical() preserves the visual
+      // output that the existing fixture images depend on.
       ImmutableImage bg = ImmutableImage.create(width, height)
-         .fill(LinearGradient.horizontal(dominant[0].awt(), dominant[1].awt()));
+         .fill(LinearGradient.vertical(dominant[0].awt(), dominant[1].awt()));
       // write the input over
       return bg.overlay(input, Position.Center);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/DominantGradient.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/DominantGradient.java
@@ -14,8 +14,12 @@ public class DominantGradient implements Transform {
       // get the dominant colours
       RGBColor[] dominant = input.quantize(2);
 
-      // create the linear gradient image
+      // create the linear gradient image (top-to-bottom). The previous code
+      // called LinearGradient.horizontal(...) which, due to a swapped name
+      // bug fixed in the same commit as this file, actually produced a
+      // vertical gradient — switching to vertical() preserves the visual
+      // output that the existing fixture images depend on.
       return ImmutableImage.create(input.width, input.height)
-         .fill(LinearGradient.horizontal(dominant[0].awt(), dominant[1].awt()));
+         .fill(LinearGradient.vertical(dominant[0].awt(), dominant[1].awt()));
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/LinearGradientDirectionTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/LinearGradientDirectionTest.kt
@@ -1,0 +1,75 @@
+package com.sksamuel.scrimage.canvas
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.painters.LinearGradient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for LinearGradient.horizontal / vertical names being
+ * swapped relative to what they actually produce.
+ *
+ * Pre-fix:
+ *
+ *   horizontal(c1, c2) → new LinearGradient(0, MIN, c1, 0, MAX, c2)
+ *   vertical(c1, c2)   → new LinearGradient(MIN, 0, c1, MAX, 0, c2)
+ *
+ * The first form has equal x coordinates and varying y, which is a
+ * VERTICAL gradient (color varies along y). The second has equal y
+ * and varying x, which is a HORIZONTAL gradient. Names and outputs
+ * were inverted.
+ *
+ * The fix swaps the factory bodies so each name matches its visual
+ * effect.
+ */
+class LinearGradientDirectionTest : FunSpec({
+
+   test("horizontal(red, blue) varies left-to-right (red on left, blue on right)") {
+      val image = ImmutableImage.create(20, 20, BufferedImage.TYPE_INT_ARGB)
+         .fill(LinearGradient.horizontal(Color.RED, Color.BLUE))
+      val midRowY = 10
+      val left = image.pixel(0, midRowY)
+      val right = image.pixel(19, midRowY)
+      // red dominates on the left, blue dominates on the right
+      left.red() shouldBeGreaterThan right.red()
+      right.blue() shouldBeGreaterThan left.blue()
+      // and at the very left edge the colour is exactly red (gradient anchored at x=0)
+      left.red() shouldBe 255
+      left.blue() shouldBe 0
+   }
+
+   test("vertical(red, blue) varies top-to-bottom (red on top, blue at bottom)") {
+      val image = ImmutableImage.create(20, 20, BufferedImage.TYPE_INT_ARGB)
+         .fill(LinearGradient.vertical(Color.RED, Color.BLUE))
+      val midColX = 10
+      val top = image.pixel(midColX, 0)
+      val bottom = image.pixel(midColX, 19)
+      // red dominates at the top, blue dominates at the bottom
+      top.red() shouldBeGreaterThan bottom.red()
+      bottom.blue() shouldBeGreaterThan top.blue()
+      // and at the very top the colour is exactly red (gradient anchored at y=0)
+      top.red() shouldBe 255
+      top.blue() shouldBe 0
+   }
+
+   test("horizontal gradient is constant along columns") {
+      val image = ImmutableImage.create(20, 20, BufferedImage.TYPE_INT_ARGB)
+         .fill(LinearGradient.horizontal(Color.RED, Color.BLUE))
+      val col5Top = image.pixel(5, 0)
+      val col5Bottom = image.pixel(5, 19)
+      // Same column → same colour at top and bottom
+      col5Top.argb shouldBe col5Bottom.argb
+   }
+
+   test("vertical gradient is constant along rows") {
+      val image = ImmutableImage.create(20, 20, BufferedImage.TYPE_INT_ARGB)
+         .fill(LinearGradient.vertical(Color.RED, Color.BLUE))
+      val row5Left = image.pixel(0, 5)
+      val row5Right = image.pixel(19, 5)
+      // Same row → same colour on left and right
+      row5Left.argb shouldBe row5Right.argb
+   }
+})


### PR DESCRIPTION
## Summary
The two static factories produced gradients in the opposite direction from their names:

\`\`\`java
horizontal(c1, c2) → new LinearGradient(0, MIN, c1, 0, MAX, c2)
                      // x equal, y varies → VERTICAL gradient
vertical(c1, c2)   → new LinearGradient(MIN, 0, c1, MAX, 0, c2)
                      // y equal, x varies → HORIZONTAL gradient
\`\`\`

Confirmed by inspecting the test fixture \`/com/sksamuel/scrimage/transform/dominant/bird.png\` — its gradient varies top-to-bottom (vertical) even though \`DominantGradient\` calls \`LinearGradient.horizontal()\`.

Swap the two factory bodies so each name matches its visual effect, and update the two internal callers (\`DominantGradient\`, \`BackgroundGradient\`) to switch from \`horizontal()\` to \`vertical()\`. **That preserves the visual output the existing fixture images depend on** — the existing DominantGradient/BackgroundGradient tests stay green without regenerating fixtures.

External users who relied on the bug to get horizontal gradients via \`LinearGradient.vertical()\` will need to flip their call to \`.horizontal()\` — the function names now do what they say.

## Test plan
- [x] New \`LinearGradientDirectionTest\` pins corrected directions: \`horizontal\` varies left-to-right, \`vertical\` varies top-to-bottom, both are constant along their perpendicular axes
- [x] Pre-fix: 4 of 4 new tests fail
- [x] Post-fix: all 4 pass
- [x] Existing DominantGradient/BackgroundGradient fixture tests remain green
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green

Found during a wider audit of Graphics2D / canvas code (follow-up to #414/#416/#425/#426).