### PR TITLE
Validate ColorHalftoneFilter and CrystallizeFilter sizing parameters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ColorHalftoneFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ColorHalftoneFilter.java
@@ -22,6 +22,12 @@ public class ColorHalftoneFilter extends BufferedOpFilter {
     private final float radius;
 
     public ColorHalftoneFilter(float radius) {
+        // The jhlabs implementation computes `gridSize = 2 * radius * sqrt(2)`
+        // and then `ImageMath.mod(tx, gridSize)` — a non-positive radius
+        // produces a zero gridSize and divides by zero, propagating NaN
+        // through the whole image.
+        if (!(radius > 0))
+            throw new IllegalArgumentException("radius must be > 0, got " + radius);
         this.radius = radius;
     }
 

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CrystallizeFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CrystallizeFilter.java
@@ -25,6 +25,15 @@ public class CrystallizeFilter extends BufferedOpFilter {
     private final double randomness;
 
     public CrystallizeFilter(double scale, double edgeThickness, int edgeColor, double randomness) {
+        if (!(scale > 0))
+            throw new IllegalArgumentException("scale must be > 0, got " + scale);
+        // The jhlabs implementation computes `f = (f2 - f1) / edgeThickness`
+        // — `edgeThickness == 0` produces ±Infinity, the subsequent
+        // smoothStep flattens the entire output to a single colour.
+        if (edgeThickness <= 0)
+            throw new IllegalArgumentException("edgeThickness must be > 0, got " + edgeThickness);
+        if (randomness < 0 || randomness > 1)
+            throw new IllegalArgumentException("randomness must be in [0, 1], got " + randomness);
         this.scale = scale;
         this.edgeThickness = edgeThickness;
         this.edgeColor = edgeColor;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/HalftoneCrystallizeValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/HalftoneCrystallizeValidationTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: ColorHalftoneFilter and CrystallizeFilter accepted
+ * non-positive sizing parameters that crashed (div-by-zero) or
+ * silently produced garbage output in the jhlabs implementations.
+ *
+ * - ColorHalftoneFilter: gridSize = 2 * radius * √2; radius == 0
+ *   makes gridSize == 0 and ImageMath.mod divides by zero.
+ * - CrystallizeFilter: f = (f2 - f1) / edgeThickness; edgeThickness
+ *   == 0 produces ±Infinity and the smoothStep flattens the image.
+ */
+class HalftoneCrystallizeValidationTest : FunSpec({
+
+   test("ColorHalftoneFilter rejects radius == 0") {
+      shouldThrow<IllegalArgumentException> { ColorHalftoneFilter(0f) }
+   }
+
+   test("ColorHalftoneFilter rejects negative radius") {
+      shouldThrow<IllegalArgumentException> { ColorHalftoneFilter(-1f) }
+   }
+
+   test("ColorHalftoneFilter accepts the documented default") {
+      ColorHalftoneFilter()
+   }
+
+   test("CrystallizeFilter rejects scale == 0") {
+      shouldThrow<IllegalArgumentException> { CrystallizeFilter(0.0, 0.4, 0xff000000.toInt(), 0.2) }
+   }
+
+   test("CrystallizeFilter rejects edgeThickness == 0") {
+      shouldThrow<IllegalArgumentException> { CrystallizeFilter(16.0, 0.0, 0xff000000.toInt(), 0.2) }
+   }
+
+   test("CrystallizeFilter rejects randomness > 1") {
+      shouldThrow<IllegalArgumentException> { CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 1.5) }
+   }
+
+   test("CrystallizeFilter accepts the documented default") {
+      CrystallizeFilter()
+   }
+})


### PR DESCRIPTION
## Summary

Two filters accepted non-positive sizing parameters that crashed or silently flattened their output:

- **\`ColorHalftoneFilter\`**: jhlabs computes \`gridSize = 2 * radius * √2\` then \`ImageMath.mod(tx, gridSize)\`. \`radius == 0\` divides by zero, propagating NaN through every pixel.
- **\`CrystallizeFilter\`**: jhlabs computes \`f = (f2 - f1) / edgeThickness\`. \`edgeThickness == 0\` produces ±Infinity, smoothStep flattens the entire output to a single colour.

## Fix

Reject these up front in the wrapper constructors. Also validate \`scale > 0\` and \`randomness ∈ [0, 1]\` on \`CrystallizeFilter\` while we're there.

## Test plan
- [x] New \`HalftoneCrystallizeValidationTest\` covers rejected cases + documented defaults
- [x] \`./gradlew :scrimage-filters:test --tests \"*.HalftoneCrystallizeValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)