### PR TITLE
perf: make contrastInPlace allocation-free and avoid truncate autoboxing

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -119,16 +119,12 @@ public class MutableImage extends AwtImage {
 
    public void contrastInPlace(double factor) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel pixel = new Pixel(x, y, argb[i]);
-            int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);
-            int g = PixelTools.truncate((factor * (pixel.green() - 128)) + 128);
-            int b = PixelTools.truncate((factor * (pixel.blue() - 128)) + 128);
-            argb[i] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();
-            i++;
-         }
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int r = PixelTools.truncate((factor * (PixelTools.red(p) - 128)) + 128);
+         int g = PixelTools.truncate((factor * (PixelTools.green(p) - 128)) + 128);
+         int b = PixelTools.truncate((factor * (PixelTools.blue(p) - 128)) + 128);
+         argb[i] = PixelTools.argb(PixelTools.alpha(p), r, g, b);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -72,9 +72,18 @@ public class PixelTools {
    }
 
    public static int truncate(Double value) {
+      return truncate(value.doubleValue());
+   }
+
+   /**
+    * Clamps the given value to [0, 255] and truncates it to an int, avoiding the
+    * autoboxing the {@link #truncate(Double)} overload incurs when called in a
+    * per-pixel loop.
+    */
+   public static int truncate(double value) {
       if (value < 0) return 0;
       else if (value > 255) return 255;
-      else return value.intValue();
+      else return (int) value;
    }
 
    /**


### PR DESCRIPTION
## What

`MutableImage.contrastInPlace` ran two allocations per pixel and boxed a `Double` three times per pixel:

```java
Pixel pixel = new Pixel(x, y, argb[i]);                       // alloc 1
int r = PixelTools.truncate((factor * (pixel.red() - 128)) + 128);   // Double boxing
...
argb[i] = new Pixel(x, y, r, g, b, pixel.alpha()).toARGBInt();  // alloc 2
```

`PixelTools.truncate(Double)` takes a boxed `Double`, so each of the three calls autoboxes the `double` argument. On a megapixel image that's ~5 short-lived objects per pixel.

## Change

1. Add a primitive `truncate(double)` overload; the existing `truncate(Double)` delegates to it.
2. Operate on the packed ARGB int directly via `PixelTools` channel accessors / `argb()` packer — no `Pixel` objects. Since the `x`/`y` coordinates were never used, the nested loop collapses to a single pass.

```java
for (int i = 0; i < argb.length; i++) {
   int p = argb[i];
   int r = PixelTools.truncate((factor * (PixelTools.red(p)   - 128)) + 128);
   int g = PixelTools.truncate((factor * (PixelTools.green(p) - 128)) + 128);
   int b = PixelTools.truncate((factor * (PixelTools.blue(p)  - 128)) + 128);
   argb[i] = PixelTools.argb(PixelTools.alpha(p), r, g, b);
}
```

## Behaviour

Identical output.
- `Pixel.red/green/blue/alpha()` just delegate to `PixelTools.red/green/blue/alpha(argb)`.
- `new Pixel(x,y,r,g,b,a).toARGBInt()` is exactly `PixelTools.argb(a,r,g,b)`.
- `Double.intValue()` is specified as `(int) doubleValue()`, so the primitive `truncate` truncates identically; the `<0` / `>255` clamps are unchanged.

`ImageTest` and `PixelToolsTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)