### PR TITLE
Compare luminance instead of packed ARGB in DifferenceHasher

### DIFF
--- a/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
+++ b/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
@@ -16,9 +16,15 @@ class DifferenceHasher(private val cols: Int, private val rows: Int) {
       // the centre instead of summarising the whole image. That defeated
       // the entire point of the perceptual hash.
       val r = gs.scaleTo(cols, rows)
+      // Compare luminance via the unsigned-byte red channel of the
+      // already-grayscale image. The previous code compared `argb`
+      // packed ints directly — opaque grayscale pixels have a high
+      // byte of 0xFF, making the int negative, so on inputs with
+      // varying source alpha the dhash sorted by alpha rather than
+      // brightness and produced a perceptually meaningless hash.
       return r.rows()
          .flatMap { row ->
-            row.toList().windowed(2).map { if (it.first().argb < it.last().argb) 1 else 0 }
+            row.toList().windowed(2).map { if (it.first().red() < it.last().red()) 1 else 0 }
          }
    }
 

--- a/scrimage-hash/src/test/kotlin/com/sksamuel/scrimage/hash/DifferenceHasherAlphaTest.kt
+++ b/scrimage-hash/src/test/kotlin/com/sksamuel/scrimage/hash/DifferenceHasherAlphaTest.kt
@@ -1,0 +1,59 @@
+package com.sksamuel.scrimage.hash
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: DifferenceHasher compared packed ARGB ints with signed
+ * `<`. Opaque grayscale pixels have alpha bits `0xFF`, making the int
+ * negative — two opaque pixels of different brightness still compare
+ * correctly because the sign bit cancels, but as soon as the source
+ * image has any per-pixel alpha variation the hash sorts by alpha
+ * (top byte dominates the comparison) instead of brightness.
+ *
+ * The fix compares the unsigned red channel of the already-grayscale
+ * image, which is brightness.
+ */
+class DifferenceHasherAlphaTest : FunSpec({
+
+   // Build a 9x8 image whose left-to-right gradient is monotonically
+   // increasing in brightness *and* the leftmost column happens to
+   // have a translucent strip. After toGrayscale + scaleTo the small
+   // image has 8 rows x 9 columns; the dhash compares adjacent
+   // columns within each row → 8 bits per row, 64 bits total.
+   //
+   // The hash should reflect brightness ordering ("each pair to the
+   // right is brighter than the one to the left"), regardless of
+   // whether the source had alpha variation.
+   test("dhash with translucent strips still reflects brightness ordering") {
+      // 16 wide gradient, rows uniform. Left half opaque, right half opaque.
+      // Translucent strip in the leftmost column doesn't carry brightness
+      // information but used to dominate the signed argb compare.
+      val pixels = Array(16 * 8) { i ->
+         val x = i % 16
+         val y = i / 16
+         // Brightness increases L→R.
+         val luma = x * 16
+         // Leftmost column 50% transparent; rest opaque. The argb int
+         // becomes positive-or-negative depending on alpha, which is
+         // what the bug latched onto.
+         val alpha = if (x == 0) 128 else 255
+         Pixel(x, y, luma, luma, luma, alpha)
+      }
+      val image = ImmutableImage.create(16, 8, pixels)
+
+      val hash = image.dhash()
+
+      // Each "1" bit means the left pixel was less bright (= "dimmer").
+      // For a strictly increasing brightness gradient, every adjacent
+      // pair should yield 1. Pre-fix, the leftmost comparison was
+      // skewed by the alpha discontinuity and the hash had a leading
+      // 0 where every other position was 1.
+      hash.size shouldBe 8 * 8
+      // All bits should be 1 (each next column is brighter), regardless
+      // of alpha variation in the source.
+      hash.all { it == 1 } shouldBe true
+   }
+})


### PR DESCRIPTION
## Summary

The dhash compared \`it.first().argb < it.last().argb\` (packed ARGB ints with signed \`<\`). Opaque pixels have a high byte of \`0xFF\`, making the int negative — two opaque grayscale pixels compare correctly because the sign bit cancels, but as soon as the source image has any per-pixel alpha variation the top-byte alpha dominates the comparison and the hash sorts by alpha instead of brightness.

The resulting "perceptual hash" is perceptually meaningless on translucent inputs.

## Fix

Compare \`first.red() < last.red()\` on the already-grayscale image. LUMA-grayscale gives r=g=b=luminance, so the red channel IS the brightness.

## Test plan
- [x] New \`DifferenceHasherAlphaTest\` covers an L→R brightness gradient with a translucent leftmost column. Post-fix every bit is 1 (each column brighter than the previous); pre-fix the alpha discontinuity flipped the leading bit.
- [x] Existing \`DifferenceHasherTest\` and \`DifferenceHasherScalingTest\` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)