### PR TITLE
Use bulk pixel access in ErrorSpotterFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
@@ -51,11 +51,16 @@ public class ErrorSpotterFilter implements Filter {
                     + "src=" + src.width + "x" + src.height
                     + ", base=" + base.width + "x" + base.height);
         }
-        for (int x = 0; x < src.width; x++) {
-            for (int y = 0; y < src.height; y++) {
-                int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)), RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
-                src.awt().setRGB(x, y, delta);
-            }
+        // Pull both images once with bulk getRGB rather than calling the
+        // single-pixel getRGB/setRGB inside a nested loop (an order of magnitude
+        // slower, and the original loop was column-major over row-major storage).
+        int w = src.width;
+        int h = src.height;
+        int[] basePixels = base.awt().getRGB(0, 0, w, h, null, 0, w);
+        int[] srcPixels = src.awt().getRGB(0, 0, w, h, null, 0, w);
+        for (int i = 0; i < srcPixels.length; i++) {
+            srcPixels[i] = error(RGBColor.fromARGBInt(basePixels[i]), RGBColor.fromARGBInt(srcPixels[i]));
         }
+        src.awt().setRGB(0, 0, w, h, srcPixels, 0, w);
     }
 }


### PR DESCRIPTION
## Problem

`ErrorSpotterFilter` called single-pixel `getRGB(x, y)` **twice** and `setRGB(x, y, ...)` **once** for every pixel, inside a column-major nested loop over row-major pixel storage:

```java
for (int x = 0; x < src.width; x++) {
    for (int y = 0; y < src.height; y++) {
        int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)), RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
        src.awt().setRGB(x, y, delta);
    }
}
```

Single-pixel `getRGB`/`setRGB` go through the colour model on each call and are roughly an order of magnitude slower than a bulk `getRGB(0,0,w,h,...)` over an `int[]` — the form every other filter in this package already uses. The loop is also cache-hostile.

## Fix

Pull both images once into `int[]` arrays, compute the per-pixel error over the arrays, and write back with a single bulk `setRGB`.

## Verification

Output is **byte-identical** to `master` (the per-pixel computation is unchanged and order-independent) — confirmed by hashing the filtered result against the `master` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)