### PR TITLE
Avoid redundant full-image copy in padWith and translate

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1198,7 +1198,12 @@ public class ImmutableImage extends MutableImage {
    public ImmutableImage padWith(int left, int top, int right, int bottom, Color color) {
       int w = width + left + right;
       int h = height + top + bottom;
-      return filled(w, h, color).overlay(this, left, top).associateMetadata(metadata);
+      // filled() returns a fresh, unshared image, so draw straight into it with
+      // overlayInPlace. Going through overlay() would clone that just-created
+      // buffer first (a full-image copy) for no reason.
+      ImmutableImage result = filled(w, h, color);
+      result.overlayInPlace(awt(), left, top);
+      return result.associateMetadata(metadata);
    }
 
    /**
@@ -1570,7 +1575,11 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image with this image translated.
     */
    public ImmutableImage translate(int x, int y, Color bg) {
-      return fill(bg).overlay(this, x, y).associateMetadata(metadata);
+      // fill() returns a fresh, unshared image, so draw straight into it with
+      // overlayInPlace rather than overlay(), which would clone it first.
+      ImmutableImage result = fill(bg);
+      result.overlayInPlace(awt(), x, y);
+      return result.associateMetadata(metadata);
    }
 
    /**


### PR DESCRIPTION
## Problem

`padWith` and `translate` create a fresh background image and overlay this image onto it:

```java
return filled(w, h, color).overlay(this, left, top).associateMetadata(metadata);  // padWith
return fill(bg).overlay(this, x, y).associateMetadata(metadata);                  // translate
```

But `overlay(AwtImage, x, y)` is implemented as `copy()` followed by `overlayInPlace(...)`. The `filled()`/`fill()` result is a brand-new, unshared image, so the `copy()` clones that just-created buffer in full for nothing — doubling the allocation/copy cost of every `pad*`, `padTo`, `padWith` and `translate` call.

## Fix

Draw straight into the freshly created background image with `overlayInPlace`.

## Verification

Output is **byte-identical** to `master` — confirmed by hashing the result of `padWith` (with colour), transparent padding, and `translate` (with and without a background colour) against the `master` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)