### PR TITLE
Fix RandomPainter — every cell skipped, wrong channel order, alpha=0

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/RandomPainter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/RandomPainter.java
@@ -1,7 +1,5 @@
 package com.sksamuel.scrimage.canvas.painters;
 
-import com.sksamuel.scrimage.color.RGBColor;
-
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
@@ -35,12 +33,27 @@ public class RandomPainter implements Painter {
 
                @Override
                public Raster getRaster(int x, int y, int w, int h) {
+                  // Bugs the previous implementation had:
+                  //  - the loops incremented x / y (the method parameters),
+                  //    not x2 / y2, so only one pixel was ever written and
+                  //    the conditions terminated arbitrarily;
+                  //  - it called raster.setPixel(x2, y2, ...) using the
+                  //    GLOBAL coords rather than raster-local (0..w, 0..h),
+                  //    which would have thrown AIOOB had the loops advanced;
+                  //  - it built the channel array as [a, r, g, b] but the
+                  //    default RGB ColorModel expects [r, g, b, a];
+                  //  - it set alpha=0 on every pixel even though the Paint
+                  //    advertises Transparency.OPAQUE.
                   WritableRaster raster = getColorModel().createCompatibleWritableRaster(w, h);
                   Random r = new Random();
-                  for (int x2 = x; x2 < x + w; x++) {
-                     for (int y2 = y; y2 < y + h; y++) {
-                        RGBColor color = new RGBColor(r.nextInt(256), r.nextInt(256), r.nextInt(256), 0);
-                        raster.setPixel(x2, y2, color.toArray());
+                  int[] pixel = new int[4];
+                  pixel[3] = 255; // opaque alpha — matches getTransparency()
+                  for (int dx = 0; dx < w; dx++) {
+                     for (int dy = 0; dy < h; dy++) {
+                        pixel[0] = r.nextInt(256);
+                        pixel[1] = r.nextInt(256);
+                        pixel[2] = r.nextInt(256);
+                        raster.setPixel(dx, dy, pixel);
                      }
                   }
                   return raster;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/RandomPainterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/RandomPainterTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.scrimage.canvas
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.painters.RandomPainter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveAtLeastSize
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for RandomPainter, which had at least four bugs in
+ * its getRaster loop:
+ *
+ *  1. the outer loop wrote `x++` instead of `x2++` and the inner loop
+ *     wrote `y++` instead of `y2++`, so only one cell was ever touched
+ *     and the loops ran an arbitrary (parameter-dependent) number of
+ *     times;
+ *  2. it called raster.setPixel(x2, y2, ...) using the GLOBAL coords
+ *     rather than raster-local (0..w, 0..h) — would have thrown AIOOB
+ *     had the loops advanced;
+ *  3. it built the channel array as [alpha, red, green, blue] but the
+ *     default RGB ColorModel expects [red, green, blue, alpha], so the
+ *     channel order was wrong;
+ *  4. it set alpha=0 on every pixel even though the Paint advertised
+ *     Transparency.OPAQUE.
+ *
+ * After the fix:
+ *  - every pixel is filled
+ *  - every pixel is opaque (alpha=255)
+ *  - colours vary across pixels (the "random" property)
+ */
+class RandomPainterTest : FunSpec({
+
+   test("RandomPainter fills every pixel of the image with opaque colour") {
+      val image = ImmutableImage.create(40, 40).fill(RandomPainter())
+      // Every pixel should be opaque (was alpha=0 before the fix).
+      val alphas = image.pixels().map { it.alpha() }.toSet()
+      alphas shouldBe setOf(255)
+   }
+
+   test("RandomPainter produces varying colours across pixels") {
+      val image = ImmutableImage.create(40, 40).fill(RandomPainter())
+      // Distinct colours — well above 1, since random over a 1600-pixel area.
+      // Before the fix only one pixel was ever written so most pixels would
+      // share the (zero-initialised) background colour.
+      val distinct = image.pixels().map { it.argb }.toSet()
+      distinct shouldHaveAtLeastSize 100
+   }
+})


### PR DESCRIPTION
## Summary
The Paint returned by \`RandomPainter\` had at least four bugs in its \`PaintContext.getRaster\` implementation:

1. The outer loop wrote \`x++\` instead of \`x2++\` and the inner loop wrote \`y++\` instead of \`y2++\`, so the loop counters never moved and only one cell was ever touched. The loops still terminated because the test condition referenced \`x\` / \`y\` (which were incrementing) — but the body ran an arbitrary parameter-dependent number of times, mostly ineffectively.
2. \`setPixel(x2, y2, ...)\` used GLOBAL coords rather than raster-local (0..w, 0..h). If the loop counters HAD advanced, the call would have thrown \`ArrayIndexOutOfBoundsException\` because the raster is allocated at size (w, h) — independent of (x, y).
3. The channel array was built as \`[alpha, red, green, blue]\` but the default RGB ColorModel expects \`[red, green, blue, alpha]\`.
4. Each pixel was created with \`alpha=0\` even though the Paint advertised \`Transparency.OPAQUE\`.

**Net effect on master**: filling an image with \`RandomPainter\` took ~minutes (because of the parameter-dependent loop length) and produced a mostly-untouched image with one transparent pixel changed. The new test takes <100 ms after the fix.

## Test plan
- [x] New \`RandomPainterTest\` verifies every pixel is opaque (alpha=255) and that distinct colours appear across pixels (the random property)
- [x] **Pre-fix both tests fail**, one of them in ~87 seconds (the broken loop is performance-pathological), the other in ms
- [x] Post-fix: both pass in ms
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green