### PR TITLE
Validate LensBlurFilter sides and radius

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/LensBlurFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/LensBlurFilter.java
@@ -25,6 +25,14 @@ public class LensBlurFilter extends BufferedOpFilter {
     private final int sides;
 
     public  LensBlurFilter(float radius, float bloom, float bloomThreshold, int sides) {
+        if (radius < 0)
+            throw new IllegalArgumentException("radius must be >= 0, got " + radius);
+        // The jhlabs implementation computes `polyAngle = π / sides` and
+        // walks the polygon vertices; sides < 3 either divides by zero
+        // (sides == 0) or produces a degenerate "polygon" of 1–2 vertices
+        // that the bokeh-shape math doesn't handle.
+        if (sides < 3)
+            throw new IllegalArgumentException("sides must be >= 3, got " + sides);
         this.radius = radius;
         this.bloom = bloom;
         this.bloomThreshold = bloomThreshold;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensBlurFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensBlurFilterValidationTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: LensBlurFilter accepted any (radius, sides). The jhlabs
+ * implementation computes `polyAngle = π / sides` — with sides == 0
+ * this divides by zero, and with sides < 3 produces a degenerate
+ * "polygon" the bokeh-shape math doesn't handle. KaleidoscopeFilter
+ * already validates sides ≥ 3 in this package; LensBlurFilter didn't.
+ */
+class LensBlurFilterValidationTest : FunSpec({
+
+   test("LensBlurFilter rejects sides == 0") {
+      shouldThrow<IllegalArgumentException> { LensBlurFilter(5f, 2f, 255f, 0) }
+   }
+
+   test("LensBlurFilter rejects sides < 3") {
+      shouldThrow<IllegalArgumentException> { LensBlurFilter(5f, 2f, 255f, 2) }
+   }
+
+   test("LensBlurFilter rejects negative radius") {
+      shouldThrow<IllegalArgumentException> { LensBlurFilter(-1f, 2f, 255f, 5) }
+   }
+
+   test("LensBlurFilter accepts the documented defaults") {
+      LensBlurFilter()
+      LensBlurFilter(0f, 2f, 255f, 3)
+   }
+})


### PR DESCRIPTION
## Summary

\`LensBlurFilter\` accepted any \`(radius, sides)\`. The jhlabs implementation computes \`polyAngle = π / sides\`; with \`sides == 0\` this divides by zero, and with \`sides < 3\` it produces a degenerate "polygon" the bokeh-shape math doesn't handle.

\`KaleidoscopeFilter\` already validates \`sides ≥ 3\` in this package; \`LensBlurFilter\` was an outlier.

## Test plan
- [x] New \`LensBlurFilterValidationTest\` rejects sides 0 / sides 2 / negative radius; accepts defaults
- [x] \`./gradlew :scrimage-filters:test --tests \"*.LensBlurFilterValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)