### PR TITLE
Preserve all options in WebpWriter builder methods

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpWriter.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/WebpWriter.java
@@ -65,7 +65,7 @@ public class WebpWriter implements ImageWriter {
     * @return a new {@code WebpWriter} instance with lossless compression enabled.
     */
    public WebpWriter withLossless() {
-      return new WebpWriter(z, q, m, true);
+      return new WebpWriter(z, q, m, true, noAlpha, multiThread);
    }
 
    /**
@@ -75,7 +75,7 @@ public class WebpWriter implements ImageWriter {
     * @return a new {@code WebpWriter} instance with alpha channel support disabled.
     */
    public WebpWriter withoutAlpha() {
-      return new WebpWriter(z, q, m, lossless, true);
+      return new WebpWriter(z, q, m, lossless, true, multiThread);
    }
 
    /**
@@ -97,7 +97,7 @@ public class WebpWriter implements ImageWriter {
    public WebpWriter withQ(int q) {
       if (q < 0) throw new IllegalArgumentException("q must be between 0 and 100");
       if (q > 100) throw new IllegalArgumentException("q must be between 0 and 100");
-      return new WebpWriter(z, q, m, lossless, noAlpha);
+      return new WebpWriter(z, q, m, lossless, noAlpha, multiThread);
    }
 
    /**
@@ -110,7 +110,7 @@ public class WebpWriter implements ImageWriter {
    public WebpWriter withM(int m) {
       if (m < 0) throw new IllegalArgumentException("m must be between 0 and 6");
       if (m > 6) throw new IllegalArgumentException("m must be between 0 and 6");
-      return new WebpWriter(z, q, m, lossless, noAlpha);
+      return new WebpWriter(z, q, m, lossless, noAlpha, multiThread);
    }
 
    /**
@@ -122,7 +122,7 @@ public class WebpWriter implements ImageWriter {
    public WebpWriter withZ(int z) {
       if (z < 0) throw new IllegalArgumentException("z must be between 0 and 9");
       if (z > 9) throw new IllegalArgumentException("z must be between 0 and 9");
-      return new WebpWriter(z, q, m, lossless, noAlpha);
+      return new WebpWriter(z, q, m, lossless, noAlpha, multiThread);
    }
 
    @Override


### PR DESCRIPTION
## Problem

`WebpWriter`'s chainable `with*` methods rebuilt the writer through constructors that silently reset fields they did not take:

- `withLossless()` used the 4-arg constructor → dropped both `noAlpha` **and** `multiThread`
- `withoutAlpha()`, `withQ()`, `withM()`, `withZ()` used the 5-arg constructor → dropped `multiThread`

So a chain like `WebpWriter.DEFAULT.withMultiThread().withQ(80)` produced a writer with `multiThread=false`, and `writer.withLossless()` discarded any previously-set `noAlpha`/`multiThread`. The encode then ran without the requested `-mt` / `-noalpha` flags, with no error.

`Gif2WebpWriter` in the same module does this correctly because it has no extra fields — confirming this is an oversight specific to `WebpWriter`.

## Fix

Route every builder through the full 6-arg constructor so each copy-on-write step preserves the other options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)