### PR TITLE
Add StreamingWebpWriter mirroring StreamingGifWriter

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Img2WebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Img2WebpHandler.java
@@ -100,12 +100,8 @@ public class Img2WebpHandler extends WebpHandler {
    }
 
    /**
-    * Encode the given frame files into an animated WebP at {@code target}.
-    *
-    * <p>Per the img2webp CLI, per-frame options ({@code -d}, {@code -lossy} /
-    * {@code -lossless}, {@code -q}, {@code -m}) are emitted before each frame.
-    * They stick across frames, but emitting them every time keeps the call
-    * unambiguous regardless of the number of frames.
+    * Encode the given frame files into an animated WebP at {@code target},
+    * using a single uniform delay for every frame.
     */
    public void convert(List<Path> inputs,
                        Path target,
@@ -114,6 +110,51 @@ public class Img2WebpHandler extends WebpHandler {
                        int q,
                        int m,
                        boolean lossless) throws IOException {
+      int[] delays = new int[inputs.size()];
+      for (int i = 0; i < delays.length; i++) delays[i] = frameDelayMs;
+      convert(inputs, delays, target, loopCount, q, m, lossless);
+   }
+
+   /**
+    * Encode the given frame files into an animated WebP at {@code target},
+    * with a per-frame delay supplied alongside each input.
+    *
+    * <p>Per the img2webp CLI, per-frame options ({@code -d}, {@code -lossy} /
+    * {@code -lossless}, {@code -q}, {@code -m}) are emitted before each frame.
+    * The settings are sticky across frames, but emitting them every time keeps
+    * the call unambiguous regardless of frame count and lets each frame have
+    * its own delay.
+    *
+    * @param inputs         the frame files in playback order
+    * @param frameDelaysMs  one entry per input giving that frame's display
+    *                       duration in milliseconds, or {@code -1} to leave
+    *                       img2webp's default of 100 ms for that frame
+    * @param target         the output webp path
+    * @param loopCount      number of times the animation should loop, or
+    *                       {@code -1} to leave img2webp's default of 0
+    *                       (loop forever)
+    * @param q              RGB quality factor 0..100, or {@code -1} for default
+    * @param m              encoding method 0..6, or {@code -1} for default
+    * @param lossless       if {@code true} emits {@code -lossless}; otherwise
+    *                       {@code -lossy}
+    */
+   public void convert(List<Path> inputs,
+                       int[] frameDelaysMs,
+                       Path target,
+                       int loopCount,
+                       int q,
+                       int m,
+                       boolean lossless) throws IOException {
+
+      if (inputs == null || inputs.isEmpty()) {
+         throw new IllegalArgumentException("At least one frame is required");
+      }
+      if (frameDelaysMs == null || frameDelaysMs.length != inputs.size()) {
+         throw new IllegalArgumentException(
+            "frameDelaysMs must have one entry per input frame; got "
+               + (frameDelaysMs == null ? "null" : Integer.toString(frameDelaysMs.length))
+               + " for " + inputs.size() + " frames");
+      }
 
       Path stdout = Files.createTempFile("img2webp_stdout_", ".log");
       try {
@@ -123,10 +164,11 @@ public class Img2WebpHandler extends WebpHandler {
             commands.add("-loop");
             commands.add(Integer.toString(loopCount));
          }
-         for (Path input : inputs) {
-            if (frameDelayMs >= 0) {
+         for (int i = 0; i < inputs.size(); i++) {
+            int delay = frameDelaysMs[i];
+            if (delay >= 0) {
                commands.add("-d");
-               commands.add(Integer.toString(frameDelayMs));
+               commands.add(Integer.toString(delay));
             }
             commands.add(lossless ? "-lossless" : "-lossy");
             if (q >= 0) {
@@ -137,7 +179,7 @@ public class Img2WebpHandler extends WebpHandler {
                commands.add("-m");
                commands.add(Integer.toString(m));
             }
-            commands.add(input.toAbsolutePath().toString());
+            commands.add(inputs.get(i).toAbsolutePath().toString());
          }
          commands.add("-o");
          commands.add(target.toAbsolutePath().toString());

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/StreamingWebpWriter.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/StreamingWebpWriter.java
@@ -1,0 +1,225 @@
+package com.sksamuel.scrimage.webp;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.nio.PngWriter;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds an animated WebP one frame at a time, mirroring the contract of
+ * {@link com.sksamuel.scrimage.nio.StreamingGifWriter}. Use this when you want
+ * to assemble a WebP animation from frames you produce on the fly without
+ * having to hold every frame in memory at once, and without going via GIF
+ * first ({@link Gif2WebpWriter} covers the GIF route).
+ *
+ * <p>Typical usage:
+ * <pre>{@code
+ * StreamingWebpWriter writer = new StreamingWebpWriter()
+ *    .withFrameDelay(Duration.ofMillis(100))
+ *    .withInfiniteLoop(true);
+ *
+ * try (StreamingWebpWriter.WebpStream stream = writer.prepareStream(target)) {
+ *    stream.writeFrame(frame0);
+ *    stream.writeFrame(frame1, Duration.ofMillis(250));
+ *    stream.writeFrame(frame2);
+ * }
+ * }</pre>
+ *
+ * <p>Implementation notes: img2webp is a one-shot CLI that consumes all of its
+ * inputs at once, so {@link WebpStream#writeFrame(ImmutableImage)} buffers each
+ * frame to disk as a PNG and the actual encode happens at {@link
+ * WebpStream#close()}. Buffering on disk (instead of memory) keeps the working
+ * set bounded for long animations.
+ */
+public class StreamingWebpWriter {
+
+   /**
+    * Eagerly load {@link Img2WebpHandler} so that the bundled binary is unpacked
+    * and chmod'd the moment {@code StreamingWebpWriter} is first referenced —
+    * not on the very first {@link WebpStream#close()} call deep inside a
+    * try-with-resources, where a missing binary would otherwise surface as a
+    * confusing failure inside an animation pipeline.
+    */
+   private static final Img2WebpHandler HANDLER = new Img2WebpHandler();
+
+   private final Duration frameDelay;
+   private final boolean infiniteLoop;
+   private final boolean lossless;
+   private final int q;
+   private final int m;
+
+   public StreamingWebpWriter() {
+      this(Duration.ofSeconds(2), true, true, -1, -1);
+   }
+
+   public StreamingWebpWriter(Duration frameDelay,
+                              boolean infiniteLoop,
+                              boolean lossless,
+                              int q,
+                              int m) {
+      this.frameDelay = frameDelay;
+      this.infiniteLoop = infiniteLoop;
+      this.lossless = lossless;
+      this.q = q;
+      this.m = m;
+   }
+
+   /**
+    * Default delay used by {@link WebpStream#writeFrame(ImmutableImage)}.
+    */
+   public StreamingWebpWriter withFrameDelay(Duration delay) {
+      return new StreamingWebpWriter(delay, infiniteLoop, lossless, q, m);
+   }
+
+   /**
+    * If {@code true} (the default) the animation loops forever; otherwise it
+    * plays exactly once.
+    */
+   public StreamingWebpWriter withInfiniteLoop(boolean infiniteLoop) {
+      return new StreamingWebpWriter(frameDelay, infiniteLoop, lossless, q, m);
+   }
+
+   /**
+    * If {@code true} (the default) frames are encoded with {@code -lossless};
+    * otherwise with {@code -lossy}.
+    */
+   public StreamingWebpWriter withLossless(boolean lossless) {
+      return new StreamingWebpWriter(frameDelay, infiniteLoop, lossless, q, m);
+   }
+
+   /**
+    * RGB quality factor in {@code [0, 100]}. Ignored unless set explicitly.
+    */
+   public StreamingWebpWriter withQ(int q) {
+      if (q < 0 || q > 100) throw new IllegalArgumentException("q must be between 0 and 100");
+      return new StreamingWebpWriter(frameDelay, infiniteLoop, lossless, q, m);
+   }
+
+   /**
+    * Encoding method in {@code [0, 6]}. Ignored unless set explicitly.
+    */
+   public StreamingWebpWriter withM(int m) {
+      if (m < 0 || m > 6) throw new IllegalArgumentException("m must be between 0 and 6");
+      return new StreamingWebpWriter(frameDelay, infiniteLoop, lossless, q, m);
+   }
+
+   /**
+    * Mirrors {@link com.sksamuel.scrimage.nio.StreamingGifWriter.GifStream}:
+    * the caller writes frames incrementally and the actual encode happens on
+    * {@link #close()}.
+    */
+   public interface WebpStream extends AutoCloseable {
+
+      /**
+       * Writes the given frame using the writer's default {@code frameDelay}.
+       */
+      WebpStream writeFrame(ImmutableImage image) throws IOException;
+
+      /**
+       * Writes the given frame with an explicit display duration.
+       */
+      WebpStream writeFrame(ImmutableImage image, Duration delay) throws IOException;
+
+      /**
+       * Encodes the buffered frames into the destination supplied to
+       * {@code prepareStream} and releases all temp resources.
+       */
+      @Override
+      void close() throws IOException;
+   }
+
+   public WebpStream prepareStream(String path) throws IOException {
+      return prepareStream(Paths.get(path));
+   }
+
+   public WebpStream prepareStream(Path path) throws IOException {
+      return prepareStream(path.toFile());
+   }
+
+   public WebpStream prepareStream(File file) throws IOException {
+      FileOutputStream output = new FileOutputStream(file);
+      try {
+         return prepareStream(output);
+      } catch (RuntimeException e) {
+         try {
+            output.close();
+         } catch (IOException suppressed) {
+            e.addSuppressed(suppressed);
+         }
+         throw e;
+      }
+   }
+
+   public WebpStream prepareStream(OutputStream output) {
+
+      final List<Path> inputs = new ArrayList<>();
+      final List<Integer> delays = new ArrayList<>();
+
+      return new WebpStream() {
+
+         private boolean closed = false;
+
+         @Override
+         public WebpStream writeFrame(ImmutableImage image) throws IOException {
+            return writeFrame(image, frameDelay);
+         }
+
+         @Override
+         public WebpStream writeFrame(ImmutableImage image, Duration delay) throws IOException {
+            if (closed) throw new IOException("WebpStream is already closed");
+            // PngWriter is the lossless format img2webp ingests directly
+            // without re-encoding. NoCompression keeps writeFrame fast since
+            // these PNGs are intermediates that get discarded at close().
+            byte[] pngBytes = image.bytes(PngWriter.NoCompression);
+            Path temp = Files.createTempFile("scrimage_webp_frame_", ".png");
+            Files.write(temp, pngBytes, StandardOpenOption.CREATE);
+            inputs.add(temp);
+            delays.add((int) delay.toMillis());
+            return this;
+         }
+
+         @Override
+         public void close() throws IOException {
+            if (closed) return;
+            closed = true;
+            try {
+               if (inputs.isEmpty()) {
+                  throw new IOException("Cannot close StreamingWebpWriter without writing any frames");
+               }
+               int[] delayArr = new int[delays.size()];
+               for (int i = 0; i < delayArr.length; i++) delayArr[i] = delays.get(i);
+               int loopCount = infiniteLoop ? 0 : 1;
+
+               Path target = Files.createTempFile("scrimage_webp_out_", ".webp");
+               try {
+                  HANDLER.convert(inputs, delayArr, target, loopCount, q, m, lossless);
+                  Files.copy(target, output);
+               } finally {
+                  try {
+                     target.toFile().delete();
+                  } catch (Exception ignored) {
+                  }
+               }
+            } finally {
+               for (Path input : inputs) {
+                  try {
+                     input.toFile().delete();
+                  } catch (Exception ignored) {
+                  }
+               }
+               output.close();
+            }
+         }
+      };
+   }
+}

--- a/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/StreamingWebpWriterTest.kt
+++ b/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/StreamingWebpWriterTest.kt
@@ -1,0 +1,163 @@
+package com.sksamuel.scrimage.webp
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.nio.file.Files
+import java.time.Duration
+
+class StreamingWebpWriterTest : FunSpec({
+
+   /**
+    * The animated WebP container has the magic bytes "RIFF" at offset 0 and
+    * "WEBP" at offset 8. An animation specifically also carries an "ANIM"
+    * chunk somewhere in the file (followed by per-frame "ANMF" chunks).
+    */
+   fun isAnimatedWebp(bytes: ByteArray): Boolean {
+      if (bytes.size < 12) return false
+      if (String(bytes, 0, 4) != "RIFF") return false
+      if (String(bytes, 8, 4) != "WEBP") return false
+      val needle = "ANIM".toByteArray()
+      outer@ for (i in 12..(bytes.size - needle.size)) {
+         for (j in needle.indices) if (bytes[i + j] != needle[j]) continue@outer
+         return true
+      }
+      return false
+   }
+
+   /**
+    * Counts "ANMF" frame chunks in a WebP container. Each animated WebP frame
+    * is wrapped in one ANMF chunk, so this is a quick way to verify the writer
+    * actually emitted the number of frames the caller asked for.
+    */
+   fun countAnmfChunks(bytes: ByteArray): Int {
+      val needle = "ANMF".toByteArray()
+      var count = 0
+      var i = 12
+      while (i <= bytes.size - needle.size) {
+         var match = true
+         for (j in needle.indices) if (bytes[i + j] != needle[j]) { match = false; break }
+         if (match) { count++; i += needle.size } else i++
+      }
+      return count
+   }
+
+   val red = ImmutableImage.filled(32, 16, Color.RED)
+   val blue = ImmutableImage.filled(32, 16, Color.BLUE)
+   val green = ImmutableImage.filled(32, 16, Color.GREEN)
+
+   test("write to memory via OutputStream") {
+      val writer = StreamingWebpWriter().withFrameDelay(Duration.ofMillis(500))
+      val output = ByteArrayOutputStream()
+      writer.prepareStream(output).use { stream ->
+         stream.writeFrame(red)
+         stream.writeFrame(blue)
+         stream.writeFrame(green)
+      }
+      val bytes = output.toByteArray()
+      isAnimatedWebp(bytes).shouldBeTrue()
+      countAnmfChunks(bytes) shouldBe 3
+   }
+
+   test("write to a file path") {
+      val target = Files.createTempFile("streaming_webp_test_", ".webp")
+      try {
+         val writer = StreamingWebpWriter().withFrameDelay(Duration.ofMillis(120))
+         writer.prepareStream(target).use { stream ->
+            stream.writeFrame(red)
+            stream.writeFrame(blue)
+         }
+         val bytes = Files.readAllBytes(target)
+         isAnimatedWebp(bytes).shouldBeTrue()
+         countAnmfChunks(bytes) shouldBe 2
+      } finally {
+         target.toFile().delete()
+      }
+   }
+
+   test("per-frame delay overrides the writer default") {
+      // Mixing the default with an explicit per-frame delay exercises both
+      // overloads of writeFrame and confirms they coexist on a single stream.
+      val writer = StreamingWebpWriter().withFrameDelay(Duration.ofMillis(50))
+      val output = ByteArrayOutputStream()
+      writer.prepareStream(output).use { stream ->
+         stream.writeFrame(red)                              // default 50ms
+         stream.writeFrame(blue, Duration.ofMillis(250))      // explicit
+         stream.writeFrame(green)                             // default 50ms
+      }
+      val bytes = output.toByteArray()
+      isAnimatedWebp(bytes).shouldBeTrue()
+      countAnmfChunks(bytes) shouldBe 3
+   }
+
+   test("withInfiniteLoop(false) still produces a valid animated webp") {
+      val writer = StreamingWebpWriter().withInfiniteLoop(false)
+      val output = ByteArrayOutputStream()
+      writer.prepareStream(output).use { stream ->
+         stream.writeFrame(red)
+         stream.writeFrame(blue)
+      }
+      val bytes = output.toByteArray()
+      isAnimatedWebp(bytes).shouldBeTrue()
+      countAnmfChunks(bytes) shouldBe 2
+   }
+
+   test("lossy and lossless both produce valid animated webps") {
+      val lossless = ByteArrayOutputStream()
+      StreamingWebpWriter().withLossless(true).prepareStream(lossless).use { s ->
+         s.writeFrame(red); s.writeFrame(blue)
+      }
+      isAnimatedWebp(lossless.toByteArray()).shouldBeTrue()
+
+      val lossy = ByteArrayOutputStream()
+      StreamingWebpWriter().withLossless(false).withQ(75).prepareStream(lossy).use { s ->
+         s.writeFrame(red); s.writeFrame(blue)
+      }
+      isAnimatedWebp(lossy.toByteArray()).shouldBeTrue()
+   }
+
+   test("closing without writing any frames throws") {
+      val writer = StreamingWebpWriter()
+      val output = ByteArrayOutputStream()
+      shouldThrow<IOException> {
+         writer.prepareStream(output).close()
+      }
+   }
+
+   test("writing after close throws") {
+      val writer = StreamingWebpWriter()
+      val output = ByteArrayOutputStream()
+      val stream = writer.prepareStream(output)
+      stream.writeFrame(red)
+      stream.close()
+      shouldThrow<IOException> {
+         stream.writeFrame(blue)
+      }
+   }
+
+   test("close is idempotent") {
+      val writer = StreamingWebpWriter()
+      val output = ByteArrayOutputStream()
+      val stream = writer.prepareStream(output)
+      stream.writeFrame(red)
+      stream.close()
+      // Second close must not throw, must not re-encode, must not corrupt the
+      // already-written output.
+      stream.close()
+   }
+
+   test("withQ rejects out-of-range values") {
+      shouldThrow<IllegalArgumentException> { StreamingWebpWriter().withQ(-1) }
+      shouldThrow<IllegalArgumentException> { StreamingWebpWriter().withQ(101) }
+   }
+
+   test("withM rejects out-of-range values") {
+      shouldThrow<IllegalArgumentException> { StreamingWebpWriter().withM(-1) }
+      shouldThrow<IllegalArgumentException> { StreamingWebpWriter().withM(7) }
+   }
+})


### PR DESCRIPTION
## Summary

Follow-up to #446. Adds `StreamingWebpWriter` — the animated WebP equivalent of `StreamingGifWriter`. Lets callers assemble an animated WebP one frame at a time without holding every frame in memory.

```java
StreamingWebpWriter writer = new StreamingWebpWriter()
   .withFrameDelay(Duration.ofMillis(100))
   .withInfiniteLoop(true);

try (StreamingWebpWriter.WebpStream stream = writer.prepareStream(target)) {
   stream.writeFrame(frame0);
   stream.writeFrame(frame1, Duration.ofMillis(250));
   stream.writeFrame(frame2);
}
```

## Contract — mirrors StreamingGifWriter

| StreamingGifWriter | StreamingWebpWriter |
|---|---|
| `withFrameDelay(Duration)` | same |
| `withInfiniteLoop(boolean)` | same |
| `withCompression(boolean)` | `withLossless(boolean)` (the WebP-native equivalent) |
| — | `withQ(int)` 0..100 (validated) |
| — | `withM(int)` 0..6 (validated) |
| `prepareStream(File / Path / String / OutputStream, imageType)` | `prepareStream(File / Path / String / OutputStream)` (no imageType — img2webp accepts any of PNG/JPEG/TIFF/PNM/WebP) |
| `GifStream extends AutoCloseable` | `WebpStream extends AutoCloseable` |
| `writeFrame(image)` / `writeFrame(image, Duration)` | same two overloads |
| Encode runs incrementally | Encode runs at `close()` (img2webp is one-shot) |

## Implementation notes

- `img2webp` is a one-shot CLI, so `writeFrame` buffers each frame to disk as a `NoCompression` PNG and the actual encode is invoked from `close()` with all frames + per-frame delays. Buffering on disk (not memory) keeps the working set bounded for long animations.
- Per-frame delay support required extending `Img2WebpHandler` with a new `convert(List<Path>, int[] frameDelaysMs, Path, int loopCount, int q, int m, boolean lossless)` overload. The existing single-delay `convert(...)` overload now delegates to it with a uniform delays array, so #446's API is unchanged.
- A `private static final Img2WebpHandler HANDLER = new Img2WebpHandler();` field forces `Img2WebpHandler`'s static initialiser — and therefore the bundled binary unpack + chmod — the moment `StreamingWebpWriter` is first referenced. A missing/broken binary surfaces immediately rather than mid-pipeline inside a try-with-resources.

## Test plan

- [x] New `StreamingWebpWriterTest` with 10 cases drives the bundled binary end-to-end:
  - write to memory via `OutputStream`
  - write to a file path
  - per-frame delay overrides the writer default
  - `withInfiniteLoop(false)` still produces a valid animated webp
  - lossy and lossless both produce valid animated webps
  - closing without writing any frames throws
  - writing after close throws
  - `close()` is idempotent
  - `withQ` rejects out-of-range values
  - `withM` rejects out-of-range values
- All 21 `:scrimage-webp:test` cases green (10 new + 11 from #446 / pre-existing).
- Output verified by parsing the WebP container: each `ANMF` chunk = one frame, plus the file-level `RIFF…WEBP…ANIM` markers.

## Note on stacking

This PR is stacked on top of #446 (the `add-img2webp-handler` branch). The GitHub diff therefore includes #446's changes (the handler + bundled binaries) until that PR merges. Once #446 lands, GitHub will automatically narrow the diff to only the streaming writer + handler overload + tests added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)