### PR TITLE
Fix CaptionFilter background ignoring requested position

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CaptionFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CaptionFilter.java
@@ -88,9 +88,15 @@ public class CaptionFilter implements Filter {
             captionY = y;
         }
 
+        // The caption background must be drawn at the same y as the text;
+        // previously it was hard-coded to (image.height - captionHeight),
+        // which placed the background at the bottom of the image regardless
+        // of the configured Position or explicit y. The bug was masked because
+        // every existing test happens to use Position.BottomLeft, where
+        // captionY == image.height - captionHeight.
         FilledRect bg = new FilledRect(
                 captionX,
-                image.height - captionHeight,
+                captionY,
                 captionWidth,
                 captionHeight,
                 g -> {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CaptionFilterPositionTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CaptionFilterPositionTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.FontUtils
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.Position
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class CaptionFilterPositionTest : FunSpec({
+
+   // Build a fully-black source image so the white caption background pixels
+   // are easy to detect. Use a generous height so TopLeft and the buggy
+   // (image.height - captionHeight) y are clearly different.
+   val font = FontUtils.createTrueType(
+      this::class.java.getResourceAsStream("/fonts/Roboto-Light.ttf"),
+      12,
+   )
+
+   fun captionAt(position: Position): ImmutableImage {
+      val source = ImmutableImage.filled(400, 400, Color.BLACK)
+      return source.filter(
+         CaptionFilter(
+            "Caption",
+            position,
+            font,
+            Color.WHITE,         // text colour
+            1.0,
+            false,
+            false,
+            Color.WHITE,         // caption background — we look for this
+            1.0,                 // fully opaque background to make detection clean
+            Padding(10, 10, 10, 10),
+         )
+      )
+   }
+
+   fun whiteCount(image: ImmutableImage, yRange: IntRange): Int {
+      var count = 0
+      for (y in yRange) for (x in 0 until image.width) {
+         if (image.pixel(x, y).toARGBInt() == Color.WHITE.rgb) count++
+      }
+      return count
+   }
+
+   test("Position.TopLeft places the caption background near the top, not the bottom") {
+      val out = captionAt(Position.TopLeft)
+
+      // The caption background is a large filled rectangle, so wherever it
+      // ends up there will be many white pixels. The text alone is small
+      // and accounts for at most a few hundred white pixels.
+      val topWhite = whiteCount(out, 0 until 60)
+      val bottomWhite = whiteCount(out, (out.height - 60) until out.height)
+
+      // With the fix the background lives in the top region, so most of
+      // the white pixels should be there. With the previous bug the
+      // background was pinned to (image.height - captionHeight), so most
+      // of the white pixels would be at the bottom.
+      (topWhite > bottomWhite * 4) shouldBe true
+   }
+})


### PR DESCRIPTION
## Summary

`CaptionFilter` computed `captionX` / `captionY` from the configured `Position` (or explicit `x`/`y`), but the `FilledRect` for the caption background was hard-coded to `y = image.height - captionHeight` — i.e. always pinned to the bottom of the image. The text used `captionY` correctly, so unless the caption happened to land at the bottom anyway, the background drifted away from the text.

The bug was masked because every existing test in `CaptionFilterTest` uses `Position.BottomLeft`, which happens to be the one position where `captionY == image.height - captionHeight`. (Those tests are also currently `ignore`d.)

## Bug demonstration

The added regression test renders a caption on a `Position.TopLeft` filter against a 400×400 fully-black source. The caption background is a large rectangle filled with white. After applying the filter:
- with the previous code, white pixels appear at the bottom of the image, not the top;
- with the fix, white pixels appear at the top, matching the requested position.

The test counts white pixels in the top 60 rows vs the bottom 60 rows and asserts that the top has at least 4× as many — which is true with the fix and false with the bug (where almost all white pixels are at the bottom).

## Test plan

- [x] New `CaptionFilterPositionTest` fails on master and passes after the fix.
- [x] Full `:scrimage-filters:test` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)