### PR TITLE
Iterate instead of recurse in AutocropOps scan methods

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
@@ -7,35 +7,39 @@ import java.awt.*;
 
 public class AutocropOps {
 
+   // Each scan*() walks one axis until it hits the first non-matching
+   // strip or the image edge. The earlier implementations were
+   // unbounded tail recursion; the JVM does not eliminate Java tail
+   // calls, so a fully-cropable wide/tall image blew the stack on
+   // sufficiently large inputs (e.g. a 5000-px wide image with the
+   // entire border matching cropped colour recursed 5000 times). Use
+   // a plain while loop.
+
    /**
     * Starting with the given column index, will return the first column index
     * which contains a colour that does not match the given color.
     */
    public static int scanright(Color color, int height, int width, int col, PixelsExtractor f, int tolerance) {
-      if (col == width || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
-         return col;
-      else
-         return scanright(color, height, width, col + 1, f, tolerance);
+      while (col < width && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
+         col++;
+      return col;
    }
 
    public static int scanleft(Color color, int height, int col, PixelsExtractor f, int tolerance) {
-      if (col == 0 || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
-         return col;
-      else
-         return scanleft(color, height,  col - 1, f, tolerance);
+      while (col > 0 && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))
+         col--;
+      return col;
    }
 
    public static int scandown(Color color, int height, int width, int row, PixelsExtractor f, int tolerance) {
-      if (row == height || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
-         return row;
-      else
-         return scandown(color, height, width, row + 1, f, tolerance);
+      while (row < height && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
+         row++;
+      return row;
    }
 
    public static int scanup(Color color, int width, int row, PixelsExtractor f, int tolerance) {
-      if (row == 0 || !PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
-         return row;
-      else
-         return scanup(color, width, row - 1, f, tolerance);
+      while (row > 0 && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(0, row, width, 1))))
+         row--;
+      return row;
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/AutocropStackSafetyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/AutocropStackSafetyTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.scrimage.core.ops
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: AutocropOps.scanright/left/up/down were unbounded tail
+ * recursion. The JVM does not eliminate Java tail calls, so an image
+ * whose border is fully one colour and whose width or height is
+ * large enough recursed once per pixel column/row and tripped
+ * StackOverflowError. Rewritten as a while loop, the work scales
+ * the same way but uses constant stack space.
+ */
+class AutocropStackSafetyTest : FunSpec({
+
+   test("autocrop on a wide image with a full single-colour interior is stack-safe") {
+      // 20000-px wide, single-colour image. The crop would recurse
+      // ~20000 deep on each axis pre-fix and trip StackOverflowError
+      // on most JVM defaults.
+      val img = ImmutableImage.filled(20000, 10, Color.WHITE)
+      val out = img.autocrop(Color.WHITE)
+      // The whole image matches the crop colour, so cropping returns
+      // the trivial 0-px or 1-px image. Either way it returns rather
+      // than blowing the stack — that's the regression we care about.
+      out.width shouldBe out.width // (forces evaluation)
+   }
+})


### PR DESCRIPTION
## Summary

\`AutocropOps.scanright\` / \`scanleft\` / \`scandown\` / \`scanup\` were unbounded tail recursion. The JVM does not eliminate Java tail calls, so a fully cropable wide/tall image recursed once per pixel column/row and blew the stack — a 20000-px wide single-colour image tripped \`StackOverflowError\` on default JVM stack sizes.

## Fix

Rewrite the four scans as while loops. Same observable behaviour, constant stack use.

## Test plan
- [x] Existing autocrop tests still pass (AutoCropTest, AutocropTest, AutocropIdempotenceInvariantTest)
- [x] New \`AutocropStackSafetyTest\` autocrops a 20000-px wide single-colour image without StackOverflowError
- [x] \`./gradlew :scrimage-tests:test --tests \"*Autocrop*\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)