### PR TITLE
Fix Graphics2D resource leaks in BorderFilter and CaptionFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BorderFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BorderFilter.java
@@ -36,11 +36,14 @@ public class BorderFilter implements Filter {
     @Override
     public void apply(ImmutableImage image) {
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        g2.setColor(color);
-        g2.fillRect(0, 0, borderWidth, image.height); // left
-        g2.fillRect(image.width - borderWidth, 0, borderWidth, image.height); // right
-        g2.fillRect(0, 0, image.width, borderWidth); // top
-        g2.fillRect(0, image.height - borderWidth, image.width, borderWidth); // bottom
-
+        try {
+            g2.setColor(color);
+            g2.fillRect(0, 0, borderWidth, image.height); // left
+            g2.fillRect(image.width - borderWidth, 0, borderWidth, image.height); // right
+            g2.fillRect(0, 0, image.width, borderWidth); // top
+            g2.fillRect(0, image.height - borderWidth, image.width, borderWidth); // bottom
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CaptionFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CaptionFilter.java
@@ -62,11 +62,22 @@ public class CaptionFilter implements Filter {
     @Override
     public void apply(ImmutableImage image) {
 
+        // Graphics2D is only used here to compute font metrics. The actual
+        // drawing is done via Canvas below. Wrap in try/finally so the
+        // Graphics2D context is always released — without dispose() it
+        // leaks on every filter application.
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        g2.setFont(font);
-
-        Rectangle2D bounds = g2.getFontMetrics().getStringBounds(text, g2);
-        int descent = g2.getFontMetrics().getDescent();
+        Rectangle2D bounds;
+        int descent;
+        int fontHeight;
+        try {
+            g2.setFont(font);
+            bounds = g2.getFontMetrics().getStringBounds(text, g2);
+            descent = g2.getFontMetrics().getDescent();
+            fontHeight = g2.getFontMetrics().getHeight();
+        } finally {
+            g2.dispose();
+        }
 
         int captionWidth;
         if (fullWidth) {
@@ -103,7 +114,7 @@ public class CaptionFilter implements Filter {
         Text string = new Text(
                 text,
                 captionX + padding.left,
-                captionY + padding.top + g2.getFontMetrics().getHeight() - descent,
+                captionY + padding.top + fontHeight - descent,
                 g -> {
                     g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, (float) textAlpha));
                     g.setColor(textColor);

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BorderFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BorderFilterTest.kt
@@ -34,4 +34,19 @@ class BorderFilterTest : FunSpec({
          ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/border/love_border_red.png")
    }
 
+   // Regression: BorderFilter.apply did not call g2.dispose() on the
+   // Graphics2D it obtained — leaking the native graphics context on
+   // every call. Run a tight loop to verify the filter does not exhaust
+   // native resources after many applications.
+   test("repeated apply does not leak native graphics resources") {
+      // 500 applications of the filter against a fresh small image. Without
+      // the dispose() fix this would steadily leak Graphics2D instances
+      // (each one ties up native AWT structures); with the fix it should
+      // complete without trouble.
+      repeat(500) {
+         val target = ImmutableImage.create(64, 64)
+         BorderFilter(2, Color.RED).apply(target)
+      }
+   }
+
 })


### PR DESCRIPTION
## Summary
Both filters obtained a Graphics2D from \`image.awt().getGraphics()\` and never called \`.dispose()\` on it. The Graphics2D returned by AWT wraps native rendering state (font caches, render queue, etc.) — without the dispose call those resources stay live until the parent BufferedImage is garbage-collected.

For applications that filter many images this leaks steadily and can exhaust native AWT resources or trigger long GC pauses. Most other filters in the codebase already dispose correctly (see SummerFilter, CausticsFilter, OldPhotoFilter, …); these two were anomalies.

Wrap the Graphics2D usage in try/finally so \`dispose()\` always runs.

\`CaptionFilter\` only used the Graphics2D for font metrics — extract the values it needs into locals before disposing, then continue with the Canvas-based draw.

## Test plan
- [x] New repeated-apply loop in \`BorderFilterTest\` exercises the fix (would steadily leak without the dispose() on each iteration)
- [x] Existing fixture-comparison tests for BorderFilter remain green
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green

Found during a wider audit of Graphics2D usage (follow-up to #414/#416/#425/#426/#427).