### PR TITLE
Release writer and IIO stream on setup failure in StreamingGifWriter.prepareStream

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -107,25 +107,49 @@ public class StreamingGifWriter extends AbstractGifWriter {
    public GifStream prepareStream(OutputStream output, int imageType) throws IOException {
 
       ImageWriter writer = ImageIO.getImageWritersBySuffix("gif").next();
-      ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();
+      // Until the GifStream below is constructed and returned, nothing else owns
+      // the writer or the IIO stream. If any setup step throws (setFromTree can
+      // raise IIOInvalidTreeException, prepareWriteSequence can raise IOException),
+      // GifStream.close() is never reachable, so dispose/close them here.
+      MemoryCacheImageOutputStream ios = null;
+      try {
+         ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();
 
-      ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromBufferedImageType(imageType);
-      IIOMetadata imageMetaData = writer.getDefaultImageMetadata(imageTypeSpecifier, imageWriteParam);
+         ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromBufferedImageType(imageType);
+         IIOMetadata imageMetaData = writer.getDefaultImageMetadata(imageTypeSpecifier, imageWriteParam);
 
-      String metaFormatName = imageMetaData.getNativeMetadataFormatName();
+         String metaFormatName = imageMetaData.getNativeMetadataFormatName();
 
-      IIOMetadataNode root = (IIOMetadataNode) imageMetaData.getAsTree(metaFormatName);
-      populateGraphicsControlNode(root, frameDelay);
-      populateCommentsNode(root);
-      if (infiniteLoop)
-         populateApplicationExtensions(root, infiniteLoop);
+         IIOMetadataNode root = (IIOMetadataNode) imageMetaData.getAsTree(metaFormatName);
+         populateGraphicsControlNode(root, frameDelay);
+         populateCommentsNode(root);
+         if (infiniteLoop)
+            populateApplicationExtensions(root, infiniteLoop);
 
-      imageMetaData.setFromTree(metaFormatName, root);
+         imageMetaData.setFromTree(metaFormatName, root);
 
-      MemoryCacheImageOutputStream ios = new MemoryCacheImageOutputStream(output);
+         ios = new MemoryCacheImageOutputStream(output);
 
-      writer.setOutput(ios);
-      writer.prepareWriteSequence(null);
+         writer.setOutput(ios);
+         writer.prepareWriteSequence(null);
+
+         return buildStream(writer, ios, imageMetaData, imageWriteParam, metaFormatName, output);
+      } catch (IOException | RuntimeException e) {
+         try {
+            writer.dispose();
+         } finally {
+            if (ios != null) ios.close();
+         }
+         throw e;
+      }
+   }
+
+   private GifStream buildStream(ImageWriter writer,
+                                 MemoryCacheImageOutputStream ios,
+                                 IIOMetadata imageMetaData,
+                                 ImageWriteParam imageWriteParam,
+                                 String metaFormatName,
+                                 OutputStream output) {
 
       return new GifStream() {
 


### PR DESCRIPTION
## Problem

`prepareStream(OutputStream, int)` acquires the GIF `ImageWriter` and builds a `MemoryCacheImageOutputStream`, but the only cleanup of either lives inside the returned `GifStream.close()`. If any setup step throws **before** the `GifStream` is constructed and returned — `setFromTree` (`IIOInvalidTreeException`), `prepareWriteSequence` (`IOException`), or the metadata-tree manipulation — `close()` is never reachable, leaking the native writer and the IIO stream. The `prepareStream(File)` overload guards its own `FileOutputStream` but cannot protect these.

## Fix

Wrap the setup in `try/catch` that disposes the writer and closes the IIO stream on failure, and move the anonymous `GifStream` into a `buildStream` helper so the happy path is unchanged.

## Verification

Normal streaming GIF writing (compressed and uncompressed) still produces identical output after the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)