### PR TITLE
Validate PngWriter compression level in the constructor

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
@@ -40,10 +40,18 @@ public class PngWriter implements ImageWriter {
    }
 
    public PngWriter(int compressionLevel) {
+      // Validate up front rather than at write time. The earlier
+      // code deferred the check to write(), which only fires after
+      // the caller has opened the OutputStream — so a bad compression
+      // level both produced a confusing failure mode and (when the
+      // caller passed a FileOutputStream that wasn't closed on the
+      // throw) leaked file descriptors.
+      if (compressionLevel < 0 || compressionLevel > 9) {
+         throw new IllegalArgumentException(
+            "Compression level must be between 0 (none) and 9 (max), got " + compressionLevel);
+      }
       this.compressionLevel = compressionLevel;
    }
-
-   // require(compressionLevel >= 0 && compressionLevel < 10, "Compression level must be between 0 (none) and 9 (max)")
 
    public PngWriter withMaxCompression() {
       return MaxCompression;
@@ -59,10 +67,6 @@ public class PngWriter implements ImageWriter {
 
    @Override
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
-   
-      if (compressionLevel < 0 || compressionLevel >= 10) {
-         throw new IOException("Compression level must be between 0 (none) and 9 (max)");
-      }
 
       ImageTypeSpecifier type = ImageTypeSpecifier.createFromBufferedImageType(image.getType());
       javax.imageio.ImageWriter writer = ImageIO.getImageWriters(type, "png").next();

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
@@ -7,6 +7,7 @@ import com.sksamuel.scrimage.nio.PngReader
 import com.sksamuel.scrimage.nio.PngWriter
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import org.apache.commons.io.IOUtils
 
 class PngWriterTest : WordSpec({
@@ -43,12 +44,12 @@ class PngWriterTest : WordSpec({
       // Regression test: compressionLevel < 0 || compressionLevel >= 10 was written as && so the
       // validation was dead code — values outside 0-9 were silently accepted.
       "invalid compression level below 0 is rejected" {
-         val ex = runCatching { original.bytes(PngWriter(-1)) }.exceptionOrNull()
-         ex?.message shouldBe "Compression level must be between 0 (none) and 9 (max)"
+         val ex = runCatching { PngWriter(-1) }.exceptionOrNull()
+         ex?.message shouldStartWith "Compression level must be between 0 (none) and 9 (max)"
       }
       "invalid compression level of 10 is rejected" {
-         val ex = runCatching { original.bytes(PngWriter(10)) }.exceptionOrNull()
-         ex?.message shouldBe "Compression level must be between 0 (none) and 9 (max)"
+         val ex = runCatching { PngWriter(10) }.exceptionOrNull()
+         ex?.message shouldStartWith "Compression level must be between 0 (none) and 9 (max)"
       }
       "valid boundary compression levels 0 and 9 are accepted" {
          original.bytes(PngWriter(0)).size shouldBe original.bytes(PngWriter.NoCompression).size

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterValidationTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterValidationTest.kt
@@ -1,0 +1,35 @@
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.PngWriter
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+/**
+ * Regression: PngWriter deferred compression-level validation to
+ * write(), so an invalid level both produced a confusing late
+ * IOException AND, when the caller had opened a FileOutputStream
+ * before passing it in, leaked that stream until GC.
+ *
+ * Validate up front in the constructor so the misuse fails fast
+ * before any IO resources are allocated by the caller.
+ */
+class PngWriterValidationTest : FunSpec({
+
+   test("PngWriter rejects compressionLevel == -1 in the constructor") {
+      shouldThrow<IllegalArgumentException> { PngWriter(-1) }
+   }
+
+   test("PngWriter rejects compressionLevel == 10 in the constructor") {
+      shouldThrow<IllegalArgumentException> { PngWriter(10) }
+   }
+
+   test("PngWriter accepts 0 (none) and 9 (max)") {
+      PngWriter(0)
+      PngWriter(9)
+   }
+
+   test("PngWriter.withCompression rejects an invalid level") {
+      shouldThrow<IllegalArgumentException> { PngWriter().withCompression(-1) }
+      shouldThrow<IllegalArgumentException> { PngWriter().withCompression(11) }
+   }
+})


### PR DESCRIPTION
## Summary

\`PngWriter\` deferred its compression-level validation to \`write()\`, so an invalid level:
- Produced a confusing late \`IOException\` after the caller had already opened their \`OutputStream\`.
- Leaked the caller's \`FileOutputStream\` (etc.) until GC if the caller hadn't wrapped the stream in a \`try-with-resources\`.

Also, the loosely-defined comment hinted at "compressionLevel < 10" while the static constants implied \`[0, 9]\`; the constraint is fully \`[0, 9]\`.

## Fix

Validate in the constructor with \`IllegalArgumentException\` — misuse fails fast before any IO resources are allocated.

## Test plan
- [x] Rejects -1 / 10 / 11 in constructor and \`withCompression\`
- [x] Accepts 0 and 9
- [x] \`./gradlew :scrimage-tests:test --tests \"*.PngWriterValidationTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)