### PR TITLE
Fix DifferenceHasher.dhash using canvas-resize instead of scaling

### DIFF
--- a/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
+++ b/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
@@ -10,7 +10,12 @@ class DifferenceHasher(private val cols: Int, private val rows: Int) {
     */
    fun dhash(image: ImmutableImage): List<Int> {
       val gs = image.toGrayscale(GrayscaleMethod.LUMA)
-      val r = gs.resizeTo(cols, rows)
+      // scaleTo resamples the image down to (cols x rows). The previous
+      // code used resizeTo, which is a canvas-resize op — for any image
+      // larger than (cols x rows), it cropped to a small region around
+      // the centre instead of summarising the whole image. That defeated
+      // the entire point of the perceptual hash.
+      val r = gs.scaleTo(cols, rows)
       return r.rows()
          .flatMap { row ->
             row.toList().windowed(2).map { if (it.first().argb < it.last().argb) 1 else 0 }

--- a/scrimage-hash/src/test/kotlin/com/sksamuel/scrimage/hash/DifferenceHasherScalingTest.kt
+++ b/scrimage-hash/src/test/kotlin/com/sksamuel/scrimage/hash/DifferenceHasherScalingTest.kt
@@ -1,0 +1,63 @@
+package com.sksamuel.scrimage.hash
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class DifferenceHasherScalingTest : FunSpec({
+
+   // Both images are 200x200; the centre 9x8 pixels (around col ~95..103,
+   // row ~96..103) are uniformly white in both. The only difference is a
+   // big black block painted in the top-left corner of `withCornerBlock`.
+   //
+   // A perceptual hash that actually scales the image down should produce
+   // different hashes for these two images, because the corner block shows
+   // up as a darker pixel in the scaled-down representation. The previous
+   // implementation called resizeTo (a canvas-resize that crops, not a
+   // resampling op), so for any image larger than (cols x rows) it just
+   // captured the centre region — which is identical here — and yielded
+   // the same hash for both images.
+
+   fun fill(width: Int, height: Int, paint: (BufferedImage) -> Unit): ImmutableImage {
+      val bi = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+      val g = bi.createGraphics()
+      try {
+         g.color = Color.WHITE
+         g.fillRect(0, 0, width, height)
+         paint(bi)
+      } finally {
+         g.dispose()
+      }
+      return ImmutableImage.fromAwt(bi)
+   }
+
+   test("dhash of two images with identical centres but different corners differs") {
+      val plain = fill(200, 200) { }
+      val withCornerBlock = fill(200, 200) {
+         val g = it.createGraphics()
+         try {
+            g.color = Color.BLACK
+            g.fillRect(0, 0, 80, 80)
+         } finally {
+            g.dispose()
+         }
+      }
+
+      // Sanity: the two images really are different overall.
+      plain.argb(0, 0).contentEquals(withCornerBlock.argb(0, 0)) shouldBe false
+
+      // Sanity: the centre region of each image is uniformly white, so a
+      // pure centre-crop would not be able to tell them apart.
+      val centreColumns = 95..103
+      val centreRows = 96..103
+      for (x in centreColumns) for (y in centreRows) {
+         plain.pixel(x, y).toARGBInt() shouldBe withCornerBlock.pixel(x, y).toARGBInt()
+      }
+
+      // The hash must summarise the whole image, not just the centre.
+      plain.dhash() shouldNotBe withCornerBlock.dhash()
+   }
+})


### PR DESCRIPTION
## Summary

`DifferenceHasher.dhash()` called `gs.resizeTo(cols, rows)`. `resizeTo` is a canvas-resize op — it places the source into a small (cols × rows) canvas, so for any input image larger than (cols × rows) it just crops to a tiny region around the centre and discards everything else. The hash therefore reflected only the centre of the image instead of summarising the whole image — defeating the entire point of a perceptual hash.

For the default 9 × 8 hash on, say, a 1920 × 1080 input, the hash was computed from the centre 9 × 8 pixel region of the original. Two images that happen to have similar centres but wildly different overall content produced identical hashes; two images that are downscaled versions of each other produced very different hashes.

The fix swaps `resizeTo` → `scaleTo`, which actually resamples the image down to the target dimensions.

## Bug demonstration

The added test constructs two 200×200 images:
- One filled white.
- One filled white with a 80×80 black block painted in the top-left corner.

The centre 9×8 region of both images is uniformly white. With the previous behaviour, `dhash` produced identical all-zero hashes for both images (it never saw the corner block). With the fix, the corner block shows up in the down-scaled representation and the hashes differ as expected.

## Compatibility

This changes the hash *values* produced by `dhash` for any input not already (cols × rows). Anyone storing dhashes from previous versions for similarity lookup will need to recompute; the previous values were not meaningful anyway.

## Test plan

- [x] Added `DifferenceHasherScalingTest` — verified it fails on master (both hashes are all zeros) and passes after the fix.
- [x] Existing `DifferenceHasherTest` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)