### PR TITLE
Fix AwtImage.patches off-by-one dropping rightmost col and bottom row

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -422,11 +422,19 @@ public class AwtImage {
     * The patches are returned as an array of of pixel matrices arrays.
     */
    public Pixel[][] patches(int patchWidth, int patchHeight) {
-      Pixel[][] patches = new Pixel[(height - patchHeight) * (width - patchWidth)][];
+      // Sliding-window enumeration: a patch starting at (col, row) is valid
+      // when col + patchWidth <= width and row + patchHeight <= height,
+      // giving (width - patchWidth + 1) * (height - patchHeight + 1) patches.
+      // The previous formula dropped the rightmost column and bottom row of
+      // patch starts (e.g. patches(1, 1) on a 4x4 image returned 9 patches
+      // instead of 16).
+      int rows = height - patchHeight + 1;
+      int cols = width - patchWidth + 1;
+      Pixel[][] patches = new Pixel[rows * cols][];
       Pixel[] source = pixels();
       int k = 0;
-      for (int row = 0; row < height - patchHeight; row++) {
-         for (int col = 0; col < width - patchWidth; col++) {
+      for (int row = 0; row < rows; row++) {
+         for (int col = 0; col < cols; col++) {
             patches[k] = patchFrom(source, col, row, patchWidth, patchHeight);
             k++;
          }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/AwtImageTest.kt
@@ -13,10 +13,13 @@ class AwtImageTest : FunSpec({
    // Regression tests for https://github.com/sksamuel/scrimage/pull/351
    // k was never incremented, so every patch overwrote patches[0]
 
-   test("patches returns the correct number of non-null patches") {
+   test("patches returns one entry per valid sliding-window position") {
       val image = ImmutableImage.create(4, 4)
       val patches = image.patches(2, 2)
-      patches.size shouldBe (4 - 2) * (4 - 2)  // = 4
+      // A 2x2 patch on a 4x4 image has valid top-left positions (0..2, 0..2),
+      // so 9 patches total. The earlier (4-2)*(4-2)=4 formula dropped the
+      // rightmost column and bottom row of patch starts.
+      patches.size shouldBe (4 - 2 + 1) * (4 - 2 + 1)
       patches.forEach { it shouldNotBe null }
    }
 
@@ -25,16 +28,27 @@ class AwtImageTest : FunSpec({
       val pixels = Array(16) { i -> Pixel(i % 4, i / 4, i, 0, 0, 255) }
       val image = ImmutableImage.create(4, 4, pixels)
 
-      // 1x1 patches: (4-1)*(4-1) = 9; each patch contains one pixel
+      // 1x1 patches: (4-1+1)*(4-1+1) = 16; each patch contains one pixel
       val patches = image.patches(1, 1)
-      patches.size shouldBe 9
+      patches.size shouldBe 16
 
       // patch 0 → col=0, row=0 → pixel index 0 → red=0
       patches[0][0].red() shouldBe 0
       // patch 1 → col=1, row=0 → pixel index 1 → red=1
       patches[1][0].red() shouldBe 1
-      // patch 3 → col=0, row=1 → pixel index 4 → red=4
-      patches[3][0].red() shouldBe 4
+      // patch 4 → col=0, row=1 → pixel index 4 → red=4
+      patches[4][0].red() shouldBe 4
+      // The last patch picks up the bottom-right pixel — previously missing.
+      patches[15][0].red() shouldBe 15
+   }
+
+   // Regression: patches() previously skipped the rightmost column and
+   // bottom row of valid patch starts. A 1x1 patch should iterate every
+   // pixel in the image.
+   test("patches with patchSize 1 enumerates every pixel exactly once") {
+      val image = ImmutableImage.create(5, 3)
+      val patches = image.patches(1, 1)
+      patches.size shouldBe 5 * 3
    }
 
    // Regression: AwtImage.pixels() fast path for TYPE_INT_RGB read data[index] directly,


### PR DESCRIPTION
## Summary

`AwtImage.patches(patchWidth, patchHeight)` is a sliding-window enumeration of all valid patch positions. A patch starting at `(col, row)` is valid as long as `col + patchWidth <= width` and `row + patchHeight <= height` — so the correct count is `(width - patchWidth + 1) * (height - patchHeight + 1)`.

The previous implementation allocated `(height - patchHeight) * (width - patchWidth)` slots and looped `col < width - patchWidth`, which silently dropped the rightmost column and bottom row of valid patch starts.

Concretely:
- `patches(1, 1)` on a 4×4 image returned **9** patches instead of **16** — a per-pixel sweep was missing 7 pixels.
- `patches(2, 2)` on a 4×4 image returned **4** patches instead of **9**.

## Test plan

- [x] Updated the two existing `AwtImageTest` cases that had pinned the buggy count to use the correct sliding-window count, and added a per-pixel regression assertion (`patches(1,1)` on a 5×3 image must enumerate all 15 pixels). The new assertion fails on master (`expected 15 but was 8`) and passes after the fix.
- [x] Full `:scrimage-tests:test` suite still passes.

## Notes

This is a behavior change for callers who relied on the previous count: any consumer iterating `patches.size` will now see the rightmost column and bottom row of patches included. The two tests in `AwtImageTest` were the only call sites in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)