### PR TITLE
Fix SaltAndPepperFilter writing alpha=0 pixels (transparent salt and pepper)

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
@@ -13,16 +13,21 @@ public class SaltAndPepperFilter implements Filter {
       this.pepper = pepper;
    }
 
+   // Opaque black and opaque white as packed ARGB ints. The previous
+   // values (0 and 0x00FFFFFF) had alpha=0, so on TYPE_INT_ARGB images
+   // the salt and pepper came out fully transparent rather than the
+   // intended opaque white / opaque black.
+   private static final int OPAQUE_BLACK = 0xFF000000;
+   private static final int OPAQUE_WHITE = 0xFFFFFFFF;
+
    @Override
    public void apply(ImmutableImage img) {
       for (int i = 0; i < img.width; i++) {
          for (int j = 0; j < img.height; j++) {
             if (Math.random() < pepper) {
-               img.setColor(i, j, RGBColor.fromARGBInt(0));
+               img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_BLACK));
             } else if (Math.random() < salt) {
-               int gray = 255;
-               int rgb = ((gray * 256) + gray) * 256 + gray;
-               img.setColor(i, j, RGBColor.fromARGBInt(rgb));
+               img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_WHITE));
             }
          }
       }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SaltAndPepperFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SaltAndPepperFilterTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class SaltAndPepperFilterTest : FunSpec({
+
+   // With salt=1.0 and pepper=0.0, the inner branch reached for every pixel
+   // is the salt path. After the filter, every pixel should be opaque white.
+   //
+   // Previously the salt branch packed `(255 << 16) | (255 << 8) | 255`
+   // (= 0x00FFFFFF) as the ARGB value, so on a TYPE_INT_ARGB image every
+   // "white" pixel had alpha=0 and the entire image came out fully
+   // transparent.
+   test("salt produces opaque white pixels on a TYPE_INT_ARGB image") {
+      val source = ImmutableImage.filled(40, 30, Color.RED)
+      val out = source.filter(SaltAndPepperFilter(1.0, 0.0))
+
+      // Every pixel must now be opaque white. The earlier behaviour gave
+      // alpha=0 for every salt pixel.
+      out.pixels().forEach { p ->
+         p.alpha() shouldBe 255
+         p.red() shouldBe 255
+         p.green() shouldBe 255
+         p.blue() shouldBe 255
+      }
+   }
+
+   // Symmetric coverage for the pepper path: with pepper=1.0 every pixel
+   // should be opaque black, not transparent black.
+   test("pepper produces opaque black pixels on a TYPE_INT_ARGB image") {
+      val source = ImmutableImage.filled(40, 30, Color.RED)
+      val out = source.filter(SaltAndPepperFilter(0.0, 1.0))
+
+      out.pixels().forEach { p ->
+         p.alpha() shouldBe 255
+         p.red() shouldBe 0
+         p.green() shouldBe 0
+         p.blue() shouldBe 0
+      }
+   }
+})


### PR DESCRIPTION
## Summary

`SaltAndPepperFilter` packed its salt and pepper colours via the bare RGB expression

```java
int rgb = ((gray * 256) + gray) * 256 + gray;
```

which gives `0x00FFFFFF` for white and `0` for black — both with **alpha=0**.

`RGBColor.fromARGBInt` honours the alpha bits, so on `TYPE_INT_ARGB` images (the default data type) every salt pixel came out fully transparent white and every pepper pixel came out fully transparent black. The intent — making pixels actually appear as white / black noise — was silently broken for any image with an alpha channel.

Pack the values with `alpha=0xFF` and lift them to named constants so the intent is explicit.

## Test plan

- [x] New `SaltAndPepperFilterTest` filters a 40×30 `TYPE_INT_ARGB` red image once with `salt=1.0` and once with `pepper=1.0`, asserting every output pixel is opaque white / opaque black respectively. Both assertions fail on master (`alpha was 0`); both pass after the fix.
- [x] Full `:scrimage-filters:test` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)