### PR TITLE
Fix webp handlers leaking temp files on partial creation failure

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
@@ -49,19 +49,26 @@ public class CWebpHandler extends WebpHandler {
                          boolean lossless,
                          boolean withoutAlpha,
                          boolean multiThread) throws IOException {
+      // Use nested try/finally so if the second createTempFile throws
+      // (disk full between the two calls), the first temp file is still
+      // cleaned up. Previously both creates lived outside the try and a
+      // mid-creation failure leaked the first one.
       Path input = Files.createTempFile("input", "webp").toAbsolutePath();
-      Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();
       try {
-         Files.write(input, bytes, StandardOpenOption.CREATE);
-         convert(input, output, m, q, z, lossless, withoutAlpha, multiThread);
-         return Files.readAllBytes(output);
+         Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();
+         try {
+            Files.write(input, bytes, StandardOpenOption.CREATE);
+            convert(input, output, m, q, z, lossless, withoutAlpha, multiThread);
+            return Files.readAllBytes(output);
+         } finally {
+            try {
+               output.toFile().delete();
+            } catch (Exception e) {
+            }
+         }
       } finally {
          try {
             input.toFile().delete();
-         } catch (Exception e) {
-         }
-         try {
-            output.toFile().delete();
          } catch (Exception e) {
          }
       }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
@@ -43,8 +43,10 @@ public class DWebpHandler extends WebpHandler {
 
    public byte[] convert(byte[] bytes) throws IOException {
       Path input = Files.createTempFile("input", "webp").toAbsolutePath();
-      Files.write(input, bytes, StandardOpenOption.CREATE);
       try {
+         // Files.write was previously called BEFORE the try block; if it
+         // threw (disk full, permissions, ...) the temp file leaked.
+         Files.write(input, bytes, StandardOpenOption.CREATE);
          return convert(input);
       } finally {
          input.toFile().delete();

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
@@ -43,19 +43,26 @@ public class Gif2WebpHandler extends WebpHandler {
                          int m,
                          int q,
                          boolean lossy) throws IOException {
+      // Use nested try/finally so if the second createTempFile throws
+      // (disk full between the two calls), the first temp file is still
+      // cleaned up. Previously both creates lived outside the try and a
+      // mid-creation failure leaked the first one.
       Path input = Files.createTempFile("input", "gif").toAbsolutePath();
-      Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();
       try {
-         Files.write(input, bytes, StandardOpenOption.CREATE);
-         convert(input, output, m, q, lossy);
-         return Files.readAllBytes(output);
+         Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();
+         try {
+            Files.write(input, bytes, StandardOpenOption.CREATE);
+            convert(input, output, m, q, lossy);
+            return Files.readAllBytes(output);
+         } finally {
+            try {
+               output.toFile().delete();
+            } catch (Exception e) {
+            }
+         }
       } finally {
          try {
             input.toFile().delete();
-         } catch (Exception e) {
-         }
-         try {
-            output.toFile().delete();
          } catch (Exception e) {
          }
       }


### PR DESCRIPTION
## Summary
Two distinct leak patterns across the webp \`byte[]\` convert paths:

**1) \`DWebpHandler.convert(byte[])\`:**

\`\`\`java
Path input = Files.createTempFile("input", "webp").toAbsolutePath();
Files.write(input, bytes, StandardOpenOption.CREATE);  // <-- before try
try {
   return convert(input);
} finally {
   input.toFile().delete();
}
\`\`\`

If \`Files.write\` threw (disk full, permissions, ...) the temp file was leaked because the cleanup is in the try's finally and we never entered the try. Move \`Files.write\` inside the try block.

**2) \`CWebpHandler.convert(byte[])\` and \`Gif2WebpHandler.convert(byte[])\`:**

\`\`\`java
Path input = Files.createTempFile("input", "webp").toAbsolutePath();
Path output = Files.createTempFile("to_webp", "webp").toAbsolutePath();  // <-- can throw
try {
   ...
} finally {
   input.toFile().delete();
   output.toFile().delete();
}
\`\`\`

If the second createTempFile threw (disk full between the two calls) the first temp file leaked. Restructure into nested try/finally so each temp file is cleaned up independently, in the right order.

These are edge-case leaks but real — for callers running long-lived processes that exhaust the temp directory, every failed conversion left a stale file behind.

## Test plan
- [x] Compiles cleanly
- [x] Existing webp tests stay green