### PR TITLE
Fix scaleHeightToRatio computing new height from width

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1353,7 +1353,7 @@ public class ImmutableImage extends MutableImage {
    }
 
    public ImmutableImage scaleHeightToRatio(double ratio, ScaleMethod scaleMethod) {
-      return scaleToHeight((int) (width * ratio), scaleMethod);
+      return scaleToHeight((int) (height * ratio), scaleMethod);
    }
 
    public ImmutableImage scale(double scaleFactor) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ScaleHeightToRatioTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ScaleHeightToRatioTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.scrimage.core.ops
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: scaleHeightToRatio computed the new height from
+ * `width * ratio` instead of `height * ratio`. On a non-square image
+ * the result therefore depended on the wrong dimension and produced
+ * an unrelated height. For example, on a 400 x 200 image,
+ * `scaleHeightToRatio(0.5)` returned an image of height 200 (= width
+ * * 0.5) — completely unchanged — rather than the expected height 100.
+ */
+class ScaleHeightToRatioTest : FunSpec({
+
+   test("scaleHeightToRatio(0.5) halves the height of a non-square image") {
+      val img = ImmutableImage.create(400, 200)
+      val scaled = img.scaleHeightToRatio(0.5)
+      scaled.height shouldBe 100
+   }
+
+   test("scaleHeightToRatio(2.0) doubles the height of a non-square image") {
+      val img = ImmutableImage.create(400, 200)
+      val scaled = img.scaleHeightToRatio(2.0)
+      scaled.height shouldBe 400
+   }
+
+   test("scaleHeightToRatio(1.0) preserves the height") {
+      val img = ImmutableImage.create(400, 200)
+      img.scaleHeightToRatio(1.0).height shouldBe 200
+   }
+})


### PR DESCRIPTION
## Summary

\`scaleHeightToRatio(ratio)\` computed the target height as \`(int)(width * ratio)\` instead of \`(int)(height * ratio)\`. On a non-square image the result was unrelated to the input height.

Example: on a 400×200 image, \`scaleHeightToRatio(0.5)\` returned an image of height 200 (= width × 0.5) — completely unchanged — rather than the expected height 100.

Trivial copy-paste — the symmetric public method \`scaleWidthToRatio\` doesn't exist, so there was nothing to mirror against.

## Test plan
- [x] New \`ScaleHeightToRatioTest\` covers half/double/identity on a non-square image
- [x] \`./gradlew :scrimage-tests:test --tests \"*.ScaleHeightToRatioTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)