### PR TITLE
Fix PipelineFilter silently dropping results on non-INT-ARGB images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/PipelineFilter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/PipelineFilter.java
@@ -17,18 +17,25 @@ public class PipelineFilter implements Filter {
       this.filters = filters;
    }
 
+   /**
+    * The pipeline only operates correctly on TYPE_INT_ARGB / TYPE_INT_RGB
+    * images. Declare that here so {@link ImmutableImage#filter(Filter)}
+    * converts the image before delegating to {@link #apply(ImmutableImage)}.
+    *
+    * Previously the conversion was done inside apply() — but it conditionally
+    * created a *new* ImmutableImage and discarded it after the filters ran,
+    * so for any non-INT-ARGB/RGB source the entire pipeline silently became
+    * a no-op (NashvilleFilter on TYPE_4BYTE_ABGR did nothing).
+    */
+   @Override
+   public int[] types() {
+      return new int[]{BufferedImage.TYPE_INT_ARGB, BufferedImage.TYPE_INT_RGB};
+   }
+
    @Override
    public void apply(ImmutableImage image) throws IOException {
-
-      ImmutableImage copy;
-      if (image.getType() == BufferedImage.TYPE_INT_ARGB || image.getType() == BufferedImage.TYPE_INT_RGB) {
-         copy = image;
-      } else {
-         copy = image.copy(BufferedImage.TYPE_INT_ARGB);
-      }
-
       for (Filter filter : filters) {
-         filter.apply(copy);
+         filter.apply(image);
       }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/PipelineFilterTypeConversionTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/PipelineFilterTypeConversionTest.kt
@@ -1,0 +1,76 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.filter.GrayscaleFilter
+import com.sksamuel.scrimage.filter.PipelineFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for PipelineFilter silently dropping its work when
+ * applied to a non-INT-ARGB / non-INT-RGB image.
+ *
+ * Pre-fix the apply() method:
+ *
+ *   ImmutableImage copy;
+ *   if (image.getType() == ARGB || image.getType() == RGB) {
+ *      copy = image;
+ *   } else {
+ *      copy = image.copy(BufferedImage.TYPE_INT_ARGB);
+ *   }
+ *   for (Filter filter : filters) {
+ *      filter.apply(copy);
+ *   }
+ *
+ * For a non-ARGB/RGB image, `copy` was a *separate* ImmutableImage —
+ * filters mutated that copy and the original image was returned
+ * unchanged. NashvilleFilter (which extends PipelineFilter) on a
+ * TYPE_4BYTE_ABGR source did nothing.
+ *
+ * The fix declares types()=[INT_ARGB, INT_RGB] so
+ * ImmutableImage.filter() converts the input before delegating.
+ */
+class PipelineFilterTypeConversionTest : FunSpec({
+
+   class TestPipeline : PipelineFilter(listOf(GrayscaleFilter()))
+
+   test("pipeline applied to TYPE_4BYTE_ABGR via image.filter() actually changes the image") {
+      val source = ImmutableImage.create(4, 4, BufferedImage.TYPE_4BYTE_ABGR)
+      // Fill with a strong red so a Grayscale step will produce a noticeable change.
+      for (x in 0 until 4) for (y in 0 until 4) {
+         source.setColor(x, y, RGBColor(255, 0, 0, 255))
+      }
+      val originalRed = source.pixel(0, 0).red()
+      originalRed shouldBe 255
+
+      val out = source.filter(TestPipeline())
+      // After grayscale, red is ~54 (the Rec. 709 luma weight for pure red).
+      // The key invariant: it must NOT still be 255 (which would indicate
+      // the pipeline silently no-op'd).
+      val newRed = out.pixel(0, 0).red()
+      newRed shouldBe 54
+   }
+
+   test("pipeline declares types() so the framework knows the conversion is needed") {
+      val pipeline = TestPipeline()
+      val types = pipeline.types().toList()
+      types.contains(BufferedImage.TYPE_INT_ARGB) shouldBe true
+      types.contains(BufferedImage.TYPE_INT_RGB) shouldBe true
+      // size > 0 is the actual contract; before the fix it was empty
+      types.size shouldBeGreaterThan 0
+   }
+
+   test("pipeline still works correctly on TYPE_INT_ARGB sources (no regression)") {
+      val source = ImmutableImage.create(4, 4, BufferedImage.TYPE_INT_ARGB)
+      for (x in 0 until 4) for (y in 0 until 4) {
+         source.setColor(x, y, RGBColor(0, 255, 0, 255))
+      }
+      val out = source.filter(TestPipeline())
+      out.pixel(0, 0).red() shouldBe 182 // luma of pure green
+      out.pixel(0, 0).green() shouldBe 182
+      out.pixel(0, 0).blue() shouldBe 182
+   }
+})


### PR DESCRIPTION
## Summary
The previous \`apply()\` body:

\`\`\`java
ImmutableImage copy;
if (image.getType() == ARGB || image.getType() == RGB) {
   copy = image;
} else {
   copy = image.copy(BufferedImage.TYPE_INT_ARGB);
}
for (Filter filter : filters) {
   filter.apply(copy);
}
\`\`\`

For a TYPE_INT_ARGB / TYPE_INT_RGB source, \`copy\` aliased the input and the filters mutated it in place — fine. For any other source type \`copy\` was a **separate** ImmutableImage; the filters mutated that copy and the original image was left untouched. Concretely: \`NashvilleFilter\` (which extends \`PipelineFilter\`) on a \`TYPE_4BYTE_ABGR\` source did nothing.

Move the type requirement into \`types()\` — the standard mechanism that \`ImmutableImage.filter()\` uses to convert the input *before* delegating. That way \`image.filter(pipeline)\` gets a properly-typed input, the filters mutate it in place, and the framework returns the result.

## Test plan
- [x] New \`PipelineFilterTypeConversionTest\`:
  - NashvilleFilter-style (TestPipeline=GrayscaleFilter) on TYPE_4BYTE_ABGR actually changes the pixels
  - the filter declares the right \`types()\`
  - the INT_ARGB happy path still works (no regression)
- [x] **Pre-fix: 2 of 3 new tests fail**
- [x] Post-fix: all 3 pass
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green