### PR TITLE
Wrap Graphics2D dispose() in try/finally for Watermark and Vignette filters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
@@ -49,26 +49,29 @@ public class VignetteFilter implements Filter {
 
         ImmutableImage target = image.blank();
         Graphics2D g2 = (Graphics2D) target.awt().getGraphics();
-        float radius = image.radius() * end;
+        try {
+            float radius = image.radius() * end;
 
-        final float fraction;
-        if (start == 0) fraction = 0.01f;
-        else if (start == 1) fraction = 0.999f;
-        else fraction = start;
+            final float fraction;
+            if (start == 0) fraction = 0.01f;
+            else if (start == 1) fraction = 0.999f;
+            else fraction = start;
 
-        RadialGradientPaint p = new RadialGradientPaint(
-                new Point2D.Float(target.centreX(), target.centreY()),
-                radius,
-                new float[]{0.0f, fraction, 1f},
-                new Color[]{Color.WHITE, Color.WHITE, color});
+            RadialGradientPaint p = new RadialGradientPaint(
+                    new Point2D.Float(target.centreX(), target.centreY()),
+                    radius,
+                    new float[]{0.0f, fraction, 1f},
+                    new Color[]{Color.WHITE, Color.WHITE, color});
 
-        g2.setPaint(p);
-        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setRenderingHint(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
-        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-        g2.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-        g2.fillRect(0, 0, target.width, target.height);
-        g2.dispose();
+            g2.setPaint(p);
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.setRenderingHint(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            g2.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+            g2.fillRect(0, 0, target.width, target.height);
+        } finally {
+            g2.dispose();
+        }
 
         return target;
     }
@@ -78,8 +81,11 @@ public class VignetteFilter implements Filter {
     public void apply(ImmutableImage image) throws IOException {
         ImmutableImage bg = background(image).filter(new GaussianBlurFilter((int) (image.radius() * blur)));
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        g2.setComposite(new BlendComposite(BlendingMode.MULTIPLY, 1.0f));
-        g2.drawImage(bg.awt(), 0, 0, null);
-        g2.dispose();
+        try {
+            g2.setComposite(new BlendComposite(BlendingMode.MULTIPLY, 1.0f));
+            g2.drawImage(bg.awt(), 0, 0, null);
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkCoverFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkCoverFilter.java
@@ -42,24 +42,26 @@ public class WatermarkCoverFilter implements Filter {
     @Override
     public void apply(ImmutableImage image) {
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        setupGraphics(g2);
+        try {
+            setupGraphics(g2);
 
-        FontMetrics fontMetrics = g2.getFontMetrics();
-        Rectangle2D bounds = fontMetrics.getStringBounds(text + " ", g2);
+            FontMetrics fontMetrics = g2.getFontMetrics();
+            Rectangle2D bounds = fontMetrics.getStringBounds(text + " ", g2);
 
-        int x = 0;
-        int xstart = 0;
-        int y = (int) bounds.getY();
-        while (y < image.height + bounds.getHeight()) {
-            while (x < image.width + bounds.getWidth()) {
-                g2.drawString(text, x, y);
-                x = (int) (x + bounds.getWidth());
+            int x = 0;
+            int xstart = 0;
+            int y = (int) bounds.getY();
+            while (y < image.height + bounds.getHeight()) {
+                while (x < image.width + bounds.getWidth()) {
+                    g2.drawString(text, x, y);
+                    x = (int) (x + bounds.getWidth());
+                }
+                y = (int) (y + (bounds.getHeight() + bounds.getHeight() * 0.2));
+                xstart = (int) (xstart - bounds.getWidth() * 0.2f);
+                x = xstart;
             }
-            y = (int) (y + (bounds.getHeight() + bounds.getHeight() * 0.2));
-            xstart = (int) (xstart - bounds.getWidth() * 0.2f);
-            x = xstart;
+        } finally {
+            g2.dispose();
         }
-
-        g2.dispose();
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkStampFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkStampFilter.java
@@ -57,26 +57,29 @@ public class WatermarkStampFilter implements Filter {
     public void apply(ImmutableImage image) {
 
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        setupGraphics(g2);
+        try {
+            setupGraphics(g2);
 
-        FontMetrics fontMetrics = g2.getFontMetrics();
-        Rectangle2D bounds = fontMetrics.getStringBounds(text, g2);
+            FontMetrics fontMetrics = g2.getFontMetrics();
+            Rectangle2D bounds = fontMetrics.getStringBounds(text, g2);
 
-        g2.translate(image.width / 2.0, image.height / 2.0);
+            g2.translate(image.width / 2.0, image.height / 2.0);
 
-        AffineTransform rotation = new AffineTransform();
-        double opad = image.height / (double) image.width;
-        double angle = Math.toDegrees(Math.atan(opad));
-        double idegrees = -1 * angle;
-        double theta = (2 * Math.PI * idegrees) / 360;
-        rotation.rotate(theta);
-        g2.transform(rotation);
+            AffineTransform rotation = new AffineTransform();
+            double opad = image.height / (double) image.width;
+            double angle = Math.toDegrees(Math.atan(opad));
+            double idegrees = -1 * angle;
+            double theta = (2 * Math.PI * idegrees) / 360;
+            rotation.rotate(theta);
+            g2.transform(rotation);
 
-        double x1 = bounds.getWidth() / 2.0f * -1;
-        double y1 = bounds.getHeight() / 2.0f;
-        g2.translate(x1, y1);
+            double x1 = bounds.getWidth() / 2.0f * -1;
+            double y1 = bounds.getHeight() / 2.0f;
+            g2.translate(x1, y1);
 
-        g2.drawString(text, 0.0f, 0.0f);
-        g2.dispose();
+            g2.drawString(text, 0.0f, 0.0f);
+        } finally {
+            g2.dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three filters in `scrimage-filters` acquired a `Graphics2D` and called `dispose()` only on the success path — four call sites total:

- `WatermarkCoverFilter.apply`
- `WatermarkStampFilter.apply`
- `VignetteFilter.background` (private helper)
- `VignetteFilter.apply`

If any `drawString` / `drawImage` / `setRenderingHint` between acquisition and `dispose` throws — pathological font, incompatible composite mode, or a downstream filter exception in `VignetteFilter.apply` where the `GaussianBlurFilter` call sits between two graphics operations — the `dispose` was skipped and the underlying native graphics context leaked until GC.

Wrap each block in `try { ... } finally { g2.dispose(); }`, matching the pattern PR #432 applied across `scrimage-core` composites and PR #431 applied to `BorderFilter` / `CaptionFilter`.

## Test plan

- [x] Full `:scrimage-filters:test` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)