### PR TITLE
Close the pngj reader on the error path in PngReader

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
@@ -24,6 +24,12 @@ public class PngReader implements ImageReader {
          return null;
 
       ar.com.hjg.pngj.PngReader pngr = new ar.com.hjg.pngj.PngReader(new ByteArrayInputStream(bytes));
+      // close() in a finally: any exception during the read loop (truncated or
+      // malformed PNG, palette index out of range, OOM on a huge declared size)
+      // would otherwise skip end()/close() and leak the reader and its zlib
+      // Inflater. ImageReaders swallows the exception and tries the next reader,
+      // so repeated corrupt-PNG loads would accumulate undeflated Inflaters.
+      try {
 
       int channels = pngr.imgInfo.channels;
       int bitDepth = pngr.imgInfo.bitDepth;
@@ -88,6 +94,10 @@ public class PngReader implements ImageReader {
          image = image.subimage(rectangle);
       }
       return image;
+
+      } finally {
+         pngr.close();
+      }
    }
 
    private boolean isPng(byte[] bytes) {


### PR DESCRIPTION
## Problem

`PngReader.read` creates an `ar.com.hjg.pngj.PngReader` and releases it only via `pngr.end()` at the very end, with **no `try/finally`**. Any exception during the read loop — a truncated or malformed PNG, a palette index out of range, an `OutOfMemoryError` on a huge declared `width*height` — skips `end()`/`close()`, leaking the reader and its zlib `Inflater`.

`ImageReaders.read` catches the exception and falls through to the next reader, so this happens **silently** on every corrupt-PNG load, and repeated loads accumulate undeflated `Inflater` instances until GC eventually finalizes them.

## Fix

Wrap the read body in `try { ... } finally { pngr.close(); }`. `close()` is idempotent after `end()`.

## Verification

- A valid PNG still round-trips **byte-identically** (`getRGB` array equal before/after).
- A truncated PNG still throws (`PngjInputException`) — now with the reader closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)