### PR TITLE
Prevent ProgressiveScale infinite loop on non-downscale targets

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
@@ -17,11 +17,32 @@ public class ProgressiveScale {
                                      int targetHeight,
                                      Object interpolation) {
 
+      // Progressive scaling halves each dimension until it reaches the
+      // target. It is a downscale-only algorithm; if a target dimension
+      // is greater than or equal to the source dimension on that axis,
+      // there is nothing to do for that axis. The earlier code never
+      // moved w/h toward target when the source was already at or below
+      // it on an axis, so callers asking for `(targetWidth >= source.w,
+      // targetHeight < source.h)` spun forever, each iteration
+      // allocating a new BufferedImage.
+      if (targetWidth < 1 || targetHeight < 1)
+         throw new IllegalArgumentException("target dimensions must be positive, got "
+            + targetWidth + "x" + targetHeight);
+
       int type = getType(image);
       BufferedImage temp = image;
-      int w, h;
-      w = image.getWidth();
-      h = image.getHeight();
+      int w = image.getWidth();
+      int h = image.getHeight();
+      // Snap each axis that is already at or below the target.
+      if (w < targetWidth) w = targetWidth;
+      if (h < targetHeight) h = targetHeight;
+
+      // Already at target? Return the original; no progressive step
+      // needed, and skipping the unconditional iteration avoids a wasted
+      // allocation and Graphics2D round-trip.
+      if (w == targetWidth && h == targetHeight) {
+         return image;
+      }
 
       do {
          if (w > targetWidth) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ProgressiveScaleConvergenceTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ProgressiveScaleConvergenceTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.scrimage.core.scaling
+
+import com.sksamuel.scrimage.ProgressiveScale
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+
+/**
+ * Regression: ProgressiveScale's loop only halved an axis when it was
+ * greater than the target. If a caller invoked it with any target
+ * dimension >= the source dimension on that axis (e.g. target wider
+ * than source but shorter than source), that axis never converged
+ * and the do/while spun forever, each iteration allocating a new
+ * BufferedImage.
+ *
+ * The fix snaps each axis up to the target if it's already at-or-below,
+ * short-circuits when both axes match the target, and validates targets
+ * are positive.
+ */
+class ProgressiveScaleConvergenceTest : FunSpec({
+
+   fun source(): BufferedImage = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
+
+   test("target equal to source returns the source without allocating") {
+      val src = source()
+      val out = ProgressiveScale.scale(src, 100, 100, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      // Identity case: no progressive step needed.
+      out shouldBe src
+   }
+
+   test("target taller than source on one axis converges (no infinite loop)") {
+      // Pre-fix this hung forever because h (100) >= targetHeight (200)
+      // meant the h-halving branch never fired and `w != targetWidth ||
+      // h != targetHeight` was always true after w reached targetWidth.
+      val src = source()
+      val out = ProgressiveScale.scale(src, 50, 200, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      out.width shouldBe 50
+      out.height shouldBe 200
+   }
+
+   test("target >= source on both axes returns source (downscale-only, no infinite loop)") {
+      // ProgressiveScale is a downscale algorithm — halve until target.
+      // For a target larger than source on both axes there is no
+      // progressive step to run, so the source is returned. Pre-fix
+      // this spun forever, each iteration reallocating BufferedImages.
+      val src = source()
+      val out = ProgressiveScale.scale(src, 200, 200, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      out shouldBe src
+   }
+
+   test("target dimensions must be positive") {
+      shouldThrow<IllegalArgumentException> {
+         ProgressiveScale.scale(source(), 0, 50, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      }
+      shouldThrow<IllegalArgumentException> {
+         ProgressiveScale.scale(source(), 50, -1, RenderingHints.VALUE_INTERPOLATION_BILINEAR)
+      }
+   }
+})


### PR DESCRIPTION
## Summary

\`ProgressiveScale.scale\` only halved an axis when it was strictly greater than the target, but the do/while exit condition required exact equality on both axes. If a caller passed any target dimension \`>=\` the source dimension on that axis — including the natural identity case \`targetWidth == source.width\` — that axis never moved and the loop spun forever, each iteration reallocating a BufferedImage.

\`ImmutableImage.scaleTo\` happens to route around this by sending upscale paths to \`Bicubic\`, but the public static \`ProgressiveScale.scale\` has no guard.

## Fix

- Snap each axis up to the target when source is already at or below it.
- Short-circuit and return the source when both axes already meet the target.
- Validate that target dimensions are positive.

For mixed cases (one axis upscales, one downscales) the loop now converges to the downscale axis and the upscale axis is realised in a final \`Graphics2D.drawImage\`.

## Test plan
- [x] Identity target returns source
- [x] Mixed up/down target converges
- [x] Full-upscale target returns source (no infinite loop)
- [x] Non-positive target rejected
- [x] \`./gradlew :scrimage-tests:test --tests \"*.ProgressiveScaleConvergenceTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)