### PR TITLE
Fix autocrop throwing on image entirely filled with the crop colour

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -438,7 +438,13 @@ public class ImmutableImage extends MutableImage {
       int x2 = AutocropOps.scanleft(color, height, width - 1, pixelExtractor(), colorTolerance);
       int y1 = AutocropOps.scandown(color, height, width, 0, pixelExtractor(), colorTolerance);
       int y2 = AutocropOps.scanup(color, width, height - 1, pixelExtractor(), colorTolerance);
+      // If every column matches the crop colour, scanright walks all the way
+      // to width and scanleft all the way to 0 (and likewise for rows). The
+      // "nothing to crop" subimage(x1, y1, x2-x1+1, ...) call would then have
+      // a negative width/height. Treat an all-matching image as "nothing to
+      // keep but also nothing to crop" and return the original.
       if (x1 == 0 && y1 == 0 && x2 == width - 1 && y2 == height - 1) return this;
+      if (x1 > x2 || y1 > y2) return this;
       return subimage(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/autocrop/AutoCropTest.kt
@@ -24,6 +24,15 @@ class AutoCropTest : FunSpec() {
          image.autocrop(Color.ORANGE).shouldBeSameInstanceAs(image)
       }
 
+      // Regression: when an image is entirely filled with the crop colour,
+      // scanright returns width and scanleft returns 0, so subimage was being
+      // called with a negative width and threw "Width cannot be <= 0" instead
+      // of returning a sensible result.
+      test("autocrop on an image entirely matching the crop colour returns the original image") {
+         val image = ImmutableImage.filled(20, 10, Color.WHITE)
+         image.autocrop(Color.WHITE).shouldBeSameInstanceAs(image)
+      }
+
       // Regression: autocrop used subimage(x1, y1, x2-x1, y2-y1) which is off by one —
       // the rightmost non-background column (x2) and bottom row (y2) were excluded.
       // Fix: subimage(x1, y1, x2-x1+1, y2-y1+1).


### PR DESCRIPTION
## Summary

When every pixel of an image matches the autocrop colour, `scanright` walks all the way to `width` (returning `width`, the past-the-end value) and `scanleft` walks down to `0` (returning `0`). The subsequent

```java
subimage(x1, y1, x2 - x1 + 1, y2 - y1 + 1)
```

is then `subimage(width, 0, 0 - width + 1, ...)` — a negative width — and `subimage` throws `RuntimeException: Width cannot be <= 0`.

The existing guard

```java
if (x1 == 0 && y1 == 0 && x2 == width - 1 && y2 == height - 1) return this;
```

catches the *opposite* degenerate case (no pixel matches the crop colour, so nothing to crop). The all-matching case has no analogous guard.

Treat an all-matching image as \"nothing to keep but also nothing to crop\" and return the original. This matches the existing fallback behaviour for the no-matching case.

## Bug demonstration

```kotlin
val image = ImmutableImage.filled(20, 10, Color.WHITE)
image.autocrop(Color.WHITE)  // throws RuntimeException: Width cannot be <= 0
```

## Test plan

- [x] New `AutoCropTest` case fills a 20×10 image with `Color.WHITE` and autocrops with `Color.WHITE`. On master it throws; with the fix it returns the original instance.
- [x] All existing autocrop tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)