### PR TITLE
Fix PixelTools.scale wrapping via & 0xFF instead of clamping

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -91,11 +91,21 @@ public class PixelTools {
     * Scales the brightness of a pixel.
     */
    public static int scale(Double factor, int pixel) {
+      // Clamp each channel to [0, 255]. Without clamping, a factor > 1 (or
+      // < 0) yielded an out-of-range channel value that argb() then masked
+      // with & 0xFF, wrapping the channel around — so a "brightening" call
+      // could silently produce a darker pixel.
       return rgb(
-         (int) Math.round(factor * red(pixel)),
-         (int) Math.round(factor * green(pixel)),
-         (int) Math.round(factor * blue(pixel))
+         clampChannel((int) Math.round(factor * red(pixel))),
+         clampChannel((int) Math.round(factor * green(pixel))),
+         clampChannel((int) Math.round(factor * blue(pixel)))
       );
+   }
+
+   private static int clampChannel(int value) {
+      if (value < 0) return 0;
+      if (value > 255) return 255;
+      return value;
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -85,4 +85,33 @@ class PixelToolsTest : FunSpec({
       PixelTools.approx(ref, 10, arrayOf(pixel)) shouldBe false
    }
 
+   // Regression: scale() called rgb() without clamping, so any factor that
+   // pushed a channel above 255 (or below 0) was masked with & 0xFF and
+   // wrapped — meaning a "brightening" call could silently darken a pixel.
+   test("scale clamps rather than wrapping when factor pushes a channel above 255") {
+      val pixel = PixelTools.rgb(200, 100, 50)
+      val scaled = PixelTools.scale(2.0, pixel)
+      // Without clamping, red would have been (400 & 0xFF) = 144, i.e. darker
+      // than the input. With clamping it caps at 255.
+      PixelTools.red(scaled) shouldBe 255
+      PixelTools.green(scaled) shouldBe 200
+      PixelTools.blue(scaled) shouldBe 100
+   }
+
+   test("scale clamps rather than wrapping when factor is negative") {
+      val pixel = PixelTools.rgb(200, 100, 50)
+      val scaled = PixelTools.scale(-1.0, pixel)
+      PixelTools.red(scaled) shouldBe 0
+      PixelTools.green(scaled) shouldBe 0
+      PixelTools.blue(scaled) shouldBe 0
+   }
+
+   test("scale leaves channels unchanged when factor is exactly 1") {
+      val pixel = PixelTools.rgb(123, 45, 67)
+      val scaled = PixelTools.scale(1.0, pixel)
+      PixelTools.red(scaled) shouldBe 123
+      PixelTools.green(scaled) shouldBe 45
+      PixelTools.blue(scaled) shouldBe 67
+   }
+
 })


### PR DESCRIPTION
## Summary

`PixelTools.scale(factor, pixel)` multiplies each of red/green/blue by `factor` and feeds the result back through `rgb()`, which calls `argb()` — and that masks each channel with `& 0xFF`. So any value above 255 (or below 0) silently wrapped around instead of being clamped. A \"brightening\" call could therefore produce a darker pixel:

```
scale(2.0, rgb(200, 100, 50))
→ rgb(400, 200, 100)
→ red = (400 & 0xFF) = 144  // darker than 200!
```

Clamp each scaled channel to `[0, 255]` before packing. This mirrors the clamping shape `PixelTools.truncate` already uses on the contrast path.

## Test plan

- [x] Three new regression tests in `PixelToolsTest`:
  - factor > 1 must clamp at 255 (was 144 / wrap on master)
  - factor < 0 must clamp at 0 (was 56 / wrap on master)
  - factor == 1 must be a no-op (sanity)
- [x] Existing `PixelToolsTest` cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)