### PR TITLE
Validate bounds in AwtImage.patch to prevent silent row-wrap

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -401,9 +401,18 @@ public class AwtImage {
    }
 
    public Pixel[] patch(int x, int y, int patchWidth, int patchHeight) {
+      if (x < 0 || y < 0 || patchWidth < 0 || patchHeight < 0
+            || x + patchWidth > width || y + patchHeight > height) {
+         throw new IllegalArgumentException(
+            "Patch (" + x + "," + y + " " + patchWidth + "x" + patchHeight + ") falls outside image bounds " + width + "x" + height);
+      }
       return patchFrom(pixels(), x, y, patchWidth, patchHeight);
    }
 
+   // Internal helper, callers (this::patch, this::patches) are responsible
+   // for staying inside [0, width] × [0, height]. arraycopy below copies
+   // patchWidth contiguous Pixels per row from a row-major flat array, so
+   // an out-of-range x or width would silently span row boundaries.
    private Pixel[] patchFrom(Pixel[] source, int x, int y, int patchWidth, int patchHeight) {
       Pixel[] patch = new Pixel[patchWidth * patchHeight];
       for (int i = 0; i < patchHeight; i++) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PatchBoundsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PatchBoundsTest.kt
@@ -1,0 +1,63 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: `AwtImage.patch(x, y, patchWidth, patchHeight)` had no
+ * bounds check. The internal helper does a contiguous `System.arraycopy`
+ * of `patchWidth` pixels per row from a row-major flat array; if
+ * `x + patchWidth > width` the copy silently spans into the next row,
+ * returning the wrong pixels rather than failing. If the read goes off
+ * the end of the source array the call throws ArrayIndexOutOfBoundsException
+ * from inside arraycopy with no useful context.
+ */
+class PatchBoundsTest : FunSpec({
+
+   // 4x4 image where each pixel's red channel equals its flat index 0..15.
+   fun indexedImage(): ImmutableImage {
+      val pixels = Array(16) { i -> Pixel(i % 4, i / 4, i, 0, 0, 255) }
+      return ImmutableImage.create(4, 4, pixels)
+   }
+
+   test("in-bounds patch returns the correct pixels") {
+      val image = indexedImage()
+      val patch = image.patch(1, 1, 2, 2)
+      // (1,1)=5, (2,1)=6, (1,2)=9, (2,2)=10 — row-major
+      patch[0].red() shouldBe 5
+      patch[1].red() shouldBe 6
+      patch[2].red() shouldBe 9
+      patch[3].red() shouldBe 10
+   }
+
+   test("patch overflowing the right edge throws IllegalArgumentException") {
+      val image = indexedImage()
+      // x=3, patchWidth=2 → would silently span into the next row
+      // (returning pixels [3, 4, 7, 8] = right column of row 0 +
+      // left column of row 1).
+      shouldThrow<IllegalArgumentException> { image.patch(3, 0, 2, 2) }
+   }
+
+   test("patch overflowing the bottom edge throws IllegalArgumentException") {
+      val image = indexedImage()
+      // y=3, patchHeight=2 → row 4 doesn't exist; pre-fix this threw
+      // an opaque ArrayIndexOutOfBoundsException from inside arraycopy.
+      shouldThrow<IllegalArgumentException> { image.patch(0, 3, 2, 2) }
+   }
+
+   test("patch with negative origin throws IllegalArgumentException") {
+      val image = indexedImage()
+      shouldThrow<IllegalArgumentException> { image.patch(-1, 0, 2, 2) }
+      shouldThrow<IllegalArgumentException> { image.patch(0, -1, 2, 2) }
+   }
+
+   test("patch matching the full image is allowed") {
+      val image = indexedImage()
+      val full = image.patch(0, 0, 4, 4)
+      full.size shouldBe 16
+      full[15].red() shouldBe 15
+   }
+})


### PR DESCRIPTION
## Summary

\`AwtImage.patch(x, y, patchWidth, patchHeight)\` had no bounds check. The internal helper does a contiguous \`System.arraycopy\` of \`patchWidth\` pixels per row from a row-major flat array, so if \`x + patchWidth > width\` the read silently spans into the next row, returning the wrong pixels with no error. If the read overruns the source array, arraycopy throws a context-free \`ArrayIndexOutOfBoundsException\` from deep inside the JDK.

Example: on a 10x10 image, \`image.patch(8, 0, 5, 5)\` would return a 5x5 \"patch\" whose right two columns are stitched from the start of rows 1–4 — a horizontal wraparound.

## Fix

Validate \`x ≥ 0\`, \`y ≥ 0\`, \`x + patchWidth ≤ width\`, \`y + patchHeight ≤ height\` at the public entry point and throw \`IllegalArgumentException\` with the offending coordinates. The internal callers (\`patches()\`) already iterate within bounds and are unaffected.

## Test plan
- [x] New \`PatchBoundsTest\`: in-bounds OK, right-edge overflow rejected, bottom-edge overflow rejected, negative origin rejected, full-image patch allowed
- [x] \`./gradlew :scrimage-tests:test --tests \"*.PatchBoundsTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)