### PR TITLE
Wrap Graphics2D dispose() in try/finally for seven more filters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CausticsFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CausticsFilter.java
@@ -53,8 +53,11 @@ public class CausticsFilter implements Filter {
 
         AlphaComposite composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha);
         Graphics2D g2 = image.awt().createGraphics();
-        g2.setComposite(composite);
-        g2.drawImage(caustics, 0, 0, null);
-        g2.dispose();
+        try {
+            g2.setComposite(composite);
+            g2.drawImage(caustics, 0, 0, null);
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ColorizeFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ColorizeFilter.java
@@ -39,8 +39,11 @@ public class ColorizeFilter implements Filter {
     @Override
     public void apply(ImmutableImage image) {
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        g2.setColor(color);
-        g2.fillRect(0, 0, image.width, image.height);
-        g2.dispose();
+        try {
+            g2.setColor(color);
+            g2.fillRect(0, 0, image.width, image.height);
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OldPhotoFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OldPhotoFilter.java
@@ -29,14 +29,17 @@ public class OldPhotoFilter implements IntFilter {
       BufferedImage filtered = daisy.filter(image.awt());
 
       Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-      g2.drawImage(filtered, 0, 0, null);
+      try {
+         g2.drawImage(filtered, 0, 0, null);
 
-      BufferedImage filmSized = film.scaleTo(image.width, image.height, ScaleMethod.Bicubic).awt();
-      BufferedImage filmSizedSameType = ImmutableImage.fromAwt(filmSized, image.awt().getType()).awt();
+         BufferedImage filmSized = film.scaleTo(image.width, image.height, ScaleMethod.Bicubic).awt();
+         BufferedImage filmSizedSameType = ImmutableImage.fromAwt(filmSized, image.awt().getType()).awt();
 
-      g2.setComposite(BlendComposite.getInstance(BlendingMode.INVERSE_COLOR_DODGE, 0.30f));
-      g2.drawImage(filmSizedSameType, 0, 0, null);
-      g2.dispose();
+         g2.setComposite(BlendComposite.getInstance(BlendingMode.INVERSE_COLOR_DODGE, 0.30f));
+         g2.drawImage(filmSizedSameType, 0, 0, null);
+      } finally {
+         g2.dispose();
+      }
    }
 }
 

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SnowFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SnowFilter.java
@@ -39,8 +39,11 @@ public class SnowFilter implements IntFilter {
    public void apply(ImmutableImage image) {
       ImmutableImage scaled = ImmutableImage.wrapAwt(snow.scaleTo(image.width, image.height, ScaleMethod.Bicubic).awt(), image.getType());
       Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-      g2.setComposite(new BlendComposite(BlendingMode.SCREEN, 1.0f));
-      g2.drawImage(scaled.awt(), 0, 0, null);
-      g2.dispose();
+      try {
+         g2.setComposite(new BlendComposite(BlendingMode.SCREEN, 1.0f));
+         g2.drawImage(scaled.awt(), 0, 0, null);
+      } finally {
+         g2.dispose();
+      }
    }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SummerFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SummerFilter.java
@@ -47,9 +47,12 @@ public class SummerFilter implements IntFilter {
    public void apply(ImmutableImage image) throws IOException {
       ImmutableImage scaled = ImmutableImage.wrapAwt(summer.scaleTo(image.width, image.height, ScaleMethod.Bicubic).awt(), image.getType());
       Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-      g2.setComposite(BlendComposite.getInstance(BlendingMode.INVERSE_COLOR_BURN, 0.5f));
-      g2.drawImage(scaled.awt(), 0, 0, null);
-      g2.dispose();
+      try {
+         g2.setComposite(BlendComposite.getInstance(BlendingMode.INVERSE_COLOR_BURN, 0.5f));
+         g2.drawImage(scaled.awt(), 0, 0, null);
+      } finally {
+         g2.dispose();
+      }
       if (vignette) new VignetteFilter(0.92f, 0.98f, 0.3f, Color.BLACK).apply(image);
    }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VintageFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VintageFilter.java
@@ -28,7 +28,10 @@ public class VintageFilter implements Filter {
         ThistleFilter thistle = new ThistleFilter();
         BufferedImage filtered = thistle.filter(image.awt());
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        g2.drawImage(filtered, 0, 0, null);
-        g2.dispose();
+        try {
+            g2.drawImage(filtered, 0, 0, null);
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/WatermarkFilter.java
@@ -46,8 +46,11 @@ public class WatermarkFilter implements Filter {
     @Override
     public void apply(ImmutableImage image) {
         Graphics2D g2 = (Graphics2D) image.awt().getGraphics();
-        setupGraphics(g2);
-        g2.drawString(text, x, y);
-        g2.dispose();
+        try {
+            setupGraphics(g2);
+            g2.drawString(text, x, y);
+        } finally {
+            g2.dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Sister of #454 (Watermark{Cover,Stamp}Filter + VignetteFilter). A grep across `scrimage-filters` turned up seven more filters with the same unprotected acquire-then-dispose pattern — any of the intervening `setComposite` / `drawImage` / `fillRect` / `drawString` calls throwing would skip the `dispose` and leak the underlying native graphics context until garbage collection.

Wrapped each in `try { ... } finally { g2.dispose(); }`:

- `CausticsFilter`
- `ColorizeFilter`
- `OldPhotoFilter`
- `SnowFilter`
- `SummerFilter`
- `VintageFilter`
- `WatermarkFilter` (the third Watermark variant — PR #454 covered `WatermarkCoverFilter` and `WatermarkStampFilter`)

## Test plan

- [x] Full `:scrimage-filters:test` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)