### PR TITLE
Map JpegWriter compression=100 to highest explicit quality

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
@@ -52,9 +52,15 @@ public class JpegWriter implements ImageWriter {
       javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName("jpeg").next();
       ImageWriteParam params = writer.getDefaultWriteParam();
 
-      if (compression == 100) {
-         params.setCompressionMode(ImageWriteParam.MODE_DISABLED);
-      } else if (compression > -1 && compression < 100) {
+      // compression is a quality knob in [0, 100]. The earlier code
+      // treated `compression == 100` as MODE_DISABLED — invalid for
+      // JPEG (JPEG is always compressed) and rejected at write time
+      // by the JDK writer. Treat any non-negative compression in
+      // [0, 100] as explicit quality, including 100 → quality=1.0
+      // (the best the codec offers). Negative values (the existing
+      // CompressionFromMetaData = -1 sentinel) take the
+      // COPY_FROM_METADATA path.
+      if (compression >= 0 && compression <= 100) {
          params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
          params.setCompressionQuality(compression / 100f);
       } else {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterQualityTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/JpegWriterQualityTest.kt
@@ -1,0 +1,52 @@
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.JpegWriter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import java.awt.Color
+import java.io.ByteArrayOutputStream
+
+/**
+ * Regression: JpegWriter mapped `compression == 100` to
+ * ImageWriteParam.MODE_DISABLED — invalid for JPEG (which is always
+ * compressed). The JDK JPEG writer throws or silently misbehaves for
+ * this mode. A caller passing "100" expecting "best quality" got an
+ * UnsupportedOperationException or a corrupt write at runtime.
+ *
+ * The fix maps the full [0, 100] range to MODE_EXPLICIT with
+ * quality = compression / 100f, so 100 means "quality 1.0" — the
+ * highest quality the codec produces.
+ */
+class JpegWriterQualityTest : FunSpec({
+
+   fun source(): ImmutableImage =
+      ImmutableImage.filled(64, 64, Color.RED)
+
+   test("JpegWriter with compression=100 writes a JPEG successfully (highest quality)") {
+      val bytes = ByteArrayOutputStream().use { out ->
+         JpegWriter(100, false).write(source(), source().metadata, out)
+         out.toByteArray()
+      }
+      // Smoke check: the bytes begin with the JPEG SOI marker FF D8.
+      bytes.size shouldBeGreaterThan 2
+      bytes[0].toInt() and 0xFF shouldBe 0xFF
+      bytes[1].toInt() and 0xFF shouldBe 0xD8
+   }
+
+   test("JpegWriter with compression=80 still writes") {
+      val bytes = ByteArrayOutputStream().use { out ->
+         JpegWriter(80, false).write(source(), source().metadata, out)
+         out.toByteArray()
+      }
+      bytes.size shouldBeGreaterThan 2
+   }
+
+   test("compression=100 output is larger than compression=10 (more quality, more bytes)") {
+      val src = ImmutableImage.create(64, 64).map { p -> Color(p.x() * 4 % 256, p.y() * 4 % 256, 128) }
+      val high = ByteArrayOutputStream().also { JpegWriter(100, false).write(src, src.metadata, it) }.toByteArray()
+      val low = ByteArrayOutputStream().also { JpegWriter(10, false).write(src, src.metadata, it) }.toByteArray()
+      high.size shouldBeGreaterThan low.size
+   }
+})


### PR DESCRIPTION
## Summary

\`JpegWriter\` treated \`compression == 100\` as \`ImageWriteParam.MODE_DISABLED\` — invalid for JPEG (which is always compressed). The JDK JPEG writer either throws \`UnsupportedOperationException\` or silently misbehaves for this mode. A caller passing "100" expecting "best quality" got a runtime failure.

## Fix

Map the full \`[0, 100]\` range to \`MODE_EXPLICIT\` with \`quality = compression / 100f\`. \`100\` → quality 1.0 (the highest the codec offers). Negative values (the \`CompressionFromMetaData = -1\` sentinel) still take the \`COPY_FROM_METADATA\` path.

The \`@Deprecated JpegWriter.NoCompression = new JpegWriter(100, false)\` static now produces a max-quality JPEG instead of failing — its docstring already says "cannot be used with JPEG"; this is the friendly fallback.

## Test plan
- [x] New \`JpegWriterQualityTest\` writes at compression=100, 80, 10 and verifies the JPEG header and that high-quality output is larger than low-quality output
- [x] \`./gradlew :scrimage-tests:test --tests \"*.JpegWriterQualityTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)