### PR TITLE
Promote to long in DimensionTools.dimensionsToFit comparisons

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
@@ -57,9 +57,14 @@ public class DimensionTools {
          maxHeight = target.getY();
       }
 
-      if (maxWidth * source.getY() < maxHeight * source.getX())
-         return new Dimension(maxWidth, (int) (source.getY() * maxWidth / source.getX()));
+      // Compare with `long` arithmetic. The earlier int * int could
+      // overflow before comparison for large source images (e.g. a
+      // 60000 × 50000 source against a 60000 maxWidth produces
+      // 60000 * 50000 = 3e9, overflowing int and flipping the sign,
+      // selecting the wrong scale branch).
+      if ((long) maxWidth * source.getY() < (long) maxHeight * source.getX())
+         return new Dimension(maxWidth, (int) ((long) source.getY() * maxWidth / source.getX()));
       else
-         return new Dimension((int) (source.getX() * maxHeight / source.getY()), maxHeight);
+         return new Dimension((int) ((long) source.getX() * maxHeight / source.getY()), maxHeight);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/DimensionToolsOverflowTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/DimensionToolsOverflowTest.kt
@@ -1,0 +1,43 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.Dimension
+import com.sksamuel.scrimage.DimensionTools
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: dimensionsToFit compared `maxWidth * source.getY()` with
+ * `maxHeight * source.getX()` using int multiplication. For very large
+ * sources (e.g. a 60000 × 50000 tile) the products overflow int —
+ * 60000 * 50000 = 3e9, well past Int.MAX_VALUE — and the sign flips,
+ * selecting the wrong scaling branch.
+ *
+ * Promote to long for the comparison and for the result quotient
+ * numerator.
+ */
+class DimensionToolsOverflowTest : FunSpec({
+
+   test("dimensionsToFit on a 60000x50000 source picks the correct branch") {
+      // Source 60000x50000, target 60000x60000.
+      // Correctly: scale by min(60000/60000, 60000/50000) = 1.0, fit
+      // result = (60000, 50000) since width is the constraint and
+      // height is already smaller.
+      // Pre-fix: `60000 * 50000` overflowed to negative, the < comparison
+      // flipped, and the wrong branch was taken.
+      val source = Dimension(60000, 50000)
+      val target = Dimension(60000, 60000)
+      val fit = DimensionTools.dimensionsToFit(target, source)
+      fit.x shouldBe 60000
+      fit.y shouldBe 50000
+   }
+
+   test("dimensionsToFit on a small image still works (regression check)") {
+      // Sanity: small sources continue to work.
+      val source = Dimension(400, 200)
+      val target = Dimension(100, 100)
+      val fit = DimensionTools.dimensionsToFit(target, source)
+      // 400x200 fits inside 100x100 by scaling to 100x50 (aspect 2:1).
+      fit.x shouldBe 100
+      fit.y shouldBe 50
+   }
+})


### PR DESCRIPTION
## Summary

\`DimensionTools.dimensionsToFit\` compared \`maxWidth * source.getY()\` with \`maxHeight * source.getX()\` using \`int\` multiplication. For large sources the products overflow \`int\` — a 60000 × 50000 source against a 60000 × 60000 target produces 3 × 10⁹, well past \`Int.MAX_VALUE\` — flipping the sign and selecting the wrong scaling branch.

## Fix

Promote both operands to \`long\` for the comparison and for the result-quotient numerator.

## Test plan
- [x] \`dimensionsToFit\` on a 60000x50000 source picks the correct branch
- [x] Small-image cases still produce the same output
- [x] \`./gradlew :scrimage-tests:test --tests \"*.DimensionToolsOverflowTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)