### PR TITLE
Fix underlay(image, x, y) drawing both layers at the same position

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1670,8 +1670,14 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image with the given image overlaid.
     */
    public ImmutableImage underlay(ImmutableImage underlayImage, int x, int y) {
+      // Per the doc: the underlay sits at the back, this sits on top, and
+      // (x, y) is where the (0, 0) of the top layer (this) gets placed.
+      // Previously both calls used (x, y), so the underlay was offset to
+      // the same position as the top layer instead of being painted at
+      // the canvas origin first. The zero-arg overload masked the bug
+      // because both reduce to (0, 0).
       ImmutableImage target = this.blank();
-      target.overlayInPlace(underlayImage.awt(), x, y);
+      target.overlayInPlace(underlayImage.awt(), 0, 0);
       target.overlayInPlace(awt(), x, y);
       return target.associateMetadata(metadata);
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/UnderlayPositionTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/UnderlayPositionTest.kt
@@ -1,0 +1,56 @@
+package com.sksamuel.scrimage.core.ops
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class UnderlayPositionTest : FunSpec({
+
+   // Regression for underlay(image, x, y) drawing both `this` and the
+   // underlay at the same (x, y). The contract — and the docstring — say
+   // the underlay sits at the back and `this` sits on top, with (x, y)
+   // determining where the (0, 0) of the top layer is placed.
+   //
+   // The zero-arg `underlay(image)` reduces to (0, 0) for both, masking
+   // the bug. Anyone using the explicit (x, y) overload saw the underlay
+   // offset to the same position as the top layer instead of covering the
+   // canvas, leaving the area before (x, y) as blank pixels.
+
+   test("underlay(image, x, y) places the underlay at the canvas origin and `this` at (x, y)") {
+      val red = ImmutableImage.filled(100, 100, Color.RED)
+      val blue = ImmutableImage.filled(100, 100, Color.BLUE)
+
+      // Pull `this` (red) down/right by (40, 40); the underlay (blue) must
+      // cover the entire canvas first.
+      val out = red.underlay(blue, 40, 40)
+
+      // (0, 0) is in the area not covered by `this` after the offset, so
+      // it must be the underlay colour (blue).
+      val topLeft = out.pixel(0, 0)
+      topLeft.red() shouldBe 0
+      topLeft.green() shouldBe 0
+      topLeft.blue() shouldBe 255
+
+      // (50, 50) is inside the offset top layer, so it must be `this` (red).
+      val middle = out.pixel(50, 50)
+      middle.red() shouldBe 255
+      middle.green() shouldBe 0
+      middle.blue() shouldBe 0
+
+      // (99, 99) — bottom-right — is also inside the offset top layer.
+      val bottomRight = out.pixel(99, 99)
+      bottomRight.red() shouldBe 255
+      bottomRight.green() shouldBe 0
+      bottomRight.blue() shouldBe 0
+   }
+
+   test("zero-arg underlay still covers the canvas") {
+      val red = ImmutableImage.filled(20, 20, Color.RED)
+      val blue = ImmutableImage.filled(20, 20, Color.BLUE)
+      val out = red.underlay(blue)
+      // With both at (0, 0) the top layer covers the underlay completely.
+      out.pixel(0, 0).red() shouldBe 255
+      out.pixel(19, 19).red() shouldBe 255
+   }
+})


### PR DESCRIPTION
## Summary

`underlay` was

```java
target.overlayInPlace(underlayImage.awt(), x, y);
target.overlayInPlace(awt(), x, y);
```

so the underlay (back layer) and `this` (top layer) ended up at the same offset. Per the docstring — *"x/y parameters determine where the (0, 0) coordinate of the overlay should be placed"* — the underlay should cover the canvas first (origin (0, 0)) and `this` should be placed at (x, y) on top.

The zero-arg `underlay(image)` reduces to (0, 0) for both, which is why nobody noticed: the bug only shows up when the explicit `(x, y)` overload is used with non-zero offsets, where the canvas now has a blank rectangular gap before `(x, y)` instead of the underlay covering it.

## Bug demonstration

```java
ImmutableImage red = ImmutableImage.filled(100, 100, Color.RED);
ImmutableImage blue = ImmutableImage.filled(100, 100, Color.BLUE);

ImmutableImage out = red.underlay(blue, 40, 40);

// Before fix:  out.pixel(0, 0) is a transparent / blank pixel
//              (both layers offset to (40,40), nothing covers (0,0))
// After fix:   out.pixel(0, 0) is blue
//              (underlay drawn at origin, then red on top at (40,40))
```

## Test plan

- [x] New `UnderlayPositionTest` with two cases:
  - `underlay(blue, 40, 40)` on a red 100×100: `(0, 0)` must be blue (the underlay), `(50, 50)` and `(99, 99)` must be red (`this` on top). The first assertion fails on master because the "underlay" was offset to `(40, 40)` along with `this`.
  - Zero-arg `underlay(blue)` still has `this` covering the underlay (regression guard).
- [x] All existing op tests (`./gradlew :scrimage-tests:test --tests "com.sksamuel.scrimage.core.ops.*"`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)