### PR TITLE
Dispose the JPEG ImageWriter on the error path in JpegWriter

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/JpegWriter.java
@@ -50,6 +50,11 @@ public class JpegWriter implements ImageWriter {
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
 
       javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName("jpeg").next();
+      // dispose() in a finally that spans every use of the writer. Acquiring it
+      // here but only disposing inside the write try-block leaked the native
+      // JPEG writer if anything in between threw — e.g. allocating the no-alpha
+      // BufferedImage for a very large image, or setCompressionQuality.
+      try {
       ImageWriteParam params = writer.getDefaultWriteParam();
 
       // compression is a quality knob in [0, 100]. The earlier code
@@ -96,6 +101,8 @@ public class JpegWriter implements ImageWriter {
       try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {
          writer.setOutput(output);
          writer.write(null, new IIOImage(noAlpha, null, null), params);
+      }
+
       } finally {
          writer.dispose();
       }


### PR DESCRIPTION
## Problem

In `JpegWriter.write` the `javax.imageio.ImageWriter` is acquired at the top, but `writer.dispose()` lives only in the `finally` of the `try`-block that performs the actual write (near the end of the method). Everything in between runs **outside** any cleanup:

- `getDefaultWriteParam`, `setCompressionMode`/`setCompressionQuality`
- allocating the no-alpha `BufferedImage` — can throw `OutOfMemoryError`/`IllegalArgumentException` for very large or zero-size images
- `createGraphics` / `drawImage`

If any of these throws, the native JPEG writer is never freed. `javax.imageio.ImageWriter` requires `dispose()` precisely to release native resources.

## Fix

Wrap the writer's use in a `try/finally` that spans all of it, with `writer.dispose()` in the `finally`. The output stream is still closed by its own try-with-resources.

## Verification

JPEG output is still produced correctly for the `Default`, explicit-quality (`compression(60)`) and `CompressionFromMetaData` modes (valid JFIF magic, expected sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)