### PR TITLE
Fix GifSequenceReader.resetFrame leaking previous frame's GCE state via shadowed locals

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
@@ -810,9 +810,14 @@ public class GifSequenceReader {
       lastRect = new Rectangle(ix, iy, iw, ih);
       lastImage = image;
       lastBgColor = bgColor;
-      int dispose = 0;
-      boolean transparency = false;
-      int delay = 0;
+      // These three were previously declared as locals, shadowing the
+      // instance fields. The intent is to reset the frame state ready for
+      // the next image: per the GIF spec, the graphics control extension
+      // is optional, so when a frame omits one the parser must fall back
+      // to defaults rather than inheriting the previous frame's values.
+      this.dispose = 0;
+      this.transparency = false;
+      this.delay = 0;
       lct = null;
    }
 

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
@@ -297,8 +297,16 @@ public class GifSequenceReader {
     * @throws IOException
     */
    public byte[] bytes() throws IOException {
+      // Use the first frame's recorded delay rather than the parser's
+      // (now correctly reset-to-zero) leftover GCE state. GifSequenceWriter
+      // applies a single delay to every frame, so for uniform-delay GIFs
+      // (the common case) this preserves the source's playback timing.
+      // Previously this read the instance `delay` field, which only
+      // happened to hold the last frame's delay because resetFrame was
+      // shadowing rather than resetting it.
+      long frameDelayMs = frames.isEmpty() ? 0 : frames.get(0).delay;
       return new GifSequenceWriter()
-         .withFrameDelay(delay)
+         .withFrameDelay(frameDelayMs)
          .withInfiniteLoop(loopCount == 0)
          .bytes(frames.stream()
             .map(frame -> frame.image)

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderResetFrameTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderResetFrameTest.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.scrimage.core.nio.internal
+
+import com.sksamuel.scrimage.nio.internal.GifSequenceReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression for a bug where [GifSequenceReader.resetFrame] declared three
+ * local variables (`int dispose = 0; boolean transparency = false; int delay = 0`)
+ * that shadowed the protected instance fields with the same names. The
+ * locals were assigned but never used, so the previous frame's `dispose`,
+ * `transparency` and `delay` values silently leaked into the next frame
+ * whenever that frame omitted its (optional) graphics control extension.
+ *
+ * The test subclasses the reader to access the protected fields, sets them
+ * to non-default values to simulate "the previous frame had a GCE", invokes
+ * `resetFrame`, and asserts they're back to their per-frame defaults.
+ */
+class GifSequenceReaderResetFrameTest : FunSpec({
+
+   class ProbeReader : GifSequenceReader() {
+      fun primeAndReset(d: Int, t: Boolean, dl: Int) {
+         dispose = d
+         transparency = t
+         delay = dl
+         resetFrame()
+      }
+
+      val currentDispose: Int get() = dispose
+      val currentTransparency: Boolean get() = transparency
+      val currentDelay: Int get() = delay
+   }
+
+   test("resetFrame clears dispose/transparency/delay back to defaults") {
+      val reader = ProbeReader()
+      reader.primeAndReset(2, true, 250)
+      reader.currentDispose shouldBe 0
+      reader.currentTransparency shouldBe false
+      reader.currentDelay shouldBe 0
+   }
+})


### PR DESCRIPTION
## Summary

`GifSequenceReader.resetFrame` ends with

```java
int dispose = 0;
boolean transparency = false;
int delay = 0;
```

declaring three **local** variables that shadow the protected instance fields of the same names. The locals are assigned but never read, so the previous frame's `dispose` / `transparency` / `delay` values silently persisted into the next frame.

This matters because per the GIF spec the graphics control extension is optional — a frame that omits one is supposed to fall back to default GCE values. With this bug the next frame inherited the previous frame's GCE state instead. A GIF with, say, frame 0 `dispose=2` (restore-to-bg) followed by a frame with no GCE got decoded with `dispose=2` on the second frame too, which then cascaded into incorrect composition via `setPixels`.

## Test plan

- [x] New `GifSequenceReaderResetFrameTest` subclasses the reader to access the protected fields, primes them with non-default values to simulate \"the previous frame had a GCE\", calls `resetFrame`, and asserts the fields are back to defaults. Fails on master, passes after the fix.
- [x] Full gif test suite (`./gradlew :scrimage-tests:test --tests \"*Gif*\"`, ~25 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)