### PR TITLE
Match alpha in PixelTools.approx so autocrop respects transparency

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -142,7 +142,10 @@ public class PixelTools {
 
    /**
     * Returns true if the colors of all pixels in the array are within the given tolerance
-    * compared to the referenced color
+    * compared to the referenced color.
+    * <p>
+    * Fully-transparent pixels (alpha == 0) match a fully-transparent target regardless of
+    * RGB — the colour channels of a transparent pixel are indeterminate.
     *
     * @return true if all pixels are within tolerance of the given color, false otherwise
     */
@@ -152,9 +155,17 @@ public class PixelTools {
       int minR = Math.max(ref.red - tolerance, 0),   maxR = Math.min(ref.red + tolerance, 255);
       int minG = Math.max(ref.green - tolerance, 0), maxG = Math.min(ref.green + tolerance, 255);
       int minB = Math.max(ref.blue - tolerance, 0),  maxB = Math.min(ref.blue + tolerance, 255);
+      int minA = Math.max(ref.alpha - tolerance, 0), maxA = Math.min(ref.alpha + tolerance, 255);
 
       for (Pixel p : pixels) {
-         if (!(p.red()   >= minR && p.red()   <= maxR &&
+         // Mirror uniform()'s special case for transparency: a fully-transparent
+         // pixel matches a fully-transparent target regardless of RGB. Without
+         // this and without the alpha bounds check, autocrop(Transparent, tol>0)
+         // would treat any opaque pixel whose RGB happened to fall near (0,0,0)
+         // as matching transparent and crop it away.
+         if (p.alpha() == 0 && ref.alpha == 0) continue;
+         if (!(p.alpha() >= minA && p.alpha() <= maxA &&
+               p.red()   >= minR && p.red()   <= maxR &&
                p.green() >= minG && p.green() <= maxG &&
                p.blue()  >= minB && p.blue()  <= maxB)) return false;
       }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -114,4 +114,36 @@ class PixelToolsTest : FunSpec({
       PixelTools.blue(scaled) shouldBe 67
    }
 
+   // Regression: approx() ignored the alpha channel. autocrop routes its
+   // tolerance > 0 path through colorMatches -> approx. With a transparent
+   // target (e.g. Colors.Transparent = (0,0,0,0)) and tolerance > 0, an
+   // opaque near-black pixel matched on RGB alone — so autocropping a
+   // photo with a transparent border around an opaque dark subject would
+   // crop into the subject. approx now matches alpha within tolerance,
+   // with the same fully-transparent special case as uniform.
+   test("approx rejects an opaque near-black pixel when target is transparent") {
+      val transparent = Color(0, 0, 0, 0)
+      // RGB sits within tolerance of (0, 0, 0) but alpha is 255 — opaque
+      // content over a transparent background should not match.
+      val opaqueNearBlack = Pixel(0, 0, 5, 5, 5, 255)
+      PixelTools.approx(transparent, 10, arrayOf(opaqueNearBlack)) shouldBe false
+   }
+
+   test("approx accepts a fully-transparent pixel against a transparent target regardless of RGB") {
+      // Transparent pixels have indeterminate RGB; both PNG decoders and
+      // most callers leave them as (0,0,0,0) but the wire format permits
+      // any RGB under alpha=0. Match transparent-on-transparent regardless.
+      val transparent = Color(0, 0, 0, 0)
+      val transparentWithGarbageRgb = Pixel(0, 0, 200, 100, 50, 0)
+      PixelTools.approx(transparent, 0, arrayOf(transparentWithGarbageRgb)) shouldBe true
+      PixelTools.approx(transparent, 10, arrayOf(transparentWithGarbageRgb)) shouldBe true
+   }
+
+   test("approx rejects an opaque pixel when reference is semi-transparent and alpha is well outside tolerance") {
+      val semiTransparent = Color(100, 100, 100, 64)
+      val opaque = Pixel(0, 0, 100, 100, 100, 255)
+      // alpha tolerance of 10 → opaque (255) is far outside [54, 74].
+      PixelTools.approx(semiTransparent, 10, arrayOf(opaque)) shouldBe false
+   }
+
 })


### PR DESCRIPTION
## Summary

\`PixelTools.approx(color, tolerance, pixels)\` only compared R/G/B and ignored alpha. \`colorMatches\` routes tolerance > 0 through \`approx\`, so \`autocrop(Colors.Transparent.awt(), tolerance=10)\` treated every pixel whose RGB happened to fall in [0, tol] — including opaque near-black content — as matching the transparent target.

The practical bug: autocropping a photo of a dark subject on a transparent background, with any non-zero tolerance, cropped into the subject rather than trimming just the transparent border.

Symmetrically, autocropping with a partially-transparent target colour matched opaque pixels of the same RGB regardless of alpha.

## Fix

Include alpha in the tolerance-window check inside \`approx\`. Mirror \`uniform\`'s fully-transparent-matches-any special case so a transparent pixel still matches a transparent target regardless of its (indeterminate) RGB channels.

## Test plan
- [x] New \`PixelToolsTest\` cases pin the alpha behaviour
- [x] Existing autocrop tests (\`AutoCropTest\`, \`AutocropTest\`, \`AutocropIdempotenceInvariantTest\`) still pass
- [x] \`./gradlew :scrimage-tests:test --tests \"*.PixelToolsTest\" --tests \"*Autocrop*\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)