### PR TITLE
ci: add JMH benchmark workflow

### DIFF
--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -1,0 +1,80 @@
+name: jmh
+
+run-name: jmh @ ${{ inputs.commit || github.sha }}
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Commit SHA, branch, or tag to benchmark (defaults to HEAD of the selected branch)'
+        required: false
+        default: ''
+      include:
+        description: 'JMH benchmark regex filter (e.g. ResizeBenchmark)'
+        required: false
+        default: ''
+
+jobs:
+  jmh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+
+      - name: Run JMH benchmarks
+        run: |
+          if [ -n "${{ inputs.include }}" ]; then
+            ./gradlew :scrimage-benchmarks:jmh -Pjmh.includes='${{ inputs.include }}'
+          else
+            ./gradlew :scrimage-benchmarks:jmh
+          fi
+
+      - name: Render results to step summary
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          RESULTS=scrimage-benchmarks/build/results/jmh/results.json
+          {
+            echo "## JMH Benchmark Results"
+            echo
+            echo "Commit: \`${{ inputs.commit || github.sha }}\`"
+            echo
+            if [ ! -s "$RESULTS" ]; then
+              echo "_No JMH results produced at \`$RESULTS\`._"
+              exit 0
+            fi
+            echo "| Benchmark | Mode | Score | Error | Unit |"
+            echo "|---|---|---:|---:|---|"
+            jq -r '
+              .[]
+              | [
+                  (.benchmark | sub("^com\\.sksamuel\\.scrimage\\."; "")),
+                  .mode,
+                  (.primaryMetric.score | . * 1000 | round / 1000 | tostring),
+                  ("± " + (.primaryMetric.scoreError | . * 1000 | round / 1000 | tostring)),
+                  .primaryMetric.scoreUnit
+                ]
+              | "| " + join(" | ") + " |"
+            ' "$RESULTS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw JMH results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmh-results
+          path: scrimage-benchmarks/build/results/jmh/
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/scrimage-benchmarks/build.gradle
+++ b/scrimage-benchmarks/build.gradle
@@ -21,6 +21,12 @@ jmh {
    profilers = ['gc']
    zip64 = true
    duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+   resultFormat = 'JSON'
+   resultsFile = layout.buildDirectory.file('results/jmh/results.json')
+   def jmhIncludes = project.findProperty('jmh.includes')
+   if (jmhIncludes) {
+      includes = [jmhIncludes.toString()]
+   }
 }
 
 processJmhResources {


### PR DESCRIPTION
## Summary
Ports the same JMH workflow used in [centurion](https://github.com/sksamuel/centurion/blob/master/.github/workflows/jmh.yml):

- Triggers on push to `master` (paths-ignore: docs, *.md, mkdocs.yml) and on `workflow_dispatch` with optional inputs:
  - `commit` — SHA / branch / tag to benchmark; defaults to HEAD of the selected branch.
  - `include` — JMH regex filter, e.g. `ResizeBenchmark`.
- `run-name` shows `jmh @ <resolved ref>` so each run's title in the Actions list makes clear what was benchmarked.
- Renders a markdown table of primary metrics (benchmark / mode / score / error / unit) to the GitHub step summary.
- Uploads the raw JMH output directory as a build artifact for download.

Also updates `scrimage-benchmarks/build.gradle` to emit results as JSON (`resultFormat = 'JSON'`, `resultsFile = …/results.json`) so the inline `jq` summary renderer has structured input. Adds an opt-in `jmh.includes` Gradle property so the workflow's `include` filter flows into the JMH plugin.

The existing `.github/workflows/benchmarks.yml` is left in place — happy to delete it in a follow-up if you'd prefer one workflow file rather than two.

## Test plan
- [ ] Merge, then trigger `workflow_dispatch` with no inputs — should run all JMH benchmarks against HEAD of master and produce a step summary + artifact.
- [ ] Trigger with `commit` set to an older SHA — confirm `run-name` and checkout pin to that commit.
- [ ] Trigger with `include=ResizeBenchmark` (or similar) — confirm only matching benchmarks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)