### PR TITLE
Validate frame index in AnimatedGif accessors

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/AnimatedGif.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/AnimatedGif.java
@@ -33,15 +33,40 @@ public class AnimatedGif {
    }
 
    public Duration getDelay(int frame) {
+      checkFrameIndex(frame);
       return Duration.ofMillis(reader.getDelay(frame));
    }
 
    public DisposeMethod getDisposeMethod(int frame) {
+      checkFrameIndex(frame);
       return reader.getDisposeMethod(frame);
    }
 
    public ImmutableImage getFrame(int n) {
+      checkFrameIndex(n);
       return ImmutableImage.wrapAwt(reader.getFrame(n));
+   }
+
+   /**
+    * Validates a frame index up front so callers get a clear
+    * IndexOutOfBoundsException naming the bad index and the available
+    * frame count. Without this check:
+    *   - getFrame returned an ImmutableImage wrapping a null BufferedImage,
+    *     which then NPE'd on the next pixel access (AwtImage's `assert
+    *     awt != null` is a no-op in production)
+    *   - getDelay returned Duration.ofMillis(-1) — a negative Duration
+    *     with no indication that the index was bad
+    *   - getDisposeMethod silently returned NONE
+    *
+    * Matches the IndexOutOfBoundsException that AnimatedWebp's List.get
+    * already throws.
+    */
+   private void checkFrameIndex(int frame) {
+      int count = reader.getFrameCount();
+      if (frame < 0 || frame >= count) {
+         throw new IndexOutOfBoundsException(
+            "frame " + frame + " out of bounds for animated gif with " + count + " frames");
+      }
    }
 
    public List<ImmutableImage> getFrames() {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/AnimatedGifBoundsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/AnimatedGifBoundsTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.AnimatedGifReader
+import com.sksamuel.scrimage.nio.ImageSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.io.File
+
+class AnimatedGifBoundsTest : FunSpec({
+
+   // Regression: AnimatedGif accessors used to silently return wrong data
+   // for out-of-bounds frame indices.
+   //
+   //  - getFrame(n) wrapped a null BufferedImage from reader.getFrame and
+   //    NPE'd on the next pixel access (AwtImage's `assert awt != null`
+   //    is a no-op in production JVMs).
+   //  - getDelay returned Duration.ofMillis(-1), a negative duration with
+   //    no indication that the index was bad.
+   //  - getDisposeMethod silently returned NONE.
+   //
+   // AnimatedWebp's List.get already throws IndexOutOfBoundsException; this
+   // change brings AnimatedGif in line.
+
+   val gif = AnimatedGifReader.read(
+      ImageSource.of(File("src/test/resources/com/sksamuel/scrimage/nio/animated_birds.gif"))
+   )
+
+   test("getFrame throws IndexOutOfBoundsException for negative index") {
+      val ex = shouldThrow<IndexOutOfBoundsException> { gif.getFrame(-1) }
+      ex.message!!.shouldContain("-1")
+   }
+
+   test("getFrame throws IndexOutOfBoundsException for index >= frameCount") {
+      val ex = shouldThrow<IndexOutOfBoundsException> { gif.getFrame(gif.frameCount) }
+      ex.message!!.shouldContain(gif.frameCount.toString())
+   }
+
+   test("getDelay throws IndexOutOfBoundsException for invalid index") {
+      shouldThrow<IndexOutOfBoundsException> { gif.getDelay(gif.frameCount + 5) }
+   }
+
+   test("getDisposeMethod throws IndexOutOfBoundsException for invalid index") {
+      shouldThrow<IndexOutOfBoundsException> { gif.getDisposeMethod(-2) }
+   }
+})


### PR DESCRIPTION
## Summary

`AnimatedGif.getFrame` / `getDelay` / `getDisposeMethod` passed the index straight through to `GifSequenceReader`, which silently produced wrong data or NPEs for an out-of-bounds frame index:

- `getFrame(n)` wrapped the null result of `reader.getFrame(n)` in `ImmutableImage.wrapAwt` — `AwtImage`'s `assert awt != null` is a no-op in production JVMs, then `awt.getWidth()` NPE'd on the next pixel access
- `getDelay` returned `Duration.ofMillis(-1)`, a negative duration with no indication that the index was bad
- `getDisposeMethod` silently returned `NONE`

Add an upfront index check that throws `IndexOutOfBoundsException` naming the bad index and the available frame count:

```
frame -1 out of bounds for animated gif with 6 frames
```

Matches what `AnimatedWebp`'s underlying `List.get` already throws.

## Test plan

- [x] New `AnimatedGifBoundsTest` with four cases: negative, `== frameCount`, above frameCount, negative on `getDisposeMethod`. All four fail on master (NPE / silent wrong data); all four pass after the fix.
- [x] Full gif suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)