### PR TITLE
perf: drop per-pixel allocations in replaceTransparencyInPlace

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -48,13 +48,9 @@ public class MutableImage extends AwtImage {
 
    public void replaceTransparencyInPlace(java.awt.Color color) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
-      int i = 0;
-      for (int y = 0; y < height; y++) {
-         for (int x = 0; x < width; x++) {
-            Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color);
-            argb[i] = withoutTrans.toARGBInt();
-            i++;
-         }
+      int cr = color.getRed(), cg = color.getGreen(), cb = color.getBlue(), ca = color.getAlpha();
+      for (int i = 0; i < argb.length; i++) {
+         argb[i] = PixelTools.replaceTransparencyWithColor(argb[i], cr, cg, cb, ca);
       }
       awt().setRGB(0, 0, width, height, argb, 0, width);
    }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -162,9 +162,22 @@ public class PixelTools {
     * Returns a new Pixel with the transparency in the given pixel replaced by the given color.
     */
    public static Pixel replaceTransparencyWithColor(Pixel p, Color color) {
-      int r = (p.red() * p.alpha() + color.getRed() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
-      int g = (p.green() * p.alpha() + color.getGreen() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
-      int b = (p.blue() * p.alpha() + color.getBlue() * color.getAlpha() * (255 - p.alpha()) / 255) / 255;
-      return new Pixel(p.x, p.y, r, g, b, 255);
+      int argb = replaceTransparencyWithColor(p.argb, color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
+      return new Pixel(p.x, p.y, argb);
+   }
+
+   /**
+    * Returns the packed ARGB int for the given pixel with its transparency replaced by the
+    * given colour components. Equivalent to {@link #replaceTransparencyWithColor(Pixel, Color)}
+    * but works on packed ints, avoiding per-pixel Pixel allocation when used in a loop. The
+    * colour components are passed in so callers can hoist the java.awt.Color accessors out of
+    * their loop.
+    */
+   public static int replaceTransparencyWithColor(int pixel, int colorRed, int colorGreen, int colorBlue, int colorAlpha) {
+      int a = alpha(pixel);
+      int r = (red(pixel) * a + colorRed * colorAlpha * (255 - a) / 255) / 255;
+      int g = (green(pixel) * a + colorGreen * colorAlpha * (255 - a) / 255) / 255;
+      int b = (blue(pixel) * a + colorBlue * colorAlpha * (255 - a) / 255) / 255;
+      return argb(255, r, g, b);
    }
 }


### PR DESCRIPTION
## What

`MutableImage.replaceTransparencyInPlace` allocated two `Pixel` objects per pixel and re-read the four `java.awt.Color` components on every pixel even though the colour is constant for the whole call:

```java
Pixel withoutTrans = PixelTools.replaceTransparencyWithColor(new Pixel(x, y, argb[i]), color);
argb[i] = withoutTrans.toARGBInt();
```

(`replaceTransparencyWithColor` itself allocates a second `Pixel` and calls `color.getRed()/getAlpha()/...` internally.)

## Change

Add an int-based overload of `PixelTools.replaceTransparencyWithColor` that takes the packed pixel plus the colour components and returns a packed int. The existing `Pixel` overload delegates to it, so its contract is unchanged. The loop hoists the colour components out and calls the int overload:

```java
int cr = color.getRed(), cg = color.getGreen(), cb = color.getBlue(), ca = color.getAlpha();
for (int i = 0; i < argb.length; i++) {
   argb[i] = PixelTools.replaceTransparencyWithColor(argb[i], cr, cg, cb, ca);
}
```

## Behaviour

Identical. The per-channel expression and its integer-division grouping are copied verbatim, and the result is packed with alpha 255 exactly as the original `new Pixel(..., 255)` did.

`ImageTest`, `JpegWriterTest`, and `PixelToolsTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)