### PR TITLE
Enforce HSBFilter [-1, 1] factor range at runtime, not via assert

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/HSBFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/HSBFilter.java
@@ -26,17 +26,23 @@ public class HSBFilter extends BufferedOpFilter {
     private final float brightness;
 
     public HSBFilter(float hue, float saturation, float brightness) {
-
-        assert hue <= 1;
-        assert brightness <= 1;
-        assert saturation <= 1;
-        assert hue >= -1;
-        assert brightness >= -1;
-        assert saturation >= -1;
+        // Plain `assert` is a no-op without -ea, so the documented
+        // [-1, 1] contract wasn't enforced in production — a hue of
+        // 10 silently produced visually wrong output rather than
+        // failing fast. Use IllegalArgumentException for the same
+        // explicit validation other filters in this package use.
+        requireUnitFactor("hue", hue);
+        requireUnitFactor("saturation", saturation);
+        requireUnitFactor("brightness", brightness);
 
         this.hue = hue;
         this.saturation = saturation;
         this.brightness = brightness;
+    }
+
+    private static void requireUnitFactor(String name, float value) {
+        if (!(value >= -1f && value <= 1f))
+            throw new IllegalArgumentException(name + " must be in [-1, 1], got " + value);
     }
 
     public HSBFilter() {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/HSBFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/HSBFilterValidationTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: HSBFilter advertised a [-1, 1] range for each factor but
+ * enforced it with plain `assert`, which is a no-op without `-ea`. In
+ * production a hue of 10 silently produced visually wrong output
+ * rather than failing fast.
+ */
+class HSBFilterValidationTest : FunSpec({
+
+   test("HSBFilter rejects hue > 1") {
+      shouldThrow<IllegalArgumentException> { HSBFilter(10f, 0f, 0f) }
+   }
+
+   test("HSBFilter rejects hue < -1") {
+      shouldThrow<IllegalArgumentException> { HSBFilter(-2f, 0f, 0f) }
+   }
+
+   test("HSBFilter rejects saturation > 1") {
+      shouldThrow<IllegalArgumentException> { HSBFilter(0f, 2f, 0f) }
+   }
+
+   test("HSBFilter rejects brightness > 1") {
+      shouldThrow<IllegalArgumentException> { HSBFilter(0f, 0f, 2f) }
+   }
+
+   test("HSBFilter rejects NaN") {
+      shouldThrow<IllegalArgumentException> { HSBFilter(Float.NaN, 0f, 0f) }
+   }
+
+   test("HSBFilter accepts the documented range") {
+      HSBFilter()
+      HSBFilter(-1f, -1f, -1f)
+      HSBFilter(1f, 1f, 1f)
+      HSBFilter(0.3f, -0.2f, 0.5f)
+   }
+})


### PR DESCRIPTION
## Summary

\`HSBFilter\` advertised a [-1, 1] range for each factor (hue/saturation/brightness) but enforced it with plain \`assert\` — a no-op without \`-ea\`. In production a hue of 10 silently produced visually wrong output rather than failing fast.

## Fix

Replace asserts with \`IllegalArgumentException\`, matching the pattern already used by \`VignetteFilter\` / \`AlphaMaskFilter\` / \`ErrorSpotterFilter\`. NaN is also rejected.

## Test plan
- [x] New \`HSBFilterValidationTest\` rejects out-of-range hue/saturation/brightness + NaN; accepts documented range
- [x] \`./gradlew :scrimage-filters:test --tests \"*.HSBFilterValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)