### PR TITLE
Replace assert-based range check in BlackThresholdFilter with explicit validation

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BlackThresholdFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BlackThresholdFilter.java
@@ -11,7 +11,16 @@ public class BlackThresholdFilter implements Filter {
    private final double thresholdPercentage;
 
    public BlackThresholdFilter(double thresholdPercentage) {
-      assert (thresholdPercentage >= 0.0 && thresholdPercentage <= 100.0);
+      // Asserts are disabled by default in production JVMs, so the previous
+      // `assert` here was a no-op and out-of-range values produced silently
+      // wrong output: pct > 100 made every pixel fall below the threshold
+      // (so the whole image was blackened), pct < 0 made no pixel match
+      // (so the filter was a no-op), and NaN propagated as 0 with the same
+      // no-op result.
+      if (!(thresholdPercentage >= 0.0 && thresholdPercentage <= 100.0)) {
+         throw new IllegalArgumentException(
+            "thresholdPercentage must be in [0, 100]; got " + thresholdPercentage);
+      }
       this.thresholdPercentage = thresholdPercentage;
    }
 

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BlackThresholdFilterRangeTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/BlackThresholdFilterRangeTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class BlackThresholdFilterRangeTest : FunSpec({
+
+   // Regression: BlackThresholdFilter validated thresholdPercentage in
+   // [0, 100] via `assert`, which is disabled by default in production
+   // JVMs. Out-of-range values then silently produced wrong output:
+   //   - pct > 100  → threshold > 255, every pixel is below it, image
+   //                  comes out fully blackened
+   //   - pct < 0    → threshold < 0,  no pixel is below it, filter is
+   //                  a silent no-op
+   //   - pct = NaN  → threshold = (int) NaN = 0, same silent no-op
+
+   test("constructor rejects negative threshold") {
+      val ex = shouldThrow<IllegalArgumentException> { BlackThresholdFilter(-10.0) }
+      ex.message!!.shouldContain("thresholdPercentage")
+      ex.message!!.shouldContain("-10")
+   }
+
+   test("constructor rejects threshold above 100") {
+      val ex = shouldThrow<IllegalArgumentException> { BlackThresholdFilter(150.0) }
+      ex.message!!.shouldContain("thresholdPercentage")
+      ex.message!!.shouldContain("150")
+   }
+
+   test("constructor rejects NaN") {
+      val ex = shouldThrow<IllegalArgumentException> { BlackThresholdFilter(Double.NaN) }
+      ex.message!!.shouldContain("thresholdPercentage")
+   }
+
+   test("constructor accepts boundary values 0 and 100") {
+      BlackThresholdFilter(0.0)
+      BlackThresholdFilter(100.0)
+   }
+})


### PR DESCRIPTION
## Summary

`BlackThresholdFilter` validated `thresholdPercentage` in `[0, 100]` via `assert`, which is disabled by default in production JVMs. Out-of-range values then silently produced wrong output:

| Input | What `apply` did |
|---|---|
| `pct > 100` | `threshold > 255`, every pixel falls below it → image fully **blackened** |
| `pct < 0` | `threshold < 0`, no pixel falls below it → filter is a silent **no-op** |
| `pct = NaN` | `threshold = (int) NaN = 0` → same silent no-op |

Reject up front with `IllegalArgumentException` naming the offending value. The condition `!(0 <= x <= 100)` also catches `NaN` (every `NaN` comparison is false).

Same shape as PRs #463, #465, #466 in this assert-cleanup series.

## Test plan

- [x] New `BlackThresholdFilterRangeTest` with four cases: negative, `> 100`, `NaN`, boundary 0/100 accepted. Three fail on master (silent acceptance); all four pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)