### PR TITLE
Validate SmearFilter distance, density, mix, and smearType

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SmearFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SmearFilter.java
@@ -27,6 +27,18 @@ public class SmearFilter extends BufferedOpFilter {
     private final float mix;
 
     public SmearFilter(SmearType smearType, float angle, float density, float scatter, int distance, float mix) {
+        if (smearType == null)
+            throw new IllegalArgumentException("smearType must not be null");
+        // The jhlabs implementation does `nextInt() % distance` in the
+        // shape-drawing loops; distance == 0 throws ArithmeticException
+        // ("/ by zero") deep inside filterPixels. Negative values give
+        // negative `length` and degenerate output.
+        if (distance < 1)
+            throw new IllegalArgumentException("distance must be >= 1, got " + distance);
+        if (density < 0 || density > 1)
+            throw new IllegalArgumentException("density must be in [0, 1], got " + density);
+        if (mix < 0 || mix > 1)
+            throw new IllegalArgumentException("mix must be in [0, 1], got " + mix);
         this.smearType = smearType;
         this.angle = angle;
         this.density = density;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SmearFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SmearFilterValidationTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: SmearFilter accepted any (distance, density, mix). The
+ * jhlabs implementation does `nextInt() % distance` in the
+ * shape-drawing loops; distance == 0 throws ArithmeticException
+ * ("/ by zero") deep inside filterPixels. density / mix outside [0,1]
+ * have undefined semantics.
+ */
+class SmearFilterValidationTest : FunSpec({
+
+   test("SmearFilter rejects distance == 0") {
+      shouldThrow<IllegalArgumentException> { SmearFilter(SmearType.Lines, 0f, 0.3f, 0f, 0, 0.4f) }
+   }
+
+   test("SmearFilter rejects negative distance") {
+      shouldThrow<IllegalArgumentException> { SmearFilter(SmearType.Lines, 0f, 0.3f, 0f, -1, 0.4f) }
+   }
+
+   test("SmearFilter rejects density > 1") {
+      shouldThrow<IllegalArgumentException> { SmearFilter(SmearType.Lines, 0f, 1.5f, 0f, 3, 0.4f) }
+   }
+
+   test("SmearFilter rejects mix > 1") {
+      shouldThrow<IllegalArgumentException> { SmearFilter(SmearType.Lines, 0f, 0.3f, 0f, 3, 1.5f) }
+   }
+
+   test("SmearFilter rejects null SmearType") {
+      shouldThrow<IllegalArgumentException> { SmearFilter(null, 0f, 0.3f, 0f, 3, 0.4f) }
+   }
+
+   test("SmearFilter accepts documented defaults") {
+      SmearFilter(SmearType.Lines)
+      SmearFilter(SmearType.Circles, 0f, 0f, 0f, 1, 0f)
+   }
+})


### PR DESCRIPTION
## Summary

\`SmearFilter\` accepted any \`(distance, density, mix, smearType)\` and crashed at filter-apply time:

- \`distance == 0\` → \`ArithmeticException: / by zero\` from \`nextInt() % distance\` deep inside the jhlabs filterPixels
- \`distance < 0\` → negative \`length\` and degenerate output
- \`density\` or \`mix\` outside \`[0, 1]\` → undefined semantics
- \`null\` SmearType → NPE in the switch inside \`op()\`

## Fix

Reject all of these up front with \`IllegalArgumentException\`.

## Test plan
- [x] New \`SmearFilterValidationTest\` rejects each bad input + accepts documented defaults
- [x] \`./gradlew :scrimage-filters:test --tests \"*.SmearFilterValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)