### PR TITLE
Emit NETSCAPE2.0 loop count as full 16-bit little-endian

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/AbstractGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/AbstractGifWriter.java
@@ -54,8 +54,18 @@ abstract class AbstractGifWriter {
       child.setAttribute("applicationID", "NETSCAPE");
       child.setAttribute("authenticationCode", "2.0");
 
+      // The NETSCAPE2.0 loop count is a little-endian 16-bit integer.
+      // The previous code hard-coded the high byte to 0, silently
+      // truncating any value >= 256 to its low byte. Today only 0/1
+      // is exposed (infiniteLoop boolean), but emitting both bytes
+      // correctly makes the byte sequence spec-compliant and
+      // future-proofs the encoder for a finite-loop-count API.
       int loop = infiniteLoop ? 0 : 1;
-      child.setUserObject(new byte[]{0x1, (byte) (loop & 0xFF), (byte) (0)});
+      child.setUserObject(new byte[]{
+         0x1,
+         (byte) (loop & 0xFF),
+         (byte) ((loop >> 8) & 0xFF)
+      });
       appEntensionsNode.appendChild(child);
    }
 }


### PR DESCRIPTION
## Summary

The NETSCAPE2.0 loop-count application extension is a little-endian 16-bit integer. The previous code hard-coded the high byte to \`0\`, silently truncating any value ≥ 256 to its low byte.

Today the public API only exposes \`0\` (infinite) or \`1\` (play once), so the bug is latent — both values fit in a byte. But emitting \`(loop >> 8) & 0xFF\` for the high byte makes the encoded sequence spec-compliant and future-proofs the encoder for a finite loop-count API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)