### PR TITLE
Don't NPE in GifSequenceReader.read(stream) when stream is null

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
@@ -331,12 +331,15 @@ public class GifSequenceReader {
                status = STATUS_FORMAT_ERROR;
             }
          }
+         // Only close if we actually had a stream — the null branch
+         // sets STATUS_OPEN_ERROR and used to fall through to is.close()
+         // which then NPE'd, defeating the null check.
+         try {
+            is.close();
+         } catch (IOException e) {
+         }
       } else {
          status = STATUS_OPEN_ERROR;
-      }
-      try {
-         is.close();
-      } catch (IOException e) {
       }
       return status;
    }
@@ -360,12 +363,13 @@ public class GifSequenceReader {
                status = STATUS_FORMAT_ERROR;
             }
          }
+         // Only close if we actually had a stream — see read(BufferedInputStream).
+         try {
+            is.close();
+         } catch (IOException e) {
+         }
       } else {
          status = STATUS_OPEN_ERROR;
-      }
-      try {
-         is.close();
-      } catch (IOException e) {
       }
       return status;
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderNullStreamTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderNullStreamTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.scrimage.core.nio.internal
+
+import com.sksamuel.scrimage.nio.internal.GifSequenceReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.BufferedInputStream
+import java.io.InputStream
+
+/**
+ * Regression for GifSequenceReader.read(InputStream) and read(BufferedInputStream)
+ * NPEing on a null argument. Both methods correctly null-check at the top
+ * and set STATUS_OPEN_ERROR, but the unconditional `is.close()` afterwards
+ * threw NullPointerException (not caught by the IOException handler) so
+ * callers got an NPE rather than the documented STATUS_OPEN_ERROR return.
+ */
+class GifSequenceReaderNullStreamTest : FunSpec({
+
+   test("read(InputStream) returns STATUS_OPEN_ERROR on null instead of NPEing") {
+      val reader = GifSequenceReader()
+      val status: Int = reader.read(null as InputStream?)
+      status shouldBe GifSequenceReader.STATUS_OPEN_ERROR
+   }
+
+   test("read(BufferedInputStream) returns STATUS_OPEN_ERROR on null instead of NPEing") {
+      val reader = GifSequenceReader()
+      val status: Int = reader.read(null as BufferedInputStream?)
+      status shouldBe GifSequenceReader.STATUS_OPEN_ERROR
+   }
+})


### PR DESCRIPTION
## Summary

Both `GifSequenceReader.read(InputStream)` and `read(BufferedInputStream)` correctly null-checked at the top — setting `status = STATUS_OPEN_ERROR` in the else branch — but then unconditionally fell through to

```java
try { is.close(); } catch (IOException e) { }
```

The `IOException` catch doesn't catch `NullPointerException`, so passing `null` threw NPE instead of returning the documented `STATUS_OPEN_ERROR`. Defeats the whole point of the up-front null check.

Move the `close()` inside the non-null branch so the null path returns `STATUS_OPEN_ERROR` cleanly.

## Test plan

- [x] New `GifSequenceReaderNullStreamTest` with one case per overload. Both NPE on master (`Cannot invoke "java.io.InputStream.close()" because "is" is null` / same for BufferedInputStream); both pass after the fix and return `STATUS_OPEN_ERROR`.
- [x] Full gif test suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)