### PR TITLE
Sort anim_dump output by parsed frame index, not lexicographically

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/AnimDumpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/AnimDumpHandler.java
@@ -42,6 +42,25 @@ public class AnimDumpHandler extends WebpHandler {
    }
 
    /**
+    * Extract the integer frame index from an anim_dump output filename like
+    * {@code dump_0001.png} or {@code dump_12345.png}. Used to sort dumped
+    * frames into playback order.
+    */
+   static int frameIndex(Path path) {
+      String name = path.getFileName().toString();
+      int start = name.indexOf('_') + 1;
+      int end = name.lastIndexOf('.');
+      if (start <= 0 || end <= start) return Integer.MAX_VALUE;
+      try {
+         return Integer.parseInt(name.substring(start, end));
+      } catch (NumberFormatException e) {
+         // Anything we don't recognise sorts to the end so the recognisable
+         // frames stay in their natural order.
+         return Integer.MAX_VALUE;
+      }
+   }
+
+   /**
     * Renders each frame of the given animated WebP and returns the per-frame
     * PNG bytes in playback order.
     */
@@ -57,9 +76,12 @@ public class AnimDumpHandler extends WebpHandler {
             dumped = new ArrayList<>();
             stream.forEach(dumped::add);
          }
-         // anim_dump names files like dump_0000.png, dump_0001.png, ...; sort
-         // lexicographically to recover playback order.
-         dumped.sort(Comparator.comparing(p -> p.getFileName().toString()));
+         // anim_dump names files like dump_0000.png, dump_0001.png, ... and
+         // overflows to dump_10000.png at frame 10000. Sort by the parsed
+         // numeric portion rather than lexicographically — under a string
+         // sort dump_10000.png comes BEFORE dump_2.png, which would scramble
+         // playback order for animations with 10000+ frames.
+         dumped.sort(Comparator.comparingInt(AnimDumpHandler::frameIndex));
 
          List<byte[]> frames = new ArrayList<>(dumped.size());
          for (Path p : dumped) {

--- a/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/AnimDumpHandlerFrameOrderingTest.kt
+++ b/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/AnimDumpHandlerFrameOrderingTest.kt
@@ -1,0 +1,50 @@
+package com.sksamuel.scrimage.webp
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Paths
+
+class AnimDumpHandlerFrameOrderingTest : FunSpec({
+
+   // Regression for AnimDumpHandler sorting dumped frames lexicographically.
+   // anim_dump emits dump_0000.png, dump_0001.png, ... , dump_9999.png and
+   // then dump_10000.png. Lexicographic sort puts dump_10000.png BEFORE
+   // dump_2.png because string comparison stops at the first '1' < '2'
+   // character — scrambling playback order for animations with 10000+ frames.
+   //
+   // The frameIndex helper now parses the embedded integer so the ordering
+   // is purely numeric.
+   test("frame indices are extracted as integers, not strings") {
+      AnimDumpHandler.frameIndex(Paths.get("dump_0000.png")) shouldBe 0
+      AnimDumpHandler.frameIndex(Paths.get("dump_0001.png")) shouldBe 1
+      AnimDumpHandler.frameIndex(Paths.get("dump_0002.png")) shouldBe 2
+      AnimDumpHandler.frameIndex(Paths.get("dump_9999.png")) shouldBe 9999
+      AnimDumpHandler.frameIndex(Paths.get("dump_10000.png")) shouldBe 10000
+      AnimDumpHandler.frameIndex(Paths.get("dump_99999.png")) shouldBe 99999
+   }
+
+   test("a numeric sort by frameIndex orders dump_10000 after dump_9999, not after dump_1") {
+      val names = listOf(
+         "dump_0001.png",
+         "dump_10000.png",
+         "dump_0002.png",
+         "dump_9999.png",
+         "dump_0010.png",
+      )
+      val sortedByLex = names.sorted()
+      val sortedByIndex = names.sortedBy { AnimDumpHandler.frameIndex(Paths.get(it)) }
+
+      // Lexicographic sort scrambles dump_10000 in among the small numbers.
+      sortedByLex shouldBe listOf(
+         "dump_0001.png", "dump_0002.png", "dump_0010.png",
+         "dump_10000.png",  // <-- wrong: lands between 10 and 9999 because "1" < "9"
+         "dump_9999.png",
+      )
+
+      // Numeric sort gives playback order.
+      sortedByIndex shouldBe listOf(
+         "dump_0001.png", "dump_0002.png", "dump_0010.png",
+         "dump_9999.png", "dump_10000.png",
+      )
+   }
+})


### PR DESCRIPTION
## Summary

`anim_dump` emits `dump_0000.png`, `dump_0001.png`, ..., `dump_9999.png` and then `dump_10000.png`. `AnimDumpHandler.dumpFrames` was sorting the dumped files **lexicographically**, which placed `dump_10000.png` *before* `dump_2.png` because string comparison stops at the first `'1' < '2'` character. For animations with 10000+ frames this scrambled the output of `AnimDumpHandler.dumpFrames`, which `AnimatedWebpReader` passes through unchanged — so `animated.getFrame(n)` returned the wrong frame.

Parse the embedded integer out of the filename (`AnimDumpHandler.frameIndex`) and sort by that instead. Files that don't match `dump_NNNN.png` sort to the end so the recognisable frames stay in their natural order.

## Test plan

- [x] New `AnimDumpHandlerFrameOrderingTest` covers:
  - `frameIndex` parsing across `dump_0000.png` through `dump_99999.png`
  - a numeric-vs-lexicographic ordering demonstration including the `dump_10000.png` boundary case — lexicographic sort visibly scrambles `dump_10000.png` to between `dump_0010.png` and `dump_9999.png`, while numeric sort lands it correctly after `dump_9999.png`
- [x] Full `:scrimage-webp:test` (28 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)