### PR TITLE
Replace assert-based input validation in subpixelSubimage and AlphaMaskFilter

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1439,10 +1439,16 @@ public class ImmutableImage extends MutableImage {
       // subpixel() contract requires arg < width, hence x + subWidth ≤ width.
       // Same applies to y / subHeight / height. The previous bounds used
       // strict < and rejected valid full-width / full-height extractions.
-      assert x >= 0;
-      assert x + subWidth <= width;
-      assert y >= 0;
-      assert y + subHeight <= height;
+      //
+      // Validate explicitly: assert is a no-op in production JVMs by default,
+      // and out-of-range inputs then surfaced as ArrayIndexOutOfBoundsException
+      // from the underlying getRGB call deep inside the loop with no context.
+      if (x < 0 || y < 0 || x + subWidth > width || y + subHeight > height) {
+         throw new IllegalArgumentException(
+            "subpixelSubimage region (x=" + x + ", y=" + y
+               + ", subWidth=" + subWidth + ", subHeight=" + subHeight
+               + ") falls outside the source image (" + width + "x" + height + ")");
+      }
 
       // Walk the output grid and write each interpolated ARGB int directly
       // into a row-major buffer. The previous implementation allocated a

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/AlphaMaskFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/AlphaMaskFilter.java
@@ -17,7 +17,14 @@ public class AlphaMaskFilter implements Filter {
    }
 
    public AlphaMaskFilter(ImmutableImage mask, int channel) {
-      assert (channel >= 0 && channel <= 3);
+      // Asserts are disabled by default in production JVMs, so a channel
+      // outside [0, 3] used to silently fall through to the apply()
+      // switch's default branch (alpha channel). Validate explicitly with
+      // a useful diagnostic.
+      if (channel < 0 || channel > 3) {
+         throw new IllegalArgumentException(
+            "channel must be in [0, 3] (0=alpha, 1=red, 2=green, 3=blue); got " + channel);
+      }
       this.mask = mask;
       this.channel = channel;
    }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/AlphaMaskFilterChannelRangeTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/AlphaMaskFilterChannelRangeTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.awt.Color
+
+class AlphaMaskFilterChannelRangeTest : FunSpec({
+
+   // Regression: AlphaMaskFilter constructor validated channel via
+   // `assert (channel >= 0 && channel <= 3)`, which is disabled in
+   // production JVMs. A channel outside [0, 3] then silently fell
+   // through to apply()'s switch default branch (alpha channel),
+   // producing the wrong output silently.
+
+   val mask = ImmutableImage.filled(10, 10, Color.RED)
+
+   test("constructor rejects channel below 0") {
+      val ex = shouldThrow<IllegalArgumentException> { AlphaMaskFilter(mask, -1) }
+      ex.message!!.shouldContain("channel")
+      ex.message!!.shouldContain("-1")
+   }
+
+   test("constructor rejects channel above 3") {
+      val ex = shouldThrow<IllegalArgumentException> { AlphaMaskFilter(mask, 4) }
+      ex.message!!.shouldContain("channel")
+      ex.message!!.shouldContain("4")
+   }
+
+   test("constructor accepts channel 0 (alpha)") {
+      AlphaMaskFilter(mask, 0)
+   }
+
+   test("constructor accepts channel 3 (blue)") {
+      AlphaMaskFilter(mask, 3)
+   }
+})

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubpixelSubimageBoundsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubpixelSubimageBoundsTest.kt
@@ -5,20 +5,24 @@ import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 /**
- * Regression test for ImmutableImage.subpixelSubimage's boundary
- * assertions. The previous implementation asserted strict inequality:
+ * Regression tests for ImmutableImage.subpixelSubimage's boundary checks.
+ *
+ * The original implementation asserted strict inequality:
  *
  *   assert x + subWidth < width;
  *
  * but the loop reads subpixel(xIndex + x) for xIndex in [0, subWidth),
- * giving a maximum x argument of (subWidth - 1) + x. Subpixel only
- * requires arg < width, so the actual constraint is x + subWidth ≤ width
- * — the strict inequality rejected legitimate full-width extractions.
+ * giving a maximum x argument of (subWidth - 1) + x. Subpixel only requires
+ * arg < width, so the actual constraint is x + subWidth ≤ width — strict
+ * inequality rejected legitimate full-width extractions.
  *
- * Concrete pre-fix: subpixelSubimage(0.0, 0.0, width, height) on any
- * image throws AssertionError when run under -ea (Gradle's default).
+ * The validation was via `assert`, which is disabled by default in production
+ * JVMs. Out-of-range arguments then surfaced as a bare
+ * ArrayIndexOutOfBoundsException from getRGB deep inside the apply loop.
+ * The check is now an upfront IllegalArgumentException.
  */
 class SubpixelSubimageBoundsTest : FunSpec({
 
@@ -40,17 +44,28 @@ class SubpixelSubimageBoundsTest : FunSpec({
       sub.height shouldBe 3
    }
 
-   test("subpixelSubimage with x + subWidth > width still asserts") {
+   test("subpixelSubimage with x + subWidth > width throws IllegalArgumentException") {
       val image = ImmutableImage.create(4, 4)
-      shouldThrow<AssertionError> {
+      val ex = shouldThrow<IllegalArgumentException> {
          image.subpixelSubimage(0.0, 0.0, 5, 4)
       }
+      ex.message!!.shouldContain("subpixelSubimage region")
+      ex.message!!.shouldContain("4x4")
    }
 
-   test("subpixelSubimage with negative x still asserts") {
+   test("subpixelSubimage with negative x throws IllegalArgumentException") {
       val image = ImmutableImage.create(4, 4)
-      shouldThrow<AssertionError> {
+      val ex = shouldThrow<IllegalArgumentException> {
          image.subpixelSubimage(-0.1, 0.0, 2, 2)
       }
+      ex.message!!.shouldContain("x=-0.1")
+   }
+
+   test("subpixelSubimage with subimage extending past bottom edge throws") {
+      val image = ImmutableImage.create(4, 4)
+      val ex = shouldThrow<IllegalArgumentException> {
+         image.subpixelSubimage(0.0, 3.0, 2, 2)
+      }
+      ex.message!!.shouldContain("subHeight=2")
    }
 })


### PR DESCRIPTION
## Summary

Two more sites where input validation lived in `assert` statements that are disabled by default in production JVMs:

- **`ImmutableImage.subpixelSubimage`**'s four bounds asserts let out-of-range `x` / `y` / `subWidth` / `subHeight` through. The result was a bare `ArrayIndexOutOfBoundsException` out of `getRGB` deep inside the apply loop with no context. Now throws `IllegalArgumentException` naming the requested region and the source dimensions.
- **`AlphaMaskFilter` constructor**'s `channel` range assert let `channel < 0` or `> 3` through. The `apply()`'s switch matches 1, 2, 3 explicitly and falls back to `default` (the alpha channel) — so a bad channel value silently produced wrong output. Now throws `IllegalArgumentException` with the channel index.

Same shape as PR #463 (ErrorSpotterFilter) and PR #465 (VignetteFilter).

## Test plan

- [x] Updated `SubpixelSubimageBoundsTest`'s pre-existing throw cases (which expected `AssertionError` — only fired because Gradle runs with `-ea`) to expect `IllegalArgumentException` with diagnostic content. Added a new test for the bottom-edge boundary failure case.
- [x] New `AlphaMaskFilterChannelRangeTest` covers `channel < 0`, `channel > 3`, and the boundary values 0 and 3 still being accepted.
- [x] Full `./gradlew check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)