### PR TITLE
Honour SparkleFilter's (x, y) constructor parameters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SparkleFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SparkleFilter.java
@@ -39,11 +39,30 @@ public class SparkleFilter extends BufferedOpFilter {
 
     @Override
     public BufferedImageOp op() {
-        thirdparty.jhlabs.image.SparkleFilter op = new thirdparty.jhlabs.image.SparkleFilter();
+        // Capture the configured sparkle centre into locals so the anonymous
+        // subclass can re-apply them after jhlabs' setDimensions clobbers
+        // centreX/centreY back to (width/2, height/2). PointFilter.filter
+        // calls setDimensions(srcWidth, srcHeight) right before iterating,
+        // so without this override the constructor's (x, y) is dead.
+        //
+        // (0, 0) is kept as a sentinel meaning "image centre" so the
+        // pre-existing no-arg SparkleFilter() still produces a centred
+        // sparkle. Any other (x, y) is honoured as a pixel coordinate.
+        final int cx = x;
+        final int cy = y;
+        thirdparty.jhlabs.image.SparkleFilter op = new thirdparty.jhlabs.image.SparkleFilter() {
+            @Override
+            public void setDimensions(int width, int height) {
+                super.setDimensions(width, height);
+                if (cx != 0 || cy != 0) {
+                    setCentreX(cx);
+                    setCentreY(cy);
+                }
+            }
+        };
         op.setRays(rays);
         op.setRadius(radius);
         op.setAmount(amount);
-        op.setDimensions(x, y);
         return op;
     }
 }

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
@@ -109,6 +109,22 @@ public class SparkleFilter extends PointFilter {
 			rayLengths[i] = radius + randomness / 100.0f * radius * (float)randomNumbers.nextGaussian();
 	}
 
+	public void setCentreX(int centreX) {
+		this.centreX = centreX;
+	}
+
+	public int getCentreX() {
+		return centreX;
+	}
+
+	public void setCentreY(int centreY) {
+		this.centreY = centreY;
+	}
+
+	public int getCentreY() {
+		return centreY;
+	}
+
 	public int filterRGB(int x, int y, int rgb) {
 		float dx = x-centreX;
 		float dy = y-centreY;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SparkleFilterCentreTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SparkleFilterCentreTest.kt
@@ -1,0 +1,57 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression: the (x, y) constructor parameters on SparkleFilter were
+ * silently discarded. The wrapper used to call
+ * `op.setDimensions(x, y)` to communicate the sparkle centre, but the
+ * jhlabs PointFilter base immediately calls
+ * `setDimensions(srcWidth, srcHeight)` from filter() before iterating
+ * pixels — which sets `centreX = width/2; centreY = height/2`, blowing
+ * the wrapper's values away. Net effect: every SparkleFilter sparkled
+ * at the image centre regardless of the (x, y) supplied at construction.
+ *
+ * The fix overrides setDimensions in an anonymous jhlabs subclass to
+ * re-apply the user-supplied centre after super resets it.
+ */
+class SparkleFilterCentreTest : FunSpec({
+
+   // Solid black 101x101 canvas — every pixel post-filter is either
+   // black (untouched) or some shade brighter (sparkle ray).
+   fun blackCanvas(): ImmutableImage =
+      ImmutableImage.filled(101, 101, java.awt.Color.BLACK)
+
+   fun luma(image: ImmutableImage, x: Int, y: Int): Int {
+      val p = image.pixel(x, y)
+      return p.red() + p.green() + p.blue()
+   }
+
+   test("explicit (x, y) is honoured — the pixel at the supplied centre is fully sparkled") {
+      val img = blackCanvas().filter(SparkleFilter(20, 80, 50, 25, 50))
+      // At the sparkle centre, jhlabs' filterRGB computes a mix factor
+      // saturating to 1 (distance ~ 0), so the pixel becomes the
+      // sparkle colour (opaque white).
+      luma(img, 20, 80) shouldBe (255 * 3)
+      // Pre-fix the sparkle landed at the image centre, so (20, 80)
+      // was untouched (luma 0). Post-fix it is fully sparkled (765).
+   }
+
+   test("default no-arg SparkleFilter still sparkles at the image centre") {
+      // Sanity-check: (0, 0) sentinel preserves the legacy "centre on
+      // the image" default so existing callers don't regress.
+      val img = blackCanvas().filter(SparkleFilter())
+      luma(img, 50, 50) shouldBeGreaterThan 0
+   }
+
+   test("two SparkleFilters at different (x, y) produce different images") {
+      val a = blackCanvas().filter(SparkleFilter(10, 10, 50, 25, 50))
+      val b = blackCanvas().filter(SparkleFilter(90, 90, 50, 25, 50))
+      // Pre-fix both were identical (sparkle always at centre).
+      a shouldNotBe b
+   }
+})


### PR DESCRIPTION
## Summary

`SparkleFilter(x, y, ...)` silently ignored its (x, y) — every sparkle landed at the image centre.

The wrapper passed `op.setDimensions(x, y)` into jhlabs to position the sparkle centre. But jhlabs' \`PointFilter.filter()\` calls \`setDimensions(srcWidth, srcHeight)\` again before iterating pixels (\`PointFilter.java:38\`), which sets \`centreX = width/2; centreY = height/2\` — blowing away whatever the wrapper had configured.

## Fix

1. Add public \`setCentreX\` / \`setCentreY\` on the jhlabs \`SparkleFilter\` (additive, no breakage).
2. Override \`setDimensions\` in an anonymous subclass inside the scrimage wrapper to re-apply the user-supplied centre after \`super\` resets it.

\`(0, 0)\` is kept as a sentinel meaning \"image centre\" so the no-arg \`SparkleFilter()\` constructor preserves its existing default behaviour.

## Test plan
- [x] New regression \`SparkleFilterCentreTest\` covers: default centre, explicit (x, y) lands at supplied coords, and two filters at different (x, y) produce different images
- [x] \`./gradlew :scrimage-filters:test --tests \"*.SparkleFilterCentreTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)