### PR TITLE
Wrap remaining unprotected Graphics2D dispose() in scrimage-core

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
@@ -40,9 +40,12 @@ public class ProgressiveScale {
 
          BufferedImage tmp = new BufferedImage(w, h, type);
          Graphics2D g2 = tmp.createGraphics();
-         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
-         g2.drawImage(temp, 0, 0, w, h, null);
-         g2.dispose();
+         try {
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
+            g2.drawImage(temp, 0, 0, w, h, null);
+         } finally {
+            g2.dispose();
+         }
 
          temp = tmp;
       } while (w != targetWidth || h != targetHeight);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
@@ -207,16 +207,19 @@ public class GifSequenceReader {
             if (dispose == 2) {
                // fill last image rect area with background color
                Graphics2D g = image.createGraphics();
-               Color c = null;
-               if (transparency) {
-                  c = new Color(0, 0, 0, 0); 	// assume background is transparent
-               } else {
-                  c = new Color(lastBgColor); // use given background color
+               try {
+                  Color c = null;
+                  if (transparency) {
+                     c = new Color(0, 0, 0, 0); 	// assume background is transparent
+                  } else {
+                     c = new Color(lastBgColor); // use given background color
+                  }
+                  g.setColor(c);
+                  g.setComposite(AlphaComposite.Src); // replace area
+                  g.fill(lastRect);
+               } finally {
+                  g.dispose();
                }
-               g.setColor(c);
-               g.setComposite(AlphaComposite.Src); // replace area
-               g.fill(lastRect);
-               g.dispose();
             }
          }
       }


### PR DESCRIPTION
## Summary

Two more sites in `scrimage-core` had the same acquire-then-dispose pattern that #432 addressed across most composites and #461 addressed across more filters:

- **`ProgressiveScale.scale`**: `setRenderingHint` + `drawImage` between `createGraphics()` and `dispose()`. Either could throw and skip the dispose — leaking the native graphics context **per scaling pass**.
- **`GifSequenceReader.setPixels`** (the `dispose == 2` / restore-to-background branch): `setColor` + `setComposite` + `fill` between `createGraphics()` and `dispose()` while reading every animated GIF that uses "restore to background" disposal.

Wrap each in `try { ... } finally { g.dispose(); }`.

## Test plan

- [x] Full `./gradlew check` passes (44 tasks, 14 executed including all of `scrimage-core`, `scrimage-tests`, `scrimage-filters`, `scrimage-webp`, `scrimage-hash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)