### PR TITLE
Make salt and pepper probabilities independent in SaltAndPepperFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
@@ -22,11 +22,18 @@ public class SaltAndPepperFilter implements Filter {
 
    @Override
    public void apply(ImmutableImage img) {
+      // Single draw per pixel partitioned across the two outcomes.
+      // Using `Math.random() < pepper` followed by `else if
+      // (Math.random() < salt)` would give each pixel a probability
+      // of being salt of (1 - pepper) * salt rather than the
+      // documented `salt` — e.g. SaltAndPepperFilter(0.5, 0.5)
+      // produced 50% pepper but only 25% salt.
       for (int i = 0; i < img.width; i++) {
          for (int j = 0; j < img.height; j++) {
-            if (Math.random() < pepper) {
+            double r = Math.random();
+            if (r < pepper) {
                img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_BLACK));
-            } else if (Math.random() < salt) {
+            } else if (r < pepper + salt) {
                img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_WHITE));
             }
          }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SaltAndPepperFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SaltAndPepperFilterTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.scrimage.filter
 
 import com.sksamuel.scrimage.ImmutableImage
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import java.awt.Color
 
@@ -40,5 +41,37 @@ class SaltAndPepperFilterTest : FunSpec({
          p.green() shouldBe 0
          p.blue() shouldBe 0
       }
+   }
+
+   // Regression: salt and pepper probabilities were not independent.
+   // The old code drew two independent Math.random() calls in an
+   // if/else-if, so the salt branch was reached only when the pepper
+   // branch did not fire — effective salt probability was
+   // (1 - pepper) * salt instead of salt. For salt=pepper=0.5 the
+   // distribution was 50% pepper / 25% salt / 25% unchanged, not the
+   // 50/50/0 the caller expected. The fix draws a single Math.random()
+   // per pixel and partitions the [0, pepper+salt) interval.
+   test("salt and pepper probabilities are independent of order") {
+      val source = ImmutableImage.filled(200, 200, Color.GRAY)
+      val out = source.filter(SaltAndPepperFilter(0.5, 0.5))
+
+      var black = 0
+      var white = 0
+      var gray = 0
+      out.pixels().forEach { p ->
+         val rgb = (p.red() shl 16) or (p.green() shl 8) or p.blue()
+         when (rgb) {
+            0x000000 -> black++
+            0xFFFFFF -> white++
+            else -> gray++
+         }
+      }
+
+      // 40,000 pixels at 50/50 split → expect ~20,000 black, ~20,000 white,
+      // ~0 gray. The pre-fix code produced ~20,000 black, ~10,000 white,
+      // ~10,000 gray, with a ratio black:white ≈ 2:1. Tolerance is loose
+      // (3 sigma ~= 150) but well inside the 10,000-pixel pre-fix gap.
+      kotlin.math.abs(black - white) shouldBeLessThan 1000
+      gray shouldBeLessThan 1000
    }
 })


### PR DESCRIPTION
## Summary

\`SaltAndPepperFilter\` drew two independent \`Math.random()\` calls in an \`if/else-if\`, so the salt branch only fired when the pepper branch didn't. Effective probabilities were:

\`\`\`
P(pepper) = pepper
P(salt)   = (1 - pepper) * salt
P(none)   = (1 - pepper) * (1 - salt)
\`\`\`

For \`SaltAndPepperFilter(0.5, 0.5)\` the caller-expected 50/50 split came out as 50% pepper / 25% salt / 25% unchanged — pepper at 2x the rate of salt.

## Fix

Draw one \`Math.random()\` per pixel and partition the unit interval. \`P(pepper) = pepper\`, \`P(salt) = salt\`, \`P(unchanged) = 1 - pepper - salt\`.

## Test plan
- [x] New test asserts black ≈ white for the (0.5, 0.5) case (pre-fix: ~2:1)
- [x] Existing pure-salt / pure-pepper tests still pass
- [x] \`./gradlew :scrimage-filters:test --tests \"*.SaltAndPepperFilterTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)