### PR TITLE
Rename Arc/FilledArc parameter from endAngle to arcAngle (the span)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Arc.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Arc.java
@@ -11,26 +11,33 @@ public class Arc implements Drawable {
     private final int width;
     private final int height;
     private final int startAngle;
-    private final int endAngle;
+    private final int arcAngle;
     private final GraphicsContext context;
 
-    public Arc(int x, int y, int width, int height, int startAngle, int endAngle, GraphicsContext context) {
+    /**
+     * @param startAngle the beginning angle, in degrees, measured counter-clockwise from 3 o'clock
+     * @param arcAngle   the angular extent of the arc, in degrees (NOT the absolute end angle).
+     *                   The previous parameter name "endAngle" was misleading — Graphics2D.drawArc
+     *                   takes a span, not an absolute end. So {@code Arc(..., 30, 90)} draws an arc
+     *                   from 30° spanning 90° (i.e. ending at 120°), not from 30° to 90°.
+     */
+    public Arc(int x, int y, int width, int height, int startAngle, int arcAngle, GraphicsContext context) {
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
         this.startAngle = startAngle;
-        this.endAngle = endAngle;
+        this.arcAngle = arcAngle;
         this.context = context;
     }
 
     @Override
     public void draw(RichGraphics2D g) {
-        g.drawArc(x, y, width, height, startAngle, endAngle);
+        g.drawArc(x, y, width, height, startAngle, arcAngle);
     }
 
     public FilledArc toFilled() {
-        return new FilledArc(x, y, width, height, startAngle, endAngle, context);
+        return new FilledArc(x, y, width, height, startAngle, arcAngle, context);
     }
 
     @Override

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/FilledArc.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/FilledArc.java
@@ -11,26 +11,32 @@ public class FilledArc implements Drawable {
     private final int width;
     private final int height;
     private final int startAngle;
-    private final int endAngle;
+    private final int arcAngle;
     private final GraphicsContext context;
 
-    public FilledArc(int x, int y, int width, int height, int startAngle, int endAngle, GraphicsContext context) {
+    /**
+     * @param startAngle the beginning angle, in degrees, measured counter-clockwise from 3 o'clock
+     * @param arcAngle   the angular extent of the arc, in degrees (NOT the absolute end angle).
+     *                   The previous parameter name "endAngle" was misleading — Graphics2D.fillArc
+     *                   takes a span, not an absolute end.
+     */
+    public FilledArc(int x, int y, int width, int height, int startAngle, int arcAngle, GraphicsContext context) {
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
         this.startAngle = startAngle;
-        this.endAngle = endAngle;
+        this.arcAngle = arcAngle;
         this.context = context;
     }
 
     @Override
     public void draw(RichGraphics2D g) {
-        g.fillArc(x, y, width, height, startAngle, endAngle);
+        g.fillArc(x, y, width, height, startAngle, arcAngle);
     }
 
     public Arc toOutline() {
-        return new Arc(x, y, width, height, startAngle, endAngle, context);
+        return new Arc(x, y, width, height, startAngle, arcAngle, context);
     }
 
     @Override


### PR DESCRIPTION
## Summary
The constructor parameter on both \`Arc\` and \`FilledArc\` was called \`endAngle\`, which strongly suggests an absolute angle "draw from startAngle to endAngle". But it was passed unmodified to \`Graphics2D.drawArc\` / \`fillArc\`, which take an \`arcAngle\` (the angular span starting at startAngle), not an absolute end.

**Concrete consequence**: \`Arc(0, 0, 100, 100, 30, 90)\` reads as "arc from 30° to 90°" (a 60° span) but actually drew "arc from 30° spanning 90°" (i.e. ending at 120°). The bug only manifests when \`startAngle != 0\` — which is why no internal call site noticed (none of them set a non-zero start).

Rename the parameter and field to \`arcAngle\` and add a javadoc spelling out the contract. **Behaviour is unchanged** — the previous calls match Graphics2D.drawArc's actual semantics, only the name and surrounding documentation needed correcting.

## Test plan
- [x] Full \`./gradlew :scrimage-tests:test :scrimage-filters:test\` green