### PR TITLE
Weight colour by alpha in LinearSubpixelInterpolator

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
@@ -64,6 +64,11 @@ public class LinearSubpixelInterpolator implements SubpixelInterpolator {
         }
 
         // Accumulate the weighted channel sums over the up-to-four neighbours.
+        // Colour is weighted by alpha (premultiplied) so that the colour of
+        // transparent neighbours does not bleed into the result: a fully
+        // transparent pixel may carry arbitrary RGB, and blending it straight
+        // produces colour fringing along transparency edges. Alpha itself is
+        // interpolated normally.
         double sumA = 0, sumR = 0, sumG = 0, sumB = 0;
         for (int xi = 0; xi < xCount; xi++) {
             int xc = (xi == 0) ? x0 : x1;
@@ -74,18 +79,25 @@ public class LinearSubpixelInterpolator implements SubpixelInterpolator {
                 double weight = xw * yw;
                 if (weight == 0) continue;
                 int p = (pixels != null) ? pixels[yc * width + xc] : awt.awt().getRGB(xc, yc);
-                sumA += weight * ((p >>> 24) & 0xFF);
-                sumR += weight * ((p >> 16) & 0xFF);
-                sumG += weight * ((p >> 8) & 0xFF);
-                sumB += weight * (p & 0xFF);
+                double a = (p >>> 24) & 0xFF;
+                double wa = weight * a;
+                sumA += wa;
+                sumR += wa * ((p >> 16) & 0xFF);
+                sumG += wa * ((p >> 8) & 0xFF);
+                sumB += wa * (p & 0xFF);
             }
         }
 
+        // Un-premultiply: divide the alpha-weighted colour sums by the summed
+        // alpha-weight. When the combined alpha is zero the result is fully clear.
+        int alpha = (int) Math.round(sumA);
+        if (sumA == 0)
+            return PixelTools.argb(0, 0, 0, 0);
         return PixelTools.argb(
-                (int) Math.round(sumA),
-                (int) Math.round(sumR),
-                (int) Math.round(sumG),
-                (int) Math.round(sumB)
+                alpha,
+                (int) Math.round(sumR / sumA),
+                (int) Math.round(sumG / sumA),
+                (int) Math.round(sumB / sumA)
         );
     }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/subpixel/LinearSubpixelInterpolatorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/subpixel/LinearSubpixelInterpolatorTest.kt
@@ -91,4 +91,31 @@ class LinearSubpixelInterpolatorTest : FunSpec({
       sub.pixel(0, 0).argb shouldBe image.subpixel(2.0, 3.0)
       sub.pixel(2, 2).argb shouldBe image.subpixel(4.0, 5.0)
    }
+
+   // Colour is weighted by alpha (premultiplied) so a fully transparent
+   // neighbour, whose RGB is arbitrary, does not bleed into the result.
+   test("interpolation weights colour by alpha so transparent neighbours don't bleed") {
+      // 2x1: opaque red on the left, fully transparent green on the right.
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255), // opaque red
+         Pixel(1, 0, 0, 255, 0, 0)    // fully transparent green
+      )
+      val img = ImmutableImage.create(2, 1, pixels)
+      // x = 1.0 sits midway between the two columns → equal bilinear weights.
+      val argb = img.subpixel(1.0, 0.0)
+      ((argb ushr 16) and 0xFF) shouldBe 255 // red preserved
+      ((argb ushr 8) and 0xFF) shouldBe 0    // no green bleed from the transparent neighbour
+      (argb and 0xFF) shouldBe 0
+      ((argb ushr 24) and 0xFF) shouldBe 128 // alpha is the average of 255 and 0
+   }
+
+   // When both neighbours are fully transparent the result is fully clear.
+   test("interpolation of fully transparent neighbours is transparent") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 0),
+         Pixel(1, 0, 0, 255, 0, 0)
+      )
+      val img = ImmutableImage.create(2, 1, pixels)
+      ((img.subpixel(1.0, 0.0) ushr 24) and 0xFF) shouldBe 0
+   }
 })


### PR DESCRIPTION
## Problem

The bilinear subpixel sampler accumulated R/G/B with the bilinear weights but **without weighting by alpha**. A transparent neighbour (which may carry arbitrary RGB) bled its colour into the result — colour fringing along transparency edges.

## Fix

Accumulate colour **premultiplied by alpha** and divide by the summed alpha-weight at the end (un-premultiply). Alpha is interpolated as before. When the combined alpha is zero the result is fully clear.

## Verification

- **Opaque sampling**: byte-identical subpixel hash over a grid of fractional coordinates vs `master`.
- **Transparency**: a white-opaque pixel blended with a transparent-black neighbour now yields `a=191, rgb=255` (white, reduced coverage) instead of `master`'s `a=191, rgb=191` (grey — bled toward black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)