### PR TITLE
Replace assert-based range checks in VignetteFilter with explicit validation

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
@@ -31,10 +31,18 @@ public class VignetteFilter implements Filter {
     private final Color color;
 
     public VignetteFilter(float start, float end, float blur, Color color) {
-        assert start >= 0;
-        assert start <= 1;
-        assert blur >= 0;
-        assert blur <= 1;
+        // Asserts are disabled by default in production JVMs, so the
+        // previous assert-based range checks were no-ops. Out-of-range
+        // start surfaced as a cryptic IllegalArgumentException out of
+        // RadialGradientPaint about gradient fractions; out-of-range
+        // blur was passed to GaussianBlurFilter as a negative radius.
+        // Validate explicitly with a useful diagnostic.
+        if (!(start >= 0 && start <= 1)) {
+            throw new IllegalArgumentException("start must be in [0, 1]; got " + start);
+        }
+        if (!(blur >= 0 && blur <= 1)) {
+            throw new IllegalArgumentException("blur must be in [0, 1]; got " + blur);
+        }
         this.start = start;
         this.end = end;
         this.blur = blur;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VignetteFilterRangeTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VignetteFilterRangeTest.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.awt.Color
+
+class VignetteFilterRangeTest : FunSpec({
+
+   // Regression: VignetteFilter validated start/blur via `assert`, which is
+   // disabled by default in production JVMs. Out-of-range start used to
+   // surface as a cryptic IllegalArgumentException from RadialGradientPaint
+   // about gradient fractions; out-of-range blur was passed to
+   // GaussianBlurFilter as a negative radius. Now both reject up front
+   // with a clear IllegalArgumentException naming the offending value.
+
+   test("constructor rejects start below 0") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(-0.1f, 0.95f, 0.3f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("start")
+      ex.message!!.shouldContain("-0.1")
+   }
+
+   test("constructor rejects start above 1") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(1.5f, 0.95f, 0.3f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("start")
+      ex.message!!.shouldContain("1.5")
+   }
+
+   test("constructor rejects blur below 0") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(0.5f, 0.95f, -0.2f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("blur")
+      ex.message!!.shouldContain("-0.2")
+   }
+
+   test("constructor rejects blur above 1") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(0.5f, 0.95f, 2.0f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("blur")
+      ex.message!!.shouldContain("2.0")
+   }
+
+   test("constructor accepts boundary values 0 and 1") {
+      // Both 0 and 1 are valid (inclusive bounds).
+      VignetteFilter(0f, 0.95f, 0f, Color.BLACK)
+      VignetteFilter(1f, 0.95f, 1f, Color.BLACK)
+   }
+})


### PR DESCRIPTION
## Summary

`VignetteFilter` validated its `start` and `blur` parameters in `[0, 1]` via four `assert` statements. Asserts are disabled by default in production JVMs (you have to opt in with `-ea`), so the checks were no-ops in practice and a bad input then surfaced as a cryptic downstream error:

- out-of-range `start` was passed to `RadialGradientPaint`, which threw `IllegalArgumentException` about gradient fractions
- out-of-range `blur` was passed to `GaussianBlurFilter` as a **negative pixel radius**

Validate up front and throw `IllegalArgumentException` naming the offending value:

```
start must be in [0, 1]; got -0.1
blur must be in [0, 1]; got 2.0
```

Same shape as PR #463 for `ErrorSpotterFilter`.

## Test plan

- [x] New `VignetteFilterRangeTest` with five cases: `start < 0`, `start > 1`, `blur < 0`, `blur > 1`, boundary values `0` and `1` accepted. Four fail on master (silent acceptance — the constructor returns successfully); all five pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)