### PR TITLE
Validate buffer type in ScrimageNearestNeighbourScale

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/ScrimageNearestNeighbourScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/ScrimageNearestNeighbourScale.java
@@ -1,6 +1,7 @@
 package com.sksamuel.scrimage.scaling;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
 
 public class ScrimageNearestNeighbourScale implements Scale {
@@ -8,8 +9,20 @@ public class ScrimageNearestNeighbourScale implements Scale {
     @Override
     public BufferedImage scale(BufferedImage in, int w, int h) {
 
+        // The fast path reads/writes the int[] backing store directly,
+        // so it only works on int-buffer BufferedImages. Previously a
+        // non-int buffer threw a ClassCastException from deep inside
+        // this method with no useful context. ImmutableImage.scaleTo
+        // guards this for its callers but the class is public so a
+        // direct user can still land here.
+        DataBuffer inBuf = in.getRaster().getDataBuffer();
+        if (!(inBuf instanceof DataBufferInt))
+            throw new IllegalArgumentException(
+                "ScrimageNearestNeighbourScale requires an int-buffer BufferedImage, got "
+                    + inBuf.getClass().getSimpleName() + " (image type " + in.getType() + ")");
+
         BufferedImage out = new BufferedImage(w, h, in.getType());
-        int[] pixels = ((DataBufferInt) in.getRaster().getDataBuffer()).getData();
+        int[] pixels = ((DataBufferInt) inBuf).getData();
         int[] newpixels = ((DataBufferInt) out.getRaster().getDataBuffer()).getData();
 
         int n = 0;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ScrimageNearestNeighbourScaleBufferTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ScrimageNearestNeighbourScaleBufferTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.scrimage.core.scaling
+
+import com.sksamuel.scrimage.scaling.ScrimageNearestNeighbourScale
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression: ScrimageNearestNeighbourScale unconditionally cast the
+ * source DataBuffer to DataBufferInt. For non-int-buffer image types
+ * (TYPE_BYTE_GRAY, TYPE_4BYTE_ABGR, TYPE_3BYTE_BGR, etc.) callers got
+ * a context-free ClassCastException from inside the scale method.
+ *
+ * Validate up front with IllegalArgumentException so the contract is
+ * obvious.
+ */
+class ScrimageNearestNeighbourScaleBufferTest : FunSpec({
+
+   test("rejects TYPE_BYTE_GRAY (byte-buffer) with a helpful message") {
+      val gray = BufferedImage(20, 20, BufferedImage.TYPE_BYTE_GRAY)
+      shouldThrow<IllegalArgumentException> {
+         ScrimageNearestNeighbourScale().scale(gray, 10, 10)
+      }
+   }
+
+   test("rejects TYPE_4BYTE_ABGR (byte-buffer)") {
+      val abgr = BufferedImage(20, 20, BufferedImage.TYPE_4BYTE_ABGR)
+      shouldThrow<IllegalArgumentException> {
+         ScrimageNearestNeighbourScale().scale(abgr, 10, 10)
+      }
+   }
+
+   test("accepts TYPE_INT_ARGB") {
+      val argb = BufferedImage(20, 20, BufferedImage.TYPE_INT_ARGB)
+      val out = ScrimageNearestNeighbourScale().scale(argb, 10, 10)
+      out shouldNotBe null
+   }
+})


### PR DESCRIPTION
## Summary

\`ScrimageNearestNeighbourScale\` reads/writes the int[] backing store directly via \`DataBufferInt\`. For non-int-buffer image types (\`TYPE_BYTE_GRAY\`, \`TYPE_4BYTE_ABGR\`, \`TYPE_3BYTE_BGR\`, …) callers got a context-free \`ClassCastException\` from inside \`scale()\`. \`ImmutableImage.scaleTo\` guards this for its callers, but the class is public so direct users can land here.

## Fix

Validate the buffer type up front with \`IllegalArgumentException\` naming the actual buffer type and image-type ordinal.

## Test plan
- [x] Rejects TYPE_BYTE_GRAY / TYPE_4BYTE_ABGR with an informative message
- [x] Accepts TYPE_INT_ARGB
- [x] \`./gradlew :scrimage-tests:test --tests \"*.ScrimageNearestNeighbourScaleBufferTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)