### PR TITLE
Make Tag.equals and Tag.hashCode null-safe for rawValue and value

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Tag.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Tag.java
@@ -1,5 +1,7 @@
 package com.sksamuel.scrimage.metadata;
 
+import java.util.Objects;
+
 public class Tag {
 
    private final String name;
@@ -14,6 +16,12 @@ public class Tag {
       this.value = value;
    }
 
+   // rawValue and value can both be null in practice — they come from
+   // drewmetadata's `dir.getString(tagType)` and `tag.getDescription()`,
+   // which return null for some real EXIF tags. Use Objects.equals /
+   // Objects.hashCode rather than calling .equals / .hashCode directly
+   // to avoid NullPointerException on those metadata records.
+
    @Override
    public boolean equals(Object o) {
       if (this == o) return true;
@@ -22,17 +30,17 @@ public class Tag {
       Tag tag = (Tag) o;
 
       if (type != tag.type) return false;
-      if (!name.equals(tag.name)) return false;
-      if (!rawValue.equals(tag.rawValue)) return false;
-      return value.equals(tag.value);
+      if (!Objects.equals(name, tag.name)) return false;
+      if (!Objects.equals(rawValue, tag.rawValue)) return false;
+      return Objects.equals(value, tag.value);
    }
 
    @Override
    public int hashCode() {
-      int result = name.hashCode();
+      int result = Objects.hashCode(name);
       result = 31 * result + type;
-      result = 31 * result + rawValue.hashCode();
-      result = 31 * result + value.hashCode();
+      result = 31 * result + Objects.hashCode(rawValue);
+      result = 31 * result + Objects.hashCode(value);
       return result;
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/TagNullSafetyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/TagNullSafetyTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.scrimage.core.metadata
+
+import com.sksamuel.scrimage.metadata.Tag
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression for Tag.equals / Tag.hashCode previously calling .equals
+ * and .hashCode unconditionally on rawValue and value. Both fields can
+ * be null in the wild — they come from drewmetadata's
+ * `Directory.getString(int)` and `Tag.getDescription()`, which return
+ * null for some real EXIF tags — and the unprotected calls would NPE.
+ */
+class TagNullSafetyTest : FunSpec({
+
+   test("Tag.hashCode tolerates a null rawValue") {
+      // Did not throw: the assertion is implicit in this call returning.
+      Tag("Make", 271, null, "Canon").hashCode()
+   }
+
+   test("Tag.hashCode tolerates a null value") {
+      Tag("Make", 271, "Canon", null).hashCode()
+   }
+
+   test("Tag.hashCode tolerates both null") {
+      Tag("Make", 271, null, null).hashCode()
+   }
+
+   test("Tag.equals tolerates a null rawValue") {
+      val a = Tag("Make", 271, null, "Canon")
+      val b = Tag("Make", 271, null, "Canon")
+      a.equals(b) shouldBe true
+   }
+
+   test("Tag.equals tolerates a null value") {
+      val a = Tag("Make", 271, "Canon", null)
+      val b = Tag("Make", 271, "Canon", null)
+      a.equals(b) shouldBe true
+   }
+
+   test("Tag.equals distinguishes one null rawValue from a non-null one") {
+      val a = Tag("Make", 271, null, "Canon")
+      val b = Tag("Make", 271, "raw", "Canon")
+      a.equals(b) shouldBe false
+      b.equals(a) shouldBe false
+   }
+
+   test("Tag.equals contract: equal Tags have equal hash codes (with nulls)") {
+      val a = Tag("Make", 271, null, null)
+      val b = Tag("Make", 271, null, null)
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   test("Tag.equals: a Tag with null rawValue is not equal to one with a different name") {
+      val a = Tag("Make", 271, null, "Canon")
+      val b = Tag("Model", 272, null, "Canon")
+      a shouldNotBe b
+   }
+})


### PR DESCRIPTION
## Summary

`Tag` fields `rawValue` and `value` can both be null in practice — they come from drewmetadata's `Directory.getString(int)` and `Tag.getDescription()`, which return null for some real EXIF tags (see `ImageMetadata.fromMetadata` for the construction site). The previous `equals` and `hashCode` called `.equals` / `.hashCode` on those fields unconditionally and threw `NullPointerException` as soon as a `Tag` with either nulled field was compared, hashed, or put into a `HashSet`/`HashMap`.

Switch to `Objects.equals` / `Objects.hashCode` for the nullable fields (also applied to `name` defensively — harmless since `name` is non-null in practice).

## Test plan

- [x] New `TagNullSafetyTest` with 8 cases covering `hashCode` and `equals` across each combination of nulled `rawValue` / `value`, plus the equals/hashCode contract for two equal-with-nulls Tags. Seven NPE on master; all eight pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)