### PR TITLE
Stop Text drawable from re-applying its GraphicsContext

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Text.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Text.java
@@ -20,7 +20,11 @@ public class Text implements Drawable {
 
     @Override
     public void draw(RichGraphics2D g2) {
-        context.configure(g2);
+        // Canvas.draw / drawInPlace already invoke `d.context().configure(g2)`
+        // before calling d.draw(g2) — the same way it does for every other
+        // Drawable. This class used to call configure() a second time here,
+        // which was a no-op for overwriting setters (setColor/setFont/...) but
+        // applied additive operations (translate/rotate/transform) twice.
         g2.drawString(text, x, y);
     }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/TextDoubleConfigureTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/TextDoubleConfigureTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.scrimage.canvas
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.drawables.Text
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.awt.Font
+
+class TextDoubleConfigureTest : FunSpec({
+
+   // Regression for Text.draw calling context.configure() a second time.
+   // Canvas.draw / drawInPlace already invokes d.context().configure(g2)
+   // before calling d.draw(g2) — same as it does for every other Drawable —
+   // and Text was the only Drawable that re-applied its context inside
+   // draw(). For overwriting setters (setColor, setFont, setComposite) the
+   // duplicate is a no-op, but for *additive* operations (translate, rotate,
+   // transform) it doubled the effect.
+   //
+   // Concrete demonstration: build a Text with a context that translates by
+   // (50, 50) then sets a black foreground, draw it at coordinates (0, 0)
+   // on a white canvas, and check where the text actually lands. With the
+   // previous double-configure the translate ran twice, so the text rendered
+   // at canvas position (100, 100) instead of (50, 50).
+   test("Text honours its translate context exactly once") {
+      val canvas = Canvas(ImmutableImage.filled(160, 160, Color.WHITE))
+
+      val drawn = canvas.draw(
+         Text("X", 0, 0) { g ->
+            g.translate(50, 50)
+            g.color = Color.BLACK
+            g.font = Font(Font.SANS_SERIF, Font.PLAIN, 14)
+         }
+      ).image
+
+      // Helper: count how many pixels in a row band are markedly darker
+      // than the white background (i.e. ink pixels from the rendered glyph).
+      fun inkPixelsInRow(y: Int): Int {
+         var count = 0
+         for (x in 0 until drawn.width) {
+            val p = drawn.pixel(x, y)
+            // White background is (255,255,255). Anything noticeably darker
+            // counts as ink. AA produces grey pixels around the glyph, so
+            // pick a generous threshold.
+            if (p.red() < 200 && p.green() < 200 && p.blue() < 200) count++
+         }
+         return count
+      }
+
+      // The glyph baseline of a 14pt sans-serif "X" rendered at y=0 lands
+      // a few pixels above y, so look in a band around the requested top
+      // (y=50, after one translate) versus the doubled position (y=100,
+      // after the buggy double translate).
+      val inkAround50 = (40..70).sumOf { inkPixelsInRow(it) }
+      val inkAround100 = (90..120).sumOf { inkPixelsInRow(it) }
+
+      // Expect: ink lands around y=50, not y=100.
+      (inkAround50 > 0) shouldBe true
+      inkAround100 shouldBe 0
+   }
+})


### PR DESCRIPTION
## Summary

`Canvas.draw` / `drawInPlace` already invokes `d.context().configure(g2)` before calling `d.draw(g2)` — the same way it does for every other `Drawable`. `Text` was the only drawable that called `configure()` a second time inside `draw()`:

```java
public void draw(RichGraphics2D g2) {
    context.configure(g2);            // <-- duplicate; Canvas already did this
    g2.drawString(text, x, y);
}
```

For overwriting setters (`setColor`, `setFont`, `setComposite`, ...) the duplicate was a wasted no-op. For **additive** operations (`translate`, `rotate`, `transform`) it doubled the effect — a context that translated by (50, 50) ended up moving the text by (100, 100).

Drop the duplicate `configure` call.

## Test plan

- [x] New `TextDoubleConfigureTest` builds a `Text` with a context that translates by (50, 50), draws it on a 160×160 white canvas at coordinates (0, 0), and counts ink pixels in horizontal bands around y=50 vs y=100. With the bug, glyph lands around y=100; with the fix it lands around y=50. Fails on master, passes after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)