### PR TITLE
Tighten resource cleanup on exception paths

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
@@ -40,9 +40,12 @@ public class ProgressiveScale {
 
          BufferedImage tmp = new BufferedImage(w, h, type);
          Graphics2D g2 = tmp.createGraphics();
-         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
-         g2.drawImage(temp, 0, 0, w, h, null);
-         g2.dispose();
+         try {
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
+            g2.drawImage(temp, 0, 0, w, h, null);
+         } finally {
+            g2.dispose();
+         }
 
          temp = tmp;
       } while (w != targetWidth || h != targetHeight);

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CausticsFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CausticsFilter.java
@@ -53,8 +53,11 @@ public class CausticsFilter implements Filter {
 
         AlphaComposite composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha);
         Graphics2D g2 = image.awt().createGraphics();
-        g2.setComposite(composite);
-        g2.drawImage(caustics, 0, 0, null);
-        g2.dispose();
+        try {
+            g2.setComposite(composite);
+            g2.drawImage(caustics, 0, 0, null);
+        } finally {
+            g2.dispose();
+        }
     }
 }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/AnimDumpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/AnimDumpHandler.java
@@ -65,40 +65,45 @@ public class AnimDumpHandler extends WebpHandler {
     * PNG bytes in playback order.
     */
    public List<byte[]> dumpFrames(byte[] webpBytes) throws IOException {
+      // Nest the two temp lifetimes: if createTempDirectory throws after
+      // input has been allocated, the input file would otherwise leak.
       Path input = Files.createTempFile("anim_dump_in_", ".webp").toAbsolutePath();
-      Path folder = Files.createTempDirectory("anim_dump_out_");
       try {
-         Files.write(input, webpBytes, StandardOpenOption.CREATE);
-         dumpFrames(input, folder);
+         Path folder = Files.createTempDirectory("anim_dump_out_");
+         try {
+            Files.write(input, webpBytes, StandardOpenOption.CREATE);
+            dumpFrames(input, folder);
 
-         List<Path> dumped;
-         try (Stream<Path> stream = Files.list(folder)) {
-            dumped = new ArrayList<>();
-            stream.forEach(dumped::add);
-         }
-         // anim_dump names files like dump_0000.png, dump_0001.png, ... and
-         // overflows to dump_10000.png at frame 10000. Sort by the parsed
-         // numeric portion rather than lexicographically — under a string
-         // sort dump_10000.png comes BEFORE dump_2.png, which would scramble
-         // playback order for animations with 10000+ frames.
-         dumped.sort(Comparator.comparingInt(AnimDumpHandler::frameIndex));
+            List<Path> dumped;
+            try (Stream<Path> stream = Files.list(folder)) {
+               dumped = new ArrayList<>();
+               stream.forEach(dumped::add);
+            }
+            // anim_dump names files like dump_0000.png, dump_0001.png, ... and
+            // overflows to dump_10000.png at frame 10000. Sort by the parsed
+            // numeric portion rather than lexicographically — under a string
+            // sort dump_10000.png comes BEFORE dump_2.png, which would scramble
+            // playback order for animations with 10000+ frames.
+            dumped.sort(Comparator.comparingInt(AnimDumpHandler::frameIndex));
 
-         List<byte[]> frames = new ArrayList<>(dumped.size());
-         for (Path p : dumped) {
-            frames.add(Files.readAllBytes(p));
+            List<byte[]> frames = new ArrayList<>(dumped.size());
+            for (Path p : dumped) {
+               frames.add(Files.readAllBytes(p));
+            }
+            return frames;
+         } finally {
+            try (Stream<Path> stream = Files.list(folder)) {
+               stream.forEach(p -> p.toFile().delete());
+            } catch (Exception ignored) {
+            }
+            try {
+               folder.toFile().delete();
+            } catch (Exception ignored) {
+            }
          }
-         return frames;
       } finally {
          try {
             input.toFile().delete();
-         } catch (Exception ignored) {
-         }
-         try (Stream<Path> stream = Files.list(folder)) {
-            stream.forEach(p -> p.toFile().delete());
-         } catch (Exception ignored) {
-         }
-         try {
-            folder.toFile().delete();
          } catch (Exception ignored) {
          }
       }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/CWebpHandler.java
@@ -83,59 +83,65 @@ public class CWebpHandler extends WebpHandler {
                         boolean withoutAlpha,
                         boolean multiThread) throws IOException {
       Path stdout = Files.createTempFile("stdout", "webp");
-      List<String> commands = new ArrayList<>();
-      commands.add(binary.toAbsolutePath().toString());
-      if (m >= 0) {
-         commands.add("-m");
-         commands.add(m + "");
-      }
-      if (q >= 0) {
-         commands.add("-q");
-         commands.add(q + "");
-      }
-      if (z >= 0) {
-         commands.add("-z");
-         commands.add(z + "");
-      }
-      if (lossless) {
-         commands.add("-lossless");
-      }
-      if (withoutAlpha) {
-         commands.add("-noalpha");
-      }
-      if (multiThread) {
-         commands.add("-mt");
-      }
-      commands.add(input.toAbsolutePath().toString());
-      commands.add("-o");
-      commands.add(target.toAbsolutePath().toString());
-
-      ProcessBuilder builder = new ProcessBuilder(commands);
-      builder.redirectErrorStream(true);
-      builder.redirectOutput(stdout.toFile());
-
-      Process process = builder.start();
       try {
-         // waitFor(timeout, unit) returns false if the process is still
-         // running when the timeout expires. The previous code ignored
-         // the return value and called exitValue() unconditionally,
-         // which throws IllegalThreadStateException if the process
-         // hadn't exited — masking the real failure (a hang).
-         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
-         if (!finished) {
-            throw new IOException("cwebp timed out after 5 minutes");
+         List<String> commands = new ArrayList<>();
+         commands.add(binary.toAbsolutePath().toString());
+         if (m >= 0) {
+            commands.add("-m");
+            commands.add(m + "");
          }
-         int exitStatus = process.exitValue();
-         if (exitStatus != 0) {
-            List<String> error = Files.readAllLines(stdout);
-            throw new IOException(error.toString());
+         if (q >= 0) {
+            commands.add("-q");
+            commands.add(q + "");
          }
-      } catch (InterruptedException e) {
-         Thread.currentThread().interrupt();
-         throw new IOException(e);
+         if (z >= 0) {
+            commands.add("-z");
+            commands.add(z + "");
+         }
+         if (lossless) {
+            commands.add("-lossless");
+         }
+         if (withoutAlpha) {
+            commands.add("-noalpha");
+         }
+         if (multiThread) {
+            commands.add("-mt");
+         }
+         commands.add(input.toAbsolutePath().toString());
+         commands.add("-o");
+         commands.add(target.toAbsolutePath().toString());
+
+         ProcessBuilder builder = new ProcessBuilder(commands);
+         builder.redirectErrorStream(true);
+         builder.redirectOutput(stdout.toFile());
+
+         Process process = builder.start();
+         try {
+            // waitFor(timeout, unit) returns false if the process is still
+            // running when the timeout expires. The previous code ignored
+            // the return value and called exitValue() unconditionally,
+            // which throws IllegalThreadStateException if the process
+            // hadn't exited — masking the real failure (a hang).
+            boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+            if (!finished) {
+               throw new IOException("cwebp timed out after 5 minutes");
+            }
+            int exitStatus = process.exitValue();
+            if (exitStatus != 0) {
+               List<String> error = Files.readAllLines(stdout);
+               throw new IOException(error.toString());
+            }
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+         } finally {
+            process.destroy();
+         }
       } finally {
-         process.destroy();
-         stdout.toFile().delete();
+         try {
+            stdout.toFile().delete();
+         } catch (Exception ignored) {
+         }
       }
    }
 }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/DWebpHandler.java
@@ -66,37 +66,43 @@ public class DWebpHandler extends WebpHandler {
    private void convert(Path input, Path target) throws IOException {
 
       Path stdout = Files.createTempFile("stdout", "webp");
-      ProcessBuilder builder = new ProcessBuilder(
-         binary.toAbsolutePath().toString(),
-         input.toAbsolutePath().toString(),
-         "-o",
-         target.toAbsolutePath().toString()
-      );
-      builder.redirectErrorStream(true);
-      builder.redirectOutput(stdout.toFile());
-
-      Process process = builder.start();
       try {
-         // waitFor(timeout, unit) returns false if the process is still
-         // running when the timeout expires. The previous code ignored
-         // the return value and called exitValue() unconditionally,
-         // which throws IllegalThreadStateException if the process
-         // hadn't exited — masking the real failure (a hang).
-         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
-         if (!finished) {
-            throw new IOException("dwebp timed out after 5 minutes");
+         ProcessBuilder builder = new ProcessBuilder(
+            binary.toAbsolutePath().toString(),
+            input.toAbsolutePath().toString(),
+            "-o",
+            target.toAbsolutePath().toString()
+         );
+         builder.redirectErrorStream(true);
+         builder.redirectOutput(stdout.toFile());
+
+         Process process = builder.start();
+         try {
+            // waitFor(timeout, unit) returns false if the process is still
+            // running when the timeout expires. The previous code ignored
+            // the return value and called exitValue() unconditionally,
+            // which throws IllegalThreadStateException if the process
+            // hadn't exited — masking the real failure (a hang).
+            boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+            if (!finished) {
+               throw new IOException("dwebp timed out after 5 minutes");
+            }
+            int exitStatus = process.exitValue();
+            if (exitStatus != 0) {
+               List<String> error = Files.readAllLines(stdout);
+               throw new IOException(error.toString());
+            }
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+         } finally {
+            process.destroy();
          }
-         int exitStatus = process.exitValue();
-         if (exitStatus != 0) {
-            List<String> error = Files.readAllLines(stdout);
-            throw new IOException(error.toString());
-         }
-      } catch (InterruptedException e) {
-         Thread.currentThread().interrupt();
-         throw new IOException(e);
       } finally {
-         process.destroy();
-         stdout.toFile().delete();
+         try {
+            stdout.toFile().delete();
+         } catch (Exception ignored) {
+         }
       }
 
    }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/Gif2WebpHandler.java
@@ -75,50 +75,56 @@ public class Gif2WebpHandler extends WebpHandler {
                        boolean lossy) throws IOException {
 
       Path stdout = Files.createTempFile("stdout", "webp");
-      List<String> commands = new ArrayList<>();
-      commands.add(binary.toAbsolutePath().toString());
-      if (m >= 0) {
-         commands.add("-m");
-         commands.add(m + "");
-      }
-      if (q >= 0) {
-         commands.add("-q");
-         commands.add(q + "");
-      }
-      if (lossy) {
-         commands.add("-lossy");
-      }
-      commands.add(input.toAbsolutePath().toString());
-      commands.add("-o");
-      commands.add(target.toAbsolutePath().toString());
-
-      ProcessBuilder builder = new ProcessBuilder(commands);
-      builder.redirectErrorStream(true);
-      builder.redirectOutput(stdout.toFile());
-
-      Process process = builder.start();
       try {
-         // waitFor(timeout, unit) returns false if the process is still
-         // running when the timeout expires. The previous code ignored
-         // that return and called exitValue() unconditionally, which
-         // throws IllegalThreadStateException if the process hadn't
-         // exited — masking the real failure (a hang) with a confusing
-         // unrelated exception.
-         boolean finished = process.waitFor(5, TimeUnit.MINUTES);
-         if (!finished) {
-            throw new IOException("gif2webp timed out after 5 minutes");
+         List<String> commands = new ArrayList<>();
+         commands.add(binary.toAbsolutePath().toString());
+         if (m >= 0) {
+            commands.add("-m");
+            commands.add(m + "");
          }
-         int exitStatus = process.exitValue();
-         if (exitStatus != 0) {
-            List<String> error = Files.readAllLines(stdout);
-            throw new IOException(error.toString());
+         if (q >= 0) {
+            commands.add("-q");
+            commands.add(q + "");
          }
-      } catch (InterruptedException e) {
-         Thread.currentThread().interrupt();
-         throw new IOException(e);
+         if (lossy) {
+            commands.add("-lossy");
+         }
+         commands.add(input.toAbsolutePath().toString());
+         commands.add("-o");
+         commands.add(target.toAbsolutePath().toString());
+
+         ProcessBuilder builder = new ProcessBuilder(commands);
+         builder.redirectErrorStream(true);
+         builder.redirectOutput(stdout.toFile());
+
+         Process process = builder.start();
+         try {
+            // waitFor(timeout, unit) returns false if the process is still
+            // running when the timeout expires. The previous code ignored
+            // that return and called exitValue() unconditionally, which
+            // throws IllegalThreadStateException if the process hadn't
+            // exited — masking the real failure (a hang) with a confusing
+            // unrelated exception.
+            boolean finished = process.waitFor(5, TimeUnit.MINUTES);
+            if (!finished) {
+               throw new IOException("gif2webp timed out after 5 minutes");
+            }
+            int exitStatus = process.exitValue();
+            if (exitStatus != 0) {
+               List<String> error = Files.readAllLines(stdout);
+               throw new IOException(error.toString());
+            }
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+         } finally {
+            process.destroy();
+         }
       } finally {
-         process.destroy();
-         stdout.toFile().delete();
+         try {
+            stdout.toFile().delete();
+         } catch (Exception ignored) {
+         }
       }
    }
 }

--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpMuxHandler.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpMuxHandler.java
@@ -82,45 +82,52 @@ public class WebpMuxHandler extends WebpHandler {
     * canvas size, loop count and per-frame table out of its stdout.
     */
    public WebpInfo info(byte[] webpBytes) throws IOException {
+      // Nest the two temp-file lifetimes: if the second createTempFile
+      // throws (disk full between the two calls), `input` is still cleaned
+      // up. Previously both creates lived outside the try and a
+      // mid-creation failure leaked the first one.
       Path input = Files.createTempFile("webpmux_in_", ".webp").toAbsolutePath();
-      Path stdout = Files.createTempFile("webpmux_stdout_", ".log");
       try {
-         Files.write(input, webpBytes, StandardOpenOption.CREATE);
-
-         List<String> commands = new ArrayList<>();
-         commands.add(binary.toAbsolutePath().toString());
-         commands.add("-info");
-         commands.add(input.toAbsolutePath().toString());
-
-         ProcessBuilder builder = new ProcessBuilder(commands);
-         builder.redirectErrorStream(true);
-         builder.redirectOutput(stdout.toFile());
-
-         Process process = builder.start();
+         Path stdout = Files.createTempFile("webpmux_stdout_", ".log");
          try {
-            boolean finished = process.waitFor(1, TimeUnit.MINUTES);
-            if (!finished) {
-               throw new IOException("webpmux did not complete within 1 minute");
+            Files.write(input, webpBytes, StandardOpenOption.CREATE);
+
+            List<String> commands = new ArrayList<>();
+            commands.add(binary.toAbsolutePath().toString());
+            commands.add("-info");
+            commands.add(input.toAbsolutePath().toString());
+
+            ProcessBuilder builder = new ProcessBuilder(commands);
+            builder.redirectErrorStream(true);
+            builder.redirectOutput(stdout.toFile());
+
+            Process process = builder.start();
+            try {
+               boolean finished = process.waitFor(1, TimeUnit.MINUTES);
+               if (!finished) {
+                  throw new IOException("webpmux did not complete within 1 minute");
+               }
+               int exitStatus = process.exitValue();
+               List<String> lines = Files.readAllLines(stdout);
+               if (exitStatus != 0) {
+                  throw new IOException("webpmux exited with status " + exitStatus + ": " + lines);
+               }
+               return parseInfo(lines);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+               throw new IOException(e);
+            } finally {
+               process.destroy();
             }
-            int exitStatus = process.exitValue();
-            List<String> lines = Files.readAllLines(stdout);
-            if (exitStatus != 0) {
-               throw new IOException("webpmux exited with status " + exitStatus + ": " + lines);
-            }
-            return parseInfo(lines);
-         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IOException(e);
          } finally {
-            process.destroy();
+            try {
+               stdout.toFile().delete();
+            } catch (Exception ignored) {
+            }
          }
       } finally {
          try {
             input.toFile().delete();
-         } catch (Exception ignored) {
-         }
-         try {
-            stdout.toFile().delete();
          } catch (Exception ignored) {
          }
       }


### PR DESCRIPTION
## Summary

Several places in the codebase allocated a resource (Graphics2D, temp file, temp directory) and only released it on the happy path. Any exception between allocation and release would leak it. This PR moves each release into a `finally` block so the resource is freed regardless of how the surrounding code exits.

- **`ProgressiveScale.scale`** — `Graphics2D.dispose()` now runs in `finally`. Before, an exception from `setRenderingHint` or `drawImage` would leak the Graphics2D.
- **`CausticsFilter.apply`** — same pattern; `dispose()` moved into `finally`.
- **`DWebpHandler` / `CWebpHandler` / `Gif2WebpHandler` (private `convert`)** — the `stdout` temp file was created before the try block, so a failure in `builder.start()` (binary missing, fork failure, etc.) leaked it. The body is now wrapped in a try/finally that brackets `stdout`'s lifetime.
- **`WebpMuxHandler.info`** — `input` and `stdout` were created sequentially before the try block. If the second `createTempFile` threw, `input` leaked. Lifetimes are now nested the same way `Gif2WebpHandler.convert(byte[])` already nests them.
- **`AnimDumpHandler.dumpFrames(byte[])`** — same nested-lifetime fix for `input` plus the temp output directory.

No behavioural change on the happy path.

## Test plan

- [x] `:scrimage-webp:test --rerun-tasks` — all webp tests pass
- [x] `:scrimage-tests:test --tests "*Scale*" --tests "*Caustics*" --tests "*Progressive*"` — pass
- [x] All three modules compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)