### PR TITLE
Validate RGBColor components at runtime instead of via assert

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -23,15 +23,26 @@ public class RGBColor implements Color {
 
    public RGBColor(int red, int green, int blue, int alpha) {
 
-      assert (0 <= red && red <= 255);
-      assert (0 <= green && green <= 255);
-      assert (0 <= blue && blue <= 255);
-      assert (0 <= alpha && alpha <= 255);
+      // Validate at runtime rather than via assert (disabled by default in
+      // production JVMs). An out-of-range component would otherwise be stored
+      // unchecked and later silently wrapped by `& 0xFF` in toARGBInt() — e.g.
+      // red = 256 becomes 0 and red = -1 becomes 255 — producing a wrong colour
+      // instead of failing fast.
+      requireInRange("red", red);
+      requireInRange("green", green);
+      requireInRange("blue", blue);
+      requireInRange("alpha", alpha);
 
       this.red = red;
       this.green = green;
       this.blue = blue;
       this.alpha = alpha;
+   }
+
+   private static void requireInRange(String component, int value) {
+      if (value < 0 || value > 255)
+         throw new IllegalArgumentException(
+            "RGBColor " + component + " component must be in [0, 255] but was " + value);
    }
 
    public static RGBColor fromARGBInt(int argb) {


### PR DESCRIPTION
## Problem

`RGBColor`'s constructor checked `0 <= component <= 255` with `assert`, which is disabled by default in production JVMs. An out-of-range component was therefore stored unchecked and later silently wrapped by `& 0xFF` in `toARGBInt()` — `red = 256` becomes `0`, `red = -1` becomes `255` — producing a wrong colour rather than failing fast.

## Fix

Throw `IllegalArgumentException` for out-of-range components.

## Scope / safety

This PR covers only `RGBColor` (int channels, where the `& 0xFF` wrap actually corrupts the colour). The float-based `HSLColor`/`HSVColor`/`CMYKColor` constructors are left on `assert` deliberately: their values are produced by floating-point conversions that can land marginally outside the range, where a hard throw would be fragile.

All internal `RGBColor` constructions stay in range — masked ARGB ints, convex averages (`Color.average`), and `[0,1]`-domain `* 255` rounding (HSL/HSV/CMYK → RGB). Verified by running 2,000,000 random RGB/HSL/HSV/CMYK round-trips and averages with no false positives; out-of-range values now throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)