### PR TITLE
Return defensive copies from ImageMetadata.getDirectories() and Directory.getTags()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Directory.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Directory.java
@@ -11,7 +11,10 @@ public class Directory {
     }
 
     public Tag[] getTags() {
-        return tags;
+        // Return a defensive copy. Previously this leaked the backing
+        // array; a caller writing `dir.getTags()[0] = null` corrupted
+        // internal state and broke equals/hashCode.
+        return tags.clone();
     }
 
     private final Tag[] tags;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/ImageMetadata.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/ImageMetadata.java
@@ -77,7 +77,11 @@ public class ImageMetadata {
    private final Directory[] directories;
 
    public Directory[] getDirectories() {
-      return directories;
+      // Return a defensive copy. Previously this leaked the backing
+      // array; a caller writing `meta.getDirectories()[0] = null`
+      // corrupted internal state — equals/hashCode broke and the
+      // tags() stream NPE'd.
+      return directories.clone();
    }
 
    @Override

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/MetadataDefensiveCopyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/metadata/MetadataDefensiveCopyTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.scrimage.core.metadata
+
+import com.sksamuel.scrimage.metadata.Directory
+import com.sksamuel.scrimage.metadata.ImageMetadata
+import com.sksamuel.scrimage.metadata.Tag
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression: ImageMetadata.getDirectories() and Directory.getTags()
+ * returned the backing array directly. A caller mutating that array
+ * (`meta.getDirectories()[0] = null`) corrupted internal state — the
+ * subsequent equals/hashCode used the mutated array and `tags()`
+ * NPE'd inside the flatMap stream.
+ */
+class MetadataDefensiveCopyTest : FunSpec({
+
+   test("ImageMetadata.getDirectories() returns a defensive copy") {
+      val meta = ImageMetadata(arrayOf(Directory("Exif IFD0", arrayOf())))
+
+      val firstView = meta.directories
+      firstView[0] = Directory("Mutated", arrayOf())
+
+      // Internal state unchanged
+      meta.directories[0].name shouldBe "Exif IFD0"
+      // First view (now mutated locally) does not equal a fresh view
+      firstView[0].name shouldNotBe meta.directories[0].name
+   }
+
+   test("Directory.getTags() returns a defensive copy") {
+      val tag = Tag("Make", 271, "Canon", "Canon")
+      val dir = Directory("Exif IFD0", arrayOf(tag))
+
+      val firstView = dir.tags
+      firstView[0] = Tag("Mutated", 1, "x", "y")
+
+      // Internal state unchanged
+      dir.tags[0].name shouldBe "Make"
+      firstView[0].name shouldNotBe dir.tags[0].name
+   }
+})


### PR DESCRIPTION
## Summary

Both \`ImageMetadata.getDirectories()\` and \`Directory.getTags()\` returned their backing array directly. A caller writing \`meta.getDirectories()[0] = null\` corrupted internal state — the subsequent \`equals\` / \`hashCode\` used the mutated array, and \`ImageMetadata.tags()\` NPE'd inside the flatMap stream.

## Fix

Return \`array.clone()\` from both methods. \`Directory[]\` and \`Tag[]\` are shallow-copied; the \`Directory\` and \`Tag\` instances themselves are immutable so a shallow copy is enough.

## Test plan
- [x] New \`MetadataDefensiveCopyTest\` mutates a returned array and confirms internal state is preserved
- [x] \`./gradlew :scrimage-tests:test --tests \"*.MetadataDefensiveCopyTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)