### PR TITLE
Fix SwimFilter(Random) constructor ignoring its random parameter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SwimFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SwimFilter.java
@@ -31,7 +31,7 @@ public class SwimFilter extends BufferedOpFilter {
     }
 
     public SwimFilter(Random random) {
-        this(new Random(), 6f, 2f);
+        this(random, 6f, 2f);
     }
 
     public SwimFilter(float amount, float stretch) {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SwimFilterRandomTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SwimFilterRandomTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.util.Random
+
+class SwimFilterRandomTest : FunSpec({
+
+   // Regression for SwimFilter(Random) constructor previously delegating to
+   // `this(new Random(), 6f, 2f)` — discarding the seeded Random the caller
+   // passed in. That broke deterministic / reproducible tests because every
+   // invocation got a fresh non-deterministic Random regardless of what was
+   // passed in.
+   //
+   // With a properly threaded-through seed, two SwimFilter instances built
+   // from two Randoms with the same seed must produce byte-identical output
+   // when applied to the same source image.
+   test("SwimFilter(Random) honours the seed it's given") {
+      val source = ImmutableImage.filled(64, 32, Color.RED)
+
+      val a = source.filter(SwimFilter(Random(42L)))
+      val b = source.filter(SwimFilter(Random(42L)))
+
+      // Same seed → same output. Previously the SwimFilter(Random) constructor
+      // ignored the parameter, so two invocations diverged.
+      a.bytes(com.sksamuel.scrimage.nio.PngWriter.NoCompression)
+         .contentEquals(b.bytes(com.sksamuel.scrimage.nio.PngWriter.NoCompression)) shouldBe true
+   }
+})


### PR DESCRIPTION
## Summary

`SwimFilter`'s single-arg constructor delegated via

```java
public SwimFilter(Random random) {
    this(new Random(), 6f, 2f);   // <-- ignores `random`
}
```

The seeded `Random` the caller passed in was thrown away in favour of a fresh non-deterministic one, so anyone passing a seeded `Random` for reproducible output silently got a different random stream every time. Breaks deterministic tests and reproducible image pipelines.

## Test plan

- [x] New `SwimFilterRandomTest` builds two `SwimFilter` instances from two `Random`s with the **same seed**, applies each to the same source image, and asserts the output bytes match. Fails on master (different bytes — fresh non-deterministic Randoms each time); passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)