### PR TITLE
Preserve image type in subimage instead of forcing ARGB

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1505,7 +1505,13 @@ public class ImmutableImage extends MutableImage {
       // to materialise a Pixel[w*h] just so wrapPixels → create(Pixel[])
       // could re-extract argb from each Pixel.
       int[] argb = awt().getRGB(x, y, w, h, null, 0, w);
-      ImmutableImage result = ImmutableImage.create(w, h, DEFAULT_DATA_TYPE);
+      // Preserve the source image's type so cropping (and trim/autocrop/takeX,
+      // which delegate here) doesn't silently promote e.g. a TYPE_INT_RGB image
+      // to TYPE_INT_ARGB. TYPE_CUSTOM (0) can't be fed to the BufferedImage type
+      // constructor, so fall back to the default ARGB type for it.
+      int type = awt().getType();
+      if (type == BufferedImage.TYPE_CUSTOM) type = DEFAULT_DATA_TYPE;
+      ImmutableImage result = ImmutableImage.create(w, h, type);
       result.awt().setRGB(0, 0, w, h, argb, 0, w);
       return result.associateMetadata(metadata);
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubimageTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/SubimageTest.kt
@@ -5,8 +5,13 @@ import com.sksamuel.scrimage.metadata.ImageMetadata
 import com.sksamuel.scrimage.pixels.Pixel
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.awt.Color
 import java.awt.Rectangle
+import java.awt.Transparency
+import java.awt.color.ColorSpace
 import java.awt.image.BufferedImage
+import java.awt.image.ComponentColorModel
+import java.awt.image.DataBuffer
 
 /**
  * Pin-down tests for ImmutableImage.subimage after the int[]-direct
@@ -70,5 +75,62 @@ class SubimageTest : FunSpec({
       val sub = image.subimage(0, 0, 1, 1)
       // Empty metadata is the same singleton; just check it's not null
       sub.metadata shouldBe ImageMetadata.empty
+   }
+
+   test("subimage preserves the source image type and pixel values") {
+      // The crop must come back as the same AWT type as the source rather than
+      // being silently promoted to TYPE_INT_ARGB.
+      for (type in listOf(
+         BufferedImage.TYPE_INT_ARGB,
+         BufferedImage.TYPE_INT_RGB,
+         BufferedImage.TYPE_3BYTE_BGR
+      )) {
+         val buffered = BufferedImage(4, 4, type)
+         for (y in 0 until 4)
+            for (x in 0 until 4)
+               buffered.setRGB(x, y, Color(x * 16, y * 16, 32).rgb)
+         val image = ImmutableImage.wrapAwt(buffered)
+         image.type shouldBe type
+
+         val sub = image.subimage(1, 1, 2, 2)
+         sub.type shouldBe type
+         // sub (0,0) is source (1,1); RGB values round-trip losslessly for all these types
+         sub.pixel(0, 0).red() shouldBe 16
+         sub.pixel(0, 0).green() shouldBe 16
+         sub.pixel(0, 0).blue() shouldBe 32
+         // sub (1,1) is source (2,2)
+         sub.pixel(1, 1).red() shouldBe 32
+         sub.pixel(1, 1).green() shouldBe 32
+      }
+   }
+
+   test("ops that delegate to subimage (e.g. takeLeft) also preserve the type") {
+      val buffered = BufferedImage(4, 4, BufferedImage.TYPE_INT_RGB)
+      for (y in 0 until 4)
+         for (x in 0 until 4)
+            buffered.setRGB(x, y, Color(x * 16, y * 16, 32).rgb)
+      val image = ImmutableImage.wrapAwt(buffered)
+      image.takeLeft(2).type shouldBe BufferedImage.TYPE_INT_RGB
+   }
+
+   test("subimage falls back to the default type for TYPE_CUSTOM sources") {
+      // TYPE_CUSTOM (0) cannot be passed to the BufferedImage(w, h, type)
+      // constructor, so the crop must fall back to the default ARGB type.
+      val cm = ComponentColorModel(
+         ColorSpace.getInstance(ColorSpace.CS_sRGB),
+         intArrayOf(8, 8, 8),
+         false,
+         false,
+         Transparency.OPAQUE,
+         DataBuffer.TYPE_BYTE
+      )
+      val raster = cm.createCompatibleWritableRaster(4, 4)
+      val custom = BufferedImage(cm, raster, false, null)
+      custom.type shouldBe BufferedImage.TYPE_CUSTOM
+
+      val image = ImmutableImage.wrapAwt(custom)
+      image.type shouldBe BufferedImage.TYPE_CUSTOM
+      val sub = image.subimage(0, 0, 2, 2)
+      sub.type shouldBe ImmutableImage.DEFAULT_DATA_TYPE
    }
 })


### PR DESCRIPTION
## Problem

`subimage` hardcoded the result type to `DEFAULT_DATA_TYPE` (`TYPE_INT_ARGB`). So cropping a non-ARGB image — and `trim`/`autocrop`/`takeLeft`/`takeRight`/`takeTop`/`takeBottom`, which all delegate to `subimage` — silently promoted e.g. a `TYPE_INT_RGB` or `TYPE_3BYTE_BGR` image to `TYPE_INT_ARGB`, changing `getType()` downstream.

## Fix

Create the result with the source image's own type, falling back to the default ARGB type only for `TYPE_CUSTOM` (0), which can't be passed to the `BufferedImage(w, h, type)` constructor.

## Verification

Pixel values are unchanged — `getRGB`/`setRGB` round-trips losslessly for the int, 3-byte, 4-byte and gray types. Verified that crops of ARGB, RGB and 3BYTE_BGR sources keep the source type and identical pixel values.

## Note

This is a behaviour change: callers that relied on crops always coming back as `TYPE_INT_ARGB` will now see the source type preserved. If the always-ARGB behaviour was intentional, feel free to close — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)