### PR TITLE
Make Directory.equals and Directory.hashCode null-safe for name

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Directory.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Directory.java
@@ -1,6 +1,7 @@
 package com.sksamuel.scrimage.metadata;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class Directory {
 
@@ -21,6 +22,12 @@ public class Directory {
         this.tags = tags;
     }
 
+    // name can be null in practice — it comes from drewmetadata's
+    // `directory.getName()`, which is non-null for the bundled directory
+    // implementations but the constructor doesn't enforce that. Use
+    // Objects.equals / Objects.hashCode rather than the direct calls so
+    // we don't throw NullPointerException from equals / hashCode.
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -28,14 +35,13 @@ public class Directory {
 
         Directory directory = (Directory) o;
 
-        if (!name.equals(directory.name)) return false;
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Objects.equals(name, directory.name)) return false;
         return Arrays.equals(tags, directory.tags);
     }
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
+        int result = Objects.hashCode(name);
         result = 31 * result + Arrays.hashCode(tags);
         return result;
     }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/DirectoryNullSafetyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/DirectoryNullSafetyTest.kt
@@ -1,0 +1,49 @@
+package com.sksamuel.scrimage.core.metadata
+
+import com.sksamuel.scrimage.metadata.Directory
+import com.sksamuel.scrimage.metadata.Tag
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression for Directory.equals / Directory.hashCode previously calling
+ * .equals and .hashCode unconditionally on name. The name field can be null
+ * — Directory's constructor doesn't enforce non-null, and parallel surfaces
+ * (Tag.rawValue / value) carry the same null risk for the same reason
+ * (drewmetadata returns null for some real records). The Tag class was
+ * fixed earlier with Objects.equals / Objects.hashCode; Directory had the
+ * same shape and the same bug.
+ */
+class DirectoryNullSafetyTest : FunSpec({
+
+   test("Directory.hashCode tolerates a null name") {
+      Directory(null, arrayOf()).hashCode()
+   }
+
+   test("Directory.equals tolerates a null name") {
+      val a = Directory(null, arrayOf())
+      val b = Directory(null, arrayOf())
+      a.equals(b) shouldBe true
+   }
+
+   test("Directory.equals distinguishes a null name from a non-null one") {
+      val a = Directory(null, arrayOf())
+      val b = Directory("Exif IFD0", arrayOf())
+      a.equals(b) shouldBe false
+      b.equals(a) shouldBe false
+   }
+
+   test("Directory.equals contract: equal Directories with null name have equal hash codes") {
+      val a = Directory(null, arrayOf(Tag("Make", 271, null, "Canon")))
+      val b = Directory(null, arrayOf(Tag("Make", 271, null, "Canon")))
+      a shouldBe b
+      a.hashCode() shouldBe b.hashCode()
+   }
+
+   test("Directory.equals: tags array still discriminates when names match") {
+      val a = Directory("Exif", arrayOf(Tag("Make", 271, null, "Canon")))
+      val b = Directory("Exif", arrayOf(Tag("Make", 271, null, "Nikon")))
+      a shouldNotBe b
+   }
+})


### PR DESCRIPTION
## Summary

`Directory`'s constructor doesn't enforce a non-null `name`, but `equals` and `hashCode` call `name.equals(...)` / `name.hashCode()` unconditionally — so a Directory with `name == null` NPEs from both methods.

This is the same class of bug fixed in `Tag` in c541d98f.

## Test plan
- [x] New regression test `DirectoryNullSafetyTest` covers null-name hashCode, equals symmetry, and tag-array discrimination
- [x] `./gradlew :scrimage-tests:test --tests "*.DirectoryNullSafetyTest"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)