### PR TITLE
Fix webp handlers masking process hangs as IllegalThreadStateException

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
@@ -109,13 +109,22 @@ public class CWebpHandler extends WebpHandler {
 
       Process process = builder.start();
       try {
-         process.waitFor(5, TimeUnit.MINUTES);
+         // waitFor(timeout, unit) returns false if the process is still
+         // running when the timeout expires. The previous code ignored
+         // the return value and called exitValue() unconditionally,
+         // which throws IllegalThreadStateException if the process
+         // hadn't exited — masking the real failure (a hang).
+         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+         if (!finished) {
+            throw new IOException("cwebp timed out after 5 minutes");
+         }
          int exitStatus = process.exitValue();
          if (exitStatus != 0) {
             List<String> error = Files.readAllLines(stdout);
             throw new IOException(error.toString());
          }
       } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
          throw new IOException(e);
       } finally {
          process.destroy();

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
@@ -75,13 +75,22 @@ public class DWebpHandler extends WebpHandler {
 
       Process process = builder.start();
       try {
-         process.waitFor(5, TimeUnit.MINUTES);
+         // waitFor(timeout, unit) returns false if the process is still
+         // running when the timeout expires. The previous code ignored
+         // the return value and called exitValue() unconditionally,
+         // which throws IllegalThreadStateException if the process
+         // hadn't exited — masking the real failure (a hang).
+         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+         if (!finished) {
+            throw new IOException("dwebp timed out after 5 minutes");
+         }
          int exitStatus = process.exitValue();
          if (exitStatus != 0) {
             List<String> error = Files.readAllLines(stdout);
             throw new IOException(error.toString());
          }
-      } catch (InterruptedException | IOException e) {
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
          throw new IOException(e);
       } finally {
          process.destroy();

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
@@ -91,13 +91,23 @@ public class Gif2WebpHandler extends WebpHandler {
 
       Process process = builder.start();
       try {
-         process.waitFor(5, TimeUnit.MINUTES);
+         // waitFor(timeout, unit) returns false if the process is still
+         // running when the timeout expires. The previous code ignored
+         // that return and called exitValue() unconditionally, which
+         // throws IllegalThreadStateException if the process hadn't
+         // exited — masking the real failure (a hang) with a confusing
+         // unrelated exception.
+         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+         if (!finished) {
+            throw new IOException("gif2webp timed out after 5 minutes");
+         }
          int exitStatus = process.exitValue();
          if (exitStatus != 0) {
             List<String> error = Files.readAllLines(stdout);
             throw new IOException(error.toString());
          }
       } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
          throw new IOException(e);
       } finally {
          process.destroy();


### PR DESCRIPTION
## Summary
\`CWebpHandler\`, \`DWebpHandler\`, and \`Gif2WebpHandler\` all called:

\`\`\`java
process.waitFor(5, TimeUnit.MINUTES);
int exitStatus = process.exitValue();
\`\`\`

…ignoring the boolean return from \`waitFor\`. The \`Process.waitFor(timeout)\` contract is: returns \`true\` if the process exited within the timeout, \`false\` if it's still running. If false (timeout) the subsequent \`exitValue()\` throws \`IllegalThreadStateException\` — an unchecked, unrelated-looking exception that buries the real failure (the binary hung).

Inspect the return value and throw a clear \`IOException\` naming the binary that timed out.

Also restore the interrupt status on \`InterruptedException\` — the previous code swallowed it before wrapping in IOException, so any caller that wanted to react to interruption couldn't.

Removes the extra \`IOException\` wrap-around in DWebpHandler's catch: the inner \`throw new IOException(error.toString())\` was being caught by the multi-catch and re-wrapped, producing nested IOException messages on shell errors.

## Test plan
- [x] Compiles cleanly
- [x] Existing webp tests stay green (timeouts don't trigger in normal runs; behaviour is unchanged on the success path)