### PR TITLE
Make RandomPainter seedable and stop reseeding per tile

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/RandomPainter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/RandomPainter.java
@@ -9,8 +9,31 @@ import java.awt.image.WritableRaster;
 import java.util.Random;
 
 public class RandomPainter implements Painter {
+
+   private final Long seed;
+
+   public RandomPainter() {
+      this(null);
+   }
+
+   /**
+    * Construct a RandomPainter with a fixed seed. With a seed, every
+    * invocation of {@link #paint()} produces a deterministic pattern.
+    * Without a seed (the default), each invocation freshly seeds
+    * the RNG.
+    */
+   public RandomPainter(Long seed) {
+      this.seed = seed;
+   }
+
    @Override
    public Paint paint() {
+      // Allocate the RNG once per `paint()` (i.e. per draw) rather than
+      // once per device tile. Previously a fresh `new Random()` was
+      // built inside getRaster, called many times per fill — output was
+      // non-reproducible across runs and adjacent tiles could spawn in
+      // the same millisecond and produce correlated seams.
+      final Random rng = seed != null ? new Random(seed) : new Random();
       return new Paint() {
 
          @Override
@@ -45,14 +68,13 @@ public class RandomPainter implements Painter {
                   //  - it set alpha=0 on every pixel even though the Paint
                   //    advertises Transparency.OPAQUE.
                   WritableRaster raster = getColorModel().createCompatibleWritableRaster(w, h);
-                  Random r = new Random();
                   int[] pixel = new int[4];
                   pixel[3] = 255; // opaque alpha — matches getTransparency()
                   for (int dx = 0; dx < w; dx++) {
                      for (int dy = 0; dy < h; dy++) {
-                        pixel[0] = r.nextInt(256);
-                        pixel[1] = r.nextInt(256);
-                        pixel[2] = r.nextInt(256);
+                        pixel[0] = rng.nextInt(256);
+                        pixel[1] = rng.nextInt(256);
+                        pixel[2] = rng.nextInt(256);
                         raster.setPixel(dx, dy, pixel);
                      }
                   }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/RandomPainterSeedTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/canvas/RandomPainterSeedTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.scrimage.canvas
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.drawables.FilledRect
+import com.sksamuel.scrimage.canvas.painters.RandomPainter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression: RandomPainter allocated a `new Random()` inside
+ * `getRaster()` — called once per device tile of the draw. The RNG
+ * was reseeded with the current time *per tile*, so:
+ *
+ *  - Output was not reproducible across runs.
+ *  - Two adjacent tiles spawning in the same millisecond shared a
+ *    seed, producing correlated patterns (visible seams).
+ *
+ * The fix allocates the RNG once per `paint()` invocation (i.e. once
+ * per draw) and adds an optional seed for full determinism.
+ */
+class RandomPainterSeedTest : FunSpec({
+
+   fun drawn(painter: RandomPainter): ImmutableImage =
+      Canvas(ImmutableImage.create(40, 40)).draw(FilledRect(0, 0, 40, 40, GraphicsContext { it.setPaint(painter.paint()) })).image
+
+   test("two RandomPainters with the same seed produce identical images") {
+      val a = drawn(RandomPainter(42L))
+      val b = drawn(RandomPainter(42L))
+      a shouldBe b
+   }
+
+   test("two RandomPainters with different seeds produce different images") {
+      val a = drawn(RandomPainter(1L))
+      val b = drawn(RandomPainter(2L))
+      a shouldNotBe b
+   }
+
+   test("unseeded RandomPainter still produces (probabilistically) different output across calls") {
+      val a = drawn(RandomPainter())
+      val b = drawn(RandomPainter())
+      // 40*40 = 1600 pixels of independent random colour — the chance
+      // of two unseeded draws colliding is negligible.
+      a shouldNotBe b
+   }
+})


### PR DESCRIPTION
## Summary

\`RandomPainter\` built a fresh \`new Random()\` inside \`getRaster()\`. The AWT renderer calls \`getRaster\` once per device tile of a draw, so:

- Output was non-reproducible across runs.
- Adjacent tiles spawning in the same millisecond shared a seed and produced correlated/seamed patterns.

## Fix

- Allocate the RNG once per \`paint()\` (i.e. once per draw) — all tiles in a single draw share one RNG.
- Add a \`RandomPainter(Long seed)\` constructor for full determinism; the no-arg constructor preserves the previous non-deterministic behaviour at the per-draw granularity.

## Test plan
- [x] Two seeded RandomPainters with same seed produce identical images
- [x] Two seeded RandomPainters with different seeds produce different images
- [x] Unseeded RandomPainters still differ across runs
- [x] \`./gradlew :scrimage-tests:test --tests \"*.RandomPainterSeedTest\"\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)