### PR TITLE
Scope each drawable's Graphics2D state to prevent cross-drawable leaks

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/Canvas.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/Canvas.java
@@ -37,11 +37,7 @@ public class Canvas {
    public void drawInPlace(Collection<Drawable> drawables) {
       Graphics2D g = g2(image);
       try {
-         drawables.forEach(d -> {
-            RichGraphics2D rich2d = new RichGraphics2D(g);
-            d.context().configure(rich2d);
-            d.draw(rich2d);
-         });
+         drawables.forEach(d -> drawScoped(g, d));
       } finally {
          g.dispose();
       }
@@ -55,14 +51,27 @@ public class Canvas {
       ImmutableImage target = image.copy();
       Graphics2D g = g2(target);
       try {
-         drawables.forEach(d -> {
-            RichGraphics2D rich2d = new RichGraphics2D(g);
-            d.context().configure(rich2d);
-            d.draw(rich2d);
-         });
+         drawables.forEach(d -> drawScoped(g, d));
       } finally {
          g.dispose();
       }
       return new Canvas(target);
+   }
+
+   // Each drawable gets a scratch Graphics2D snapshot so its GraphicsContext's
+   // configure() mutations (setColor, setStroke, setFont, translate, rotate,
+   // setComposite, …) don't bleed across to the next drawable. Without this
+   // every subsequent drawable inherited whatever state the previous one
+   // happened to leave on the shared Graphics2D — a red rectangle followed
+   // by an un-configured one would render the second in red too.
+   private static void drawScoped(Graphics2D g, Drawable d) {
+      Graphics2D scoped = (Graphics2D) g.create();
+      try {
+         RichGraphics2D rich2d = new RichGraphics2D(scoped);
+         d.context().configure(rich2d);
+         d.draw(rich2d);
+      } finally {
+         scoped.dispose();
+      }
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/CanvasStateIsolationTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/CanvasStateIsolationTest.kt
@@ -1,0 +1,76 @@
+package com.sksamuel.scrimage.canvas
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.drawables.FilledRect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.Color
+
+// A GraphicsContext that sets the paint colour.
+private fun colorContext(color: Color): GraphicsContext = GraphicsContext { g -> g.setColor(color) }
+
+/**
+ * Regression: Canvas.draw / drawInPlace iterated drawables and ran each
+ * drawable's GraphicsContext.configure() against a shared Graphics2D.
+ * State mutations applied for drawable N (setColor, setStroke, setFont,
+ * translate, rotate, setComposite, …) leaked into drawable N+1.
+ *
+ * The fix wraps each drawable in a Graphics2D.create() snapshot that is
+ * disposed after the drawable finishes, scoping its state mutations.
+ */
+class CanvasStateIsolationTest : FunSpec({
+
+   test("a previous drawable's colour does not leak into a context-less drawable") {
+      // Scenario A: red rectangle then a plain (no-context) rectangle.
+      // Scenario B: blue rectangle then a plain (no-context) rectangle.
+      // Pre-fix, the plain rectangle inherited whatever colour the
+      // previous drawable left on the shared Graphics2D, so the second
+      // rectangle was red in A and blue in B. With proper scoping the
+      // plain rectangle is drawn in whatever the underlying Graphics2D
+      // defaults to — the same colour in both scenarios.
+      val plain = FilledRect(50, 50, 10, 10)
+      val redRect = FilledRect(0, 0, 10, 10, colorContext(Color.RED))
+      val blueRect = FilledRect(0, 0, 10, 10, colorContext(Color.BLUE))
+
+      val afterRed = Canvas(ImmutableImage.create(100, 100)).draw(redRect, plain).image
+      val afterBlue = Canvas(ImmutableImage.create(100, 100)).draw(blueRect, plain).image
+
+      // First-position rectangle differs (red vs blue) — sanity.
+      afterRed.pixel(0, 0).red() shouldBe 255
+      afterBlue.pixel(0, 0).blue() shouldBe 255
+
+      // Plain rectangle should look the same in both scenarios — its
+      // appearance must not depend on the previous drawable.
+      afterRed.pixel(50, 50) shouldBe afterBlue.pixel(50, 50)
+   }
+
+   test("a configured colour does not bleed into the NEXT drawable's context-free draw") {
+      // Even when both drawables use context-less constructors, drawing
+      // them after a coloured drawable should still yield identical
+      // colour to drawing them without that preamble.
+      val plain1 = FilledRect(20, 20, 10, 10)
+      val plain2 = FilledRect(60, 60, 10, 10)
+      val redRect = FilledRect(0, 0, 10, 10, colorContext(Color.RED))
+
+      val withRedPreamble = Canvas(ImmutableImage.create(100, 100)).draw(redRect, plain1, plain2).image
+      val withoutPreamble = Canvas(ImmutableImage.create(100, 100)).draw(plain1, plain2).image
+
+      withRedPreamble.pixel(20, 20) shouldBe withoutPreamble.pixel(20, 20)
+      withRedPreamble.pixel(60, 60) shouldBe withoutPreamble.pixel(60, 60)
+   }
+
+   test("two coloured drawables both honour their own colour") {
+      val redRect = FilledRect(0, 0, 10, 10, colorContext(Color.RED))
+      val blueRect = FilledRect(20, 0, 10, 10, colorContext(Color.BLUE))
+
+      val out = Canvas(ImmutableImage.create(100, 100)).draw(redRect, blueRect).image
+
+      val red = out.pixel(0, 0)
+      val blue = out.pixel(20, 0)
+      red.red() shouldBe 255
+      red.blue() shouldBe 0
+      blue.blue() shouldBe 255
+      blue.red() shouldBe 0
+   }
+})


### PR DESCRIPTION
## Summary

\`Canvas.draw\` and \`Canvas.drawInPlace\` iterated drawables and ran each drawable's \`GraphicsContext.configure()\` against a shared \`Graphics2D\`. State mutations applied for drawable N (\`setColor\`, \`setStroke\`, \`setFont\`, \`translate\`, \`rotate\`, \`setComposite\`, …) leaked into drawable N+1.

Net effect:
- A no-context drawable following a coloured one rendered in that colour.
- A drawable following a \`translate\` / \`rotate\` inherited the leftover transform.
- Behaviour depended on iteration order, including across independent canvases that happen to be drawn in the same JVM.

Example: \`canvas.draw(redRect, plainRect)\` — \`plainRect\` came out red.

## Fix

Wrap each drawable's \`configure\` + \`draw\` pair in a \`Graphics2D.create()\` snapshot that is disposed after the drawable finishes. This is the standard AWT idiom for scoped state.

## Test plan
- [x] New \`CanvasStateIsolationTest\` covers: previous colour does not leak into context-less drawable; identical scenarios produce identical pixel output regardless of preceding drawables; two coloured drawables both render in their own colour
- [x] Existing \`CanvasDisposeOnThrowTest\` still passes (dispose-on-throw still works)
- [x] All other canvas tests pass (\`LinearGradientDirectionTest\`, \`RandomPainterTest\`, \`TextDoubleConfigureTest\`)
- [x] \`./gradlew :scrimage-tests:test --tests \"com.sksamuel.scrimage.canvas.*\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)