### PR TITLE
Fix contributor-buffer overflow in ResampleOp sub-sampling

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
+++ b/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
@@ -129,7 +129,12 @@ public class ResampleOp extends AdvancedResizeOp {
 
     if (scale < 1.0f) {
       final float width = fwidth / scale;
-      numContributors = (int) (width * 2.0f + 2); // Heinz: added 1 to be save with the ceilling
+      // The sample window for a destination pixel is [floor(center - width), ceil(center + width)],
+      // whose size is ceil(center+width) - floor(center-width) + 1 and can reach ceil(2*width) + 2
+      // contributors. The previous "(int)(width*2 + 2)" pad truncated and was one short for certain
+      // scale factors (e.g. resampling a 121px axis down to 3px), letting the final contributor write
+      // into the next destination row/column's segment and corrupting both. Size from the true window.
+      numContributors = (int) Math.ceil(width * 2.0f) + 2;
       arrWeight = new float[dstSize * numContributors];
       arrPixel = new int[dstSize * numContributors];
 
@@ -178,7 +183,10 @@ public class ResampleOp extends AdvancedResizeOp {
     // super-sampling
     // Scales from smaller to bigger height
     {
-      numContributors = (int) (fwidth * 2.0f + 1);
+      // See the downscale branch: the window [floor(center-fwidth), ceil(center+fwidth)] can hold up
+      // to ceil(2*fwidth) + 2 contributors, so size the segment to that to avoid spilling into the
+      // next destination row/column.
+      numContributors = (int) Math.ceil(fwidth * 2.0f) + 2;
       arrWeight = new float[dstSize * numContributors];
       arrPixel = new int[dstSize * numContributors];
       //


### PR DESCRIPTION
## Problem

`ResampleOp.createSubSampling` allocates `numContributors = (int)(width * 2.0f + 2)` slots per destination row/column to hold the source pixels that contribute to each output pixel.

But the actual sample window for a destination pixel is `[floor(center - width), ceil(center + width)]`, whose size is `ceil(center+width) - floor(center-width) + 1` and can reach `ceil(2*width) + 2`. The truncating `+ 2` pad was **one short** for certain scale factors.

When that happens, the final contributor is written at `arrPixel[subindex + numContributors]`, i.e. it spills into the **next destination row/column's segment** and pollutes that row's weight normalisation — corrupting both. (For the last row it can also write past the end of the array.)

## Fix

Size the segment from the true maximum window: `numContributors = (int) Math.ceil(width * 2.0f) + 2` (and the analogous `fwidth` form in the super-sampling branch).

## Verification

- Resampling a **121px axis down to 3px with the Triangle filter** produced corrupted output on the old code; with the window-derived size the output is correct.
- For **all non-overflowing** size/filter combinations the resampling output is **byte-identical** to before — the consumers iterate only up to `arrN[i]`, so the extra slots carry zero weight and are never read. Confirmed by hashing outputs across a matrix of sizes (200→100, 100→300, 640→160, 300→90, 121→61, …) and all four shipped filters against the `master` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)