### PR TITLE
Default TransformFilter edgeAction to CLAMP, not RGB_CLAMP

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransformFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransformFilter.java
@@ -57,8 +57,16 @@ public abstract class TransformFilter extends AbstractBufferedImageOp {
 
     /**
      * The action to take for pixels off the image edge.
+     *
+     * Defaults to CLAMP: hold the edge colour AND alpha for pixels
+     * that the inverse transform maps outside the source image.
+     * Previously this defaulted to RGB_CLAMP, which forced alpha to 0
+     * at the edges — meaning every TransformFilter subclass (TwirlFilter,
+     * SwimFilter, RippleFilter, KaleidoscopeFilter, PinchFilter, …)
+     * produced transparent corners on opaque inputs, leaving visible
+     * holes when the result was composited.
      */
-	protected int edgeAction = RGB_CLAMP;
+	protected int edgeAction = CLAMP;
 
     /**
      * The type of interpolation to use.

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/TransformFilterEdgeAlphaTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/TransformFilterEdgeAlphaTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: TransformFilter defaulted to RGB_CLAMP for off-edge
+ * pixels, which preserves RGB but zeros alpha. Every subclass
+ * (TwirlFilter, SwimFilter, RippleFilter, KaleidoscopeFilter, …) on
+ * an opaque input produced transparent corners — visible holes when
+ * the result was composited against any non-default background.
+ *
+ * The fix changes the default to CLAMP (preserve both RGB and
+ * alpha).
+ */
+class TransformFilterEdgeAlphaTest : FunSpec({
+
+   test("TwirlFilter on an opaque image preserves alpha at the corners") {
+      val opaqueRed = ImmutableImage.filled(100, 100, Color.RED)
+      val twirled = opaqueRed.filter(TwirlFilter(1.5f))
+
+      // Corner pixels must still be opaque — pre-fix, alpha at (0, 0)
+      // was 0 (RGB_CLAMP zero-alpha), so the corner had no colour
+      // contribution when composited.
+      val c00 = twirled.pixel(0, 0)
+      val c99 = twirled.pixel(99, 99)
+      c00.alpha() shouldBe 255
+      c99.alpha() shouldBe 255
+   }
+
+   test("RippleFilter on an opaque image preserves alpha at the corners") {
+      val opaqueRed = ImmutableImage.filled(100, 100, Color.RED)
+      val rippled = opaqueRed.filter(RippleFilter(RippleType.Sine))
+
+      rippled.pixel(0, 0).alpha() shouldBe 255
+      rippled.pixel(99, 99).alpha() shouldBe 255
+   }
+})


### PR DESCRIPTION
## Summary

\`TransformFilter\` defaulted \`edgeAction\` to \`RGB_CLAMP\`. For pixels whose inverse transform falls outside the source image, \`RGB_CLAMP\` clamps the RGB channels to the edge but **forces alpha to 0** (\`& 0x00ffffff\`).

Every \`TransformFilter\` subclass that didn't explicitly override the default — \`TwirlFilter\`, \`SwimFilter\`, \`RippleFilter\`, \`KaleidoscopeFilter\`, \`PinchFilter\`, \`PolarFilter\`, \`SphereFilter\` — produced **transparent corners** on opaque inputs, leaving visible holes when the result was composited against any non-default background.

## Fix

Default to \`CLAMP\` instead, which preserves both edge RGB and alpha. Callers who actually want \`RGB_CLAMP\` (the documented "prevents grey borders" trick) can opt in via \`op.setEdgeAction(...)\`.

## Test plan
- [x] New \`TransformFilterEdgeAlphaTest\` confirms TwirlFilter and RippleFilter preserve corner alpha
- [x] No filter golden-image tests broke (the affected ScalaTest fixtures are \`ignore\`'d)
- [x] \`./gradlew :scrimage-filters:test\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)