### PR TITLE
Fix WebpHandler.installBinary leaking InputStream on IO failure

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpHandler.java
@@ -42,17 +42,21 @@ abstract class WebpHandler {
       logger.info("Installing binary at {}", output);
       for (String source : sources) {
          logger.debug("Trying source from {}", source);
-         InputStream in = WebpHandler.class.getResourceAsStream(source);
-         if (in != null) {
-            logger.debug("Source detected {}", source);
-            Files.copy(in, output, StandardCopyOption.REPLACE_EXISTING);
-            in.close();
+         // Use try-with-resources so the InputStream is closed even if
+         // Files.copy throws — the previous code closed `in` after the
+         // copy on the success path only, leaking the stream on any IO
+         // error mid-copy.
+         try (InputStream in = WebpHandler.class.getResourceAsStream(source)) {
+            if (in != null) {
+               logger.debug("Source detected {}", source);
+               Files.copy(in, output, StandardCopyOption.REPLACE_EXISTING);
 
-            if (!SystemUtils.IS_OS_WINDOWS) {
-               logger.info("Setting executable {}", output);
-               setExecutable(output);
+               if (!SystemUtils.IS_OS_WINDOWS) {
+                  logger.info("Setting executable {}", output);
+                  setExecutable(output);
+               }
+               return;
             }
-            return;
          }
       }
       throw new IOException("Could not locate webp binary at " + Arrays.toString(sources));


### PR DESCRIPTION
## Summary
The previous code:

\`\`\`java
InputStream in = WebpHandler.class.getResourceAsStream(source);
if (in != null) {
   Files.copy(in, output, StandardCopyOption.REPLACE_EXISTING);
   in.close();
   ...
}
\`\`\`

closed the stream only on the success path. If \`Files.copy\` threw midway through (disk full, permissions, …) the stream was abandoned and the resource leaked. Wrap the lookup in try-with-resources so \`close()\` always runs.

A null resource (i.e. \`getResourceAsStream\` couldn't find the source) is handled correctly by try-with-resources — no \`close()\` is invoked on the null reference.

## Test plan
- [x] Compiles cleanly
- [x] Behavior unchanged on the success path