### PR TITLE
Clamp channels in OpacityFilter to prevent bit-bleed

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
@@ -35,11 +35,21 @@ public class OpacityFilter implements Filter {
          int r = (p >> 16) & 0xFF;
          int g = (p >> 8) & 0xFF;
          int b = p & 0xFF;
-         int nr = (int) (r + (255 - r) * amount);
-         int ng = (int) (g + (255 - g) * amount);
-         int nb = (int) (b + (255 - b) * amount);
+         // Clamp to [0, 255]. For amount outside [0, 1] a channel could exceed
+         // 255 (or go negative); packed unmasked with `nr << 16` etc. it would
+         // overflow into the neighbouring channel's bits and corrupt the colour,
+         // so saturate instead of letting the value wrap.
+         int nr = clamp((int) (r + (255 - r) * amount));
+         int ng = clamp((int) (g + (255 - g) * amount));
+         int nb = clamp((int) (b + (255 - b) * amount));
          argb[i] = (a << 24) | (nr << 16) | (ng << 8) | nb;
       }
       image.awt().setRGB(0, 0, w, h, argb, 0, w);
+   }
+
+   private static int clamp(int value) {
+      if (value < 0) return 0;
+      if (value > 255) return 255;
+      return value;
    }
 }


### PR DESCRIPTION
## Problem

`OpacityFilter` computes each channel as `r + (255 - r) * amount` and packs the result with `nr << 16` etc. **without masking or clamping**:

```java
int nr = (int) (r + (255 - r) * amount);
int ng = (int) (g + (255 - g) * amount);
int nb = (int) (b + (255 - b) * amount);
argb[i] = (a << 24) | (nr << 16) | (ng << 8) | nb;
```

For `amount` inside `[0, 1]` the values stay in range, but `amount > 1` (or `< 0`) pushes a channel above 255 (or negative). Shifted unmasked, an out-of-range `nb` overflows into the green/red/alpha bits (and a negative value sets high bits), producing an arbitrary corrupted colour rather than a saturated one. `amount` is never validated, so this is reachable from the public constructor.

## Fix

Clamp each channel to `[0, 255]`. This is a no-op for the normal `[0, 1]` range and saturates gracefully otherwise — matching how `PixelTools.scale` and other filters in this package were already hardened against the same class of channel-overflow corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)