### PR TITLE
perf: drop per-pixel Point allocation in AwtImage.pixels()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -123,14 +123,12 @@ public class AwtImage {
          Pixel[] pixels = new Pixel[data.length];
          if (awt().getType() == BufferedImage.TYPE_INT_ARGB) {
             while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index]);
+               pixels[index] = new Pixel(index % width, index / width, data[index]);
                index++;
             }
          } else if (awt().getType() == BufferedImage.TYPE_INT_RGB) {
             while (index < data.length) {
-               Point point = PixelTools.offsetToPoint(index, width);
-               pixels[index] = new Pixel(point.x, point.y, data[index] | 0xFF000000);
+               pixels[index] = new Pixel(index % width, index / width, data[index] | 0xFF000000);
                index++;
             }
          } else {


### PR DESCRIPTION
## What

The `DataBufferInt` fast path in `AwtImage.pixels()` allocated a `java.awt.Point` for **every pixel** via `PixelTools.offsetToPoint(index, width)`, read its `x`/`y`, and threw it away.

```java
Point point = PixelTools.offsetToPoint(index, width);
pixels[index] = new Pixel(point.x, point.y, data[index]);
```

For a 4000×3000 image that's 12 million throwaway `Point` objects on a hot path.

## Change

Compute the coordinates inline — `index % width` and `index / width` — which is exactly what `offsetToPoint` did internally. No `Point` is allocated.

```java
pixels[index] = new Pixel(index % width, index / width, data[index]);
```

## Behaviour

Identical. `offsetToPoint(offset, width)` is defined as `new Point(offset % width, offset / width)`, so the `Pixel` coordinates are bit-for-bit the same. Applied to both the `TYPE_INT_ARGB` and `TYPE_INT_RGB` branches.

Existing `PixelsTest`, `AwtImageTest` and `PixelAccessConsistencyTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)