### PR TITLE
perf: use bulk getRGB/setRGB in ErrorSpotterFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ErrorSpotterFilter.java
@@ -51,11 +51,17 @@ public class ErrorSpotterFilter implements Filter {
                     + "src=" + src.width + "x" + src.height
                     + ", base=" + base.width + "x" + base.height);
         }
-        for (int x = 0; x < src.width; x++) {
-            for (int y = 0; y < src.height; y++) {
-                int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)), RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
-                src.awt().setRGB(x, y, delta);
-            }
+        // Read both rasters in a single bulk getRGB each, rather than a slow
+        // scalar getRGB(x, y) per pixel on both images plus a scalar
+        // setRGB(x, y) per pixel. Each pixel is computed independently, so the
+        // row-major iteration order produces identical results.
+        int w = src.width;
+        int h = src.height;
+        int[] basePixels = base.awt().getRGB(0, 0, w, h, null, 0, w);
+        int[] srcPixels = src.awt().getRGB(0, 0, w, h, null, 0, w);
+        for (int i = 0; i < srcPixels.length; i++) {
+            srcPixels[i] = error(RGBColor.fromARGBInt(basePixels[i]), RGBColor.fromARGBInt(srcPixels[i]));
         }
+        src.awt().setRGB(0, 0, w, h, srcPixels, 0, w);
     }
 }


### PR DESCRIPTION
## What

`ErrorSpotterFilter.apply` called scalar `BufferedImage.getRGB(x, y)` on **both** images and a scalar `setRGB(x, y)` for every pixel:

```java
for (int x = 0; x < src.width; x++) {
    for (int y = 0; y < src.height; y++) {
        int delta = error(RGBColor.fromARGBInt(base.awt().getRGB(x, y)),
                          RGBColor.fromARGBInt(src.awt().getRGB(x, y)));
        src.awt().setRGB(x, y, delta);
    }
}
```

Each scalar `getRGB`/`setRGB` goes through the colour model individually — three conversions per pixel.

## Change

Read each raster once with a bulk `getRGB`, compute into the source array, and write back with one bulk `setRGB`:

```java
int[] basePixels = base.awt().getRGB(0, 0, w, h, null, 0, w);
int[] srcPixels  = src.awt().getRGB(0, 0, w, h, null, 0, w);
for (int i = 0; i < srcPixels.length; i++) {
    srcPixels[i] = error(RGBColor.fromARGBInt(basePixels[i]), RGBColor.fromARGBInt(srcPixels[i]));
}
src.awt().setRGB(0, 0, w, h, srcPixels, 0, w);
```

## Behaviour

Identical. The same `error()` method is called with the same `RGBColor` inputs per pixel; only the access pattern changed. Each pixel is computed independently, so row-major order produces the same output. The dimension-mismatch guard is unchanged.

`ErrorSpotterFilterDimensionTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)