### PR TITLE
Validate OilFilter constructor parameters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OilFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OilFilter.java
@@ -23,6 +23,16 @@ public class OilFilter extends BufferedOpFilter {
     private final int levels;
 
     public OilFilter(int range, int levels) {
+        if (range < 0)
+            throw new IllegalArgumentException("range must be >= 0, got " + range);
+        // The jhlabs implementation allocates histograms of size `levels`
+        // and reads `rTotal[0] / rHistogram[0]` after the bucketing loop —
+        // so `levels < 1` crashes with NegativeArraySizeException (negative)
+        // or ArrayIndexOutOfBoundsException (zero). Buckets are computed
+        // as `r * levels / 256`, so levels above 256 wastes memory without
+        // adding fidelity but is technically valid; cap defensively anyway.
+        if (levels < 1 || levels > 256)
+            throw new IllegalArgumentException("levels must be in [1, 256], got " + levels);
         this.range = range;
         this.levels = levels;
     }

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/OilFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/OilFilterValidationTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: OilFilter accepted any (range, levels) and would crash
+ * at filter-apply time with a NegativeArraySizeException (levels < 0),
+ * ArrayIndexOutOfBoundsException (levels == 0, after the bucketing
+ * loop), or silently waste a lot of memory (levels > 256, since the
+ * bucketing math is `r * levels / 256`).
+ *
+ * Validate up front in the wrapper constructor.
+ */
+class OilFilterValidationTest : FunSpec({
+
+   test("OilFilter rejects levels == 0") {
+      shouldThrow<IllegalArgumentException> { OilFilter(3, 0) }
+   }
+
+   test("OilFilter rejects negative levels") {
+      shouldThrow<IllegalArgumentException> { OilFilter(3, -1) }
+   }
+
+   test("OilFilter rejects levels > 256") {
+      shouldThrow<IllegalArgumentException> { OilFilter(3, 257) }
+   }
+
+   test("OilFilter rejects negative range") {
+      shouldThrow<IllegalArgumentException> { OilFilter(-1, 256) }
+   }
+
+   test("OilFilter accepts the documented defaults") {
+      OilFilter()      // (3, 256)
+      OilFilter(3, 1)  // tight
+      OilFilter(3, 256)
+   }
+})


### PR DESCRIPTION
## Summary

\`OilFilter(range, levels)\` accepted any int and crashed at filter-apply time:

- \`levels < 0\` → \`NegativeArraySizeException\` when allocating histograms
- \`levels == 0\` → \`ArrayIndexOutOfBoundsException\` after the bucketing loop reaches \`rTotal[0] / rHistogram[0]\`
- \`levels > 256\` → silent memory waste; the bucketing math is \`r * levels / 256\`, so additional buckets buy no fidelity
- \`range < 0\` → degenerate neighbourhood

## Fix

Validate up front in the wrapper constructor with \`IllegalArgumentException\` — matches the pattern already used by \`KaleidoscopeFilter\` and other validated filters in this package.

## Test plan
- [x] New \`OilFilterValidationTest\` covers each rejection case + accepts documented defaults
- [x] \`./gradlew :scrimage-filters:test --tests \"*.OilFilterValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)