### PR TITLE
Fix AwtNearestNeighbourScale losing alpha precision via SrcOver

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
@@ -1,16 +1,32 @@
 package com.sksamuel.scrimage.scaling;
 
-import java.awt.*;
 import java.awt.image.BufferedImage;
 
 public class AwtNearestNeighbourScale implements Scale {
 
-    public BufferedImage scale(BufferedImage in, int w, int h) {
-        BufferedImage target = new BufferedImage(w, h, in.getType());
-        Graphics2D g2 = (Graphics2D) target.getGraphics();
-        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-        g2.drawImage(in, 0, 0, w, h, null);
-        g2.dispose();
-        return target;
-    }
+   public BufferedImage scale(BufferedImage in, int w, int h) {
+      // Bulk getRGB → manual nearest-neighbour map → bulk setRGB. The
+      // previous Graphics2D.drawImage path with NEAREST_NEIGHBOR composited
+      // via SrcOver, which premultiplied alpha and rounded away ±1 from
+      // each colour channel for non-255 alpha — same root cause as
+      // #414/#416. Doing the map ourselves is bit-exact for the standard
+      // image types (TYPE_INT_ARGB, TYPE_INT_RGB, TYPE_4BYTE_ABGR, …)
+      // because getRGB / setRGB round-trip cleanly through the colour model.
+      int srcW = in.getWidth();
+      int srcH = in.getHeight();
+      int[] src = in.getRGB(0, 0, srcW, srcH, null, 0, srcW);
+      int[] dst = new int[w * h];
+      double xRatio = (double) srcW / w;
+      double yRatio = (double) srcH / h;
+      int k = 0;
+      for (int y = 0; y < h; y++) {
+         int srcRow = ((int) (y * yRatio)) * srcW;
+         for (int x = 0; x < w; x++) {
+            dst[k++] = src[srcRow + (int) (x * xRatio)];
+         }
+      }
+      BufferedImage target = new BufferedImage(w, h, in.getType());
+      target.setRGB(0, 0, w, h, dst, 0, w);
+      return target;
+   }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/AwtNearestNeighbourScaleTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/AwtNearestNeighbourScaleTest.kt
@@ -1,0 +1,59 @@
+package com.sksamuel.scrimage.core.scaling
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for AwtNearestNeighbourScale losing channel precision
+ * when the source has alpha != 255. The previous implementation used
+ * Graphics2D.drawImage with NEAREST_NEIGHBOR interpolation, which
+ * composites via SrcOver and premultiplies alpha — losing ±1 per
+ * colour channel. Same root cause as #414 / #416 / #425.
+ *
+ * AwtNearestNeighbourScale is the FastScale path for any case that
+ * isn't "downscale on both axes AND TYPE_INT_ARGB" (those use the
+ * already-exact ScrimageNearestNeighbourScale).
+ */
+class AwtNearestNeighbourScaleTest : FunSpec({
+
+   test("FastScale up-scaling preserves alpha=128 channels exactly") {
+      // Force the AwtNearestNeighbourScale path: any dimension >= source.
+      val pixels = arrayOf(
+         Pixel(0, 0, 100, 150, 200, 128),
+         Pixel(1, 0, 50, 75, 25, 200)
+      )
+      val src = ImmutableImage.create(2, 1, pixels)
+      val scaled = src.scaleTo(4, 1, ScaleMethod.FastScale)
+      // Pixels (0, 0) and (1, 0) should be exact copies of source pixel 0
+      scaled.pixel(0, 0).red() shouldBe 100
+      scaled.pixel(0, 0).green() shouldBe 150
+      scaled.pixel(0, 0).blue() shouldBe 200
+      scaled.pixel(0, 0).alpha() shouldBe 128
+      // Pixels (2, 0) and (3, 0) should be exact copies of source pixel 1
+      scaled.pixel(2, 0).red() shouldBe 50
+      scaled.pixel(2, 0).green() shouldBe 75
+      scaled.pixel(2, 0).blue() shouldBe 25
+      scaled.pixel(2, 0).alpha() shouldBe 200
+   }
+
+   test("FastScale on TYPE_4BYTE_ABGR (non-INT_ARGB) preserves alpha exactly") {
+      // Force the AwtNearestNeighbourScale path by using a non-INT_ARGB type.
+      val src = ImmutableImage.create(2, 2, BufferedImage.TYPE_4BYTE_ABGR)
+      src.setColor(0, 0, com.sksamuel.scrimage.color.RGBColor(100, 150, 200, 128))
+      src.setColor(1, 0, com.sksamuel.scrimage.color.RGBColor(50, 75, 25, 200))
+      src.setColor(0, 1, com.sksamuel.scrimage.color.RGBColor(255, 0, 0, 64))
+      src.setColor(1, 1, com.sksamuel.scrimage.color.RGBColor(0, 255, 0, 192))
+
+      val scaled = src.scaleTo(1, 1, ScaleMethod.FastScale)
+      // 2x2 → 1x1 NN samples (0, 0)
+      val p = scaled.pixel(0, 0)
+      p.red() shouldBe 100
+      p.green() shouldBe 150
+      p.blue() shouldBe 200
+      p.alpha() shouldBe 128
+   }
+})


### PR DESCRIPTION
## Summary
Same root cause as #414 / #416 / #425. The previous implementation called \`Graphics2D.drawImage\` with NEAREST_NEIGHBOR interpolation, which composites via SrcOver and premultiplies alpha — so any source pixel with alpha != 255 came out shifted by ±1 per colour channel even though nearest-neighbour scaling should be a pure pixel copy.

Concrete pre-fix behaviour: a pixel \`(r=100, g=150, b=200, a=128)\` in the source came out as \`(r=100, g=149, b=199, a=128)\` after a TYPE_4BYTE_ABGR FastScale.

Replace the Graphics2D path with bulk \`getRGB\` → manual nearest-neighbour map → bulk \`setRGB\`. This is bit-exact for the standard image types because \`getRGB\` / \`setRGB\` round-trip cleanly through the colour model. Same dispatch surface — \`AwtNearestNeighbourScale\` is the FastScale path for cases that aren't "downscale on both axes AND TYPE_INT_ARGB" (those use the already-exact \`ScrimageNearestNeighbourScale\`).

## Test plan
- [x] New \`AwtNearestNeighbourScaleTest\` pins: 2x1 → 4x1 upscale of an alpha=128 source preserves all channels exactly; 2x2 → 1x1 downscale on TYPE_4BYTE_ABGR also preserves channels exactly
- [x] Pre-fix: 2 of 2 new tests fail
- [x] Post-fix: both pass
- [x] Existing FastScale tests stay green
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green