### PR TITLE
Fix Radians.toDegrees losing up to 1° via int cast (use Math.round)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/angles/Radians.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/angles/Radians.java
@@ -8,6 +8,9 @@ public class Radians {
    }
 
    public Degrees toDegrees() {
-      return new Degrees((int) (value * 180.0 / Math.PI));
+      // Math.round (not int cast) so values close to but slightly less
+      // than an integer degree round to the nearest. (int) cast truncates
+      // toward zero, so e.g. 89.99999° in radians → 89° instead of 90°.
+      return new Degrees((int) Math.round(Math.toDegrees(value)));
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/RadiansToDegreesTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/RadiansToDegreesTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.angles.Degrees
+import com.sksamuel.scrimage.angles.Radians
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for Radians.toDegrees() previously using a (int) cast,
+ * which truncates toward zero — losing up to 1 degree of precision when
+ * the float result was just under an integer (e.g. 89.999... → 89, not 90).
+ *
+ * The fix uses Math.round to round to the nearest integer.
+ */
+class RadiansToDegreesTest : FunSpec({
+
+   test("Degrees → Radians → Degrees round-trips for cardinal angles") {
+      for (deg in listOf(0, 30, 45, 60, 90, 120, 180, 270, 360)) {
+         Degrees(deg).toRadians().toDegrees().value shouldBe deg
+      }
+   }
+
+   test("Degrees → Radians → Degrees round-trips for negative angles") {
+      Degrees(-45).toRadians().toDegrees().value shouldBe -45
+      Degrees(-90).toRadians().toDegrees().value shouldBe -90
+      Degrees(-180).toRadians().toDegrees().value shouldBe -180
+   }
+
+   test("Degrees → Radians → Degrees round-trips for arbitrary integer angles") {
+      for (deg in 1..359) {
+         Degrees(deg).toRadians().toDegrees().value shouldBe deg
+      }
+   }
+
+   test("Radians value just under an integer degree rounds up to that degree") {
+      // 89.999° in radians; pre-fix the (int) cast truncated to 89.
+      val almost90 = Radians(Math.toRadians(89.99999))
+      almost90.toDegrees().value shouldBe 90
+   }
+})


### PR DESCRIPTION
## Summary
\`Radians.toDegrees()\` converted via:

\`\`\`java
return new Degrees((int) (value * 180.0 / Math.PI));
\`\`\`

The \`(int)\` cast truncates toward zero. The \`180/π\` conversion produces floating-point results that may sit just below an integer due to π's inexact double representation, so a \`Radians\` value computed from (say) \`Degrees(90)\` could round-trip back as \`Degrees(89)\` — losing 1°.

Switch to \`Math.round\` (and \`Math.toDegrees\` for clarity) so the round-trip is exact for every integer-degree input.

## Test plan
- [x] New \`RadiansToDegreesTest\` pins:
  - Degrees → Radians → Degrees round-trips exactly for 0..359
  - several cardinal angles
  - negative angles
  - a value explicitly chosen to be just under 90°
- [x] **Pre-fix: 3 of 4 new tests fail**
- [x] Post-fix: all 4 pass