### PR TITLE
Fix inverted VBox bounds for single-value channels in MMCQ

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
+++ b/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
@@ -254,21 +254,29 @@ public class MMCQ {
          gval = pixel[1] >> RSHIFT;
          bval = pixel[2] >> RSHIFT;
 
+         // Use independent if's (not else-if): the first pixel always takes the
+         // `< min` branch and would never update max, so a channel with a single
+         // distinct value ended up with min > max (e.g. min=10, max=0). That made
+         // VBox.volume() negative and VBox.count() iterate an empty range, silently
+         // dropping that colour dimension from the quantization.
          if (rval < rmin) {
             rmin = rval;
-         } else if (rval > rmax) {
+         }
+         if (rval > rmax) {
             rmax = rval;
          }
 
          if (gval < gmin) {
             gmin = gval;
-         } else if (gval > gmax) {
+         }
+         if (gval > gmax) {
             gmax = gval;
          }
 
          if (bval < bmin) {
             bmin = bval;
-         } else if (bval > bmax) {
+         }
+         if (bval > bmax) {
             bmax = bval;
          }
       }


### PR DESCRIPTION
## Problem

`MMCQ.vboxFromPixels` scans each channel with:

```java
if (rval < rmin) { rmin = rval; }
else if (rval > rmax) { rmax = rval; }
```

`rmin` starts at `1000000` and `rmax` at `0`, so the **first pixel always takes the `< rmin` branch** and never updates `rmax`. If a channel has only one distinct quantized value `v` (an image that is monochrome in that channel, e.g. a pure grey/red gradient at SIGBITS resolution), the channel ends up with `rmin = v`, `rmax = 0` — i.e. `min > max`.

`VBox.volume()` then computes a **negative** volume and `VBox.count()` iterates an empty range (`for i = r1..r2` with `r1 > r2`), so that colour dimension is silently dropped from the median-cut quantization, skewing the resulting palette.

## Fix

Use independent `if`s so both bounds update from every pixel. (This matches the intent; the `else if` is a long-standing defect inherited from upstream ColorThief.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)