### PR TITLE
Validate trim arguments up front for a clearer error

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1587,6 +1587,21 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image with the dimensions width-trim*2, height-trim*2
     */
    public ImmutableImage trim(int left, int top, int right, int bottom) {
+      // Validate up front so the caller gets a useful diagnostic (which
+      // arguments + the source dimensions) rather than the bare
+      // "Width cannot be <= 0" / "Height cannot be <= 0" subimage throws
+      // on negative or zero remaining dimensions.
+      if (left < 0 || top < 0 || right < 0 || bottom < 0) {
+         throw new IllegalArgumentException(
+            "trim amounts must be non-negative; got "
+               + "left=" + left + ", top=" + top + ", right=" + right + ", bottom=" + bottom);
+      }
+      if (left + right >= width || top + bottom >= height) {
+         throw new IllegalArgumentException(
+            "trim amounts leave no remaining image: "
+               + "left+right=" + (left + right) + " (width=" + width + "), "
+               + "top+bottom=" + (top + bottom) + " (height=" + height + ")");
+      }
       // Use subimage(...) — exact pixel copy that preserves alpha precision
       // and metadata. The previous create(...).overlay(this, -left, -top)
       // route went through Graphics2D.drawImage which composites via SrcOver

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/TrimDegenerateInputTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/TrimDegenerateInputTest.kt
@@ -1,0 +1,50 @@
+package com.sksamuel.scrimage.core.ops
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.awt.Color
+
+class TrimDegenerateInputTest : FunSpec({
+
+   // Regression: trim(left, top, right, bottom) used to delegate straight
+   // to subimage(left, top, width-left-right, height-bottom-top), and when
+   // the trim amounts equalled or exceeded the source dimensions the
+   // caller saw a bare "Width cannot be <= 0" / "Height cannot be <= 0"
+   // RuntimeException out of subimage with no context about which trim
+   // amounts caused it. Now trim validates up front and throws a clear
+   // IllegalArgumentException naming the offending arguments.
+
+   val source = ImmutableImage.filled(100, 80, Color.RED)
+
+   test("trim throws IllegalArgumentException when left+right equals width") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         source.trim(50, 0, 50, 0)
+      }
+      ex.message!!.shouldContain("trim amounts leave no remaining image")
+      ex.message!!.shouldContain("width=100")
+   }
+
+   test("trim throws IllegalArgumentException when top+bottom exceeds height") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         source.trim(0, 50, 0, 40)
+      }
+      ex.message!!.shouldContain("trim amounts leave no remaining image")
+      ex.message!!.shouldContain("height=80")
+   }
+
+   test("trim rejects negative trim amounts") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         source.trim(-1, 0, 0, 0)
+      }
+      ex.message!!.shouldContain("trim amounts must be non-negative")
+   }
+
+   test("trim still works for valid amounts that leave a positive remaining area") {
+      val out = source.trim(10, 5, 10, 5)
+      out.width shouldBe 80
+      out.height shouldBe 70
+   }
+})


### PR DESCRIPTION
## Summary

`ImmutableImage.trim(left, top, right, bottom)` used to delegate straight to `subimage(left, top, width - left - right, height - bottom - top)`. When the trim amounts equalled or exceeded the source dimensions, callers got a bare `RuntimeException: Width cannot be <= 0` / `Height cannot be <= 0` out of `subimage` with **no context about which trim arguments caused it**. Negative trim amounts produced an even more cryptic out-of-range failure deeper inside `getRGB`.

Validate up front and throw `IllegalArgumentException` naming the offending arguments and the source dimensions:

```
trim amounts must be non-negative; got left=-1, top=0, right=0, bottom=0
trim amounts leave no remaining image: left+right=100 (width=100), top+bottom=0 (height=80)
```

This is the same shape of fix as PR #445 made for `autocrop` on an all-bg image.

## Test plan

- [x] New `TrimDegenerateInputTest` with four cases:
  - `trim(50, 0, 50, 0)` on a 100×80 image (left+right == width)
  - `trim(0, 50, 0, 40)` on a 100×80 image (top+bottom > height)
  - `trim(-1, 0, 0, 0)` (negative amount)
  - `trim(10, 5, 10, 5)` on a 100×80 image — still works, returns 80×70
- [x] Three fail on master with the bare `RuntimeException`; all four pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)