### PR TITLE
perf: replace Math.pow squaring with integer multiply in MMCQ.nearest

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
+++ b/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
@@ -204,11 +204,10 @@ public class MMCQ {
          int numVBoxes = vboxes.size();
          for (int i = 0; i < numVBoxes; i++) {
             int[] vbColor = vboxes.get(i).avg(false);
-            d2 = Math
-               .sqrt(
-                  Math.pow(color[0] - vbColor[0], 2)
-                     + Math.pow(color[1] - vbColor[1], 2)
-                     + Math.pow(color[2] - vbColor[2], 2));
+            int dr = color[0] - vbColor[0];
+            int dg = color[1] - vbColor[1];
+            int db = color[2] - vbColor[2];
+            d2 = Math.sqrt(dr * dr + dg * dg + db * db);
             if (d2 < d1) {
                d1 = d2;
                pColor = vbColor;


### PR DESCRIPTION
## What

`MMCQ.CMap.nearest` (colour quantization) computed Euclidean distance with three `Math.pow(x, 2)` calls inside the nearest-vbox loop:

```java
d2 = Math.sqrt(
   Math.pow(color[0] - vbColor[0], 2)
 + Math.pow(color[1] - vbColor[1], 2)
 + Math.pow(color[2] - vbColor[2], 2));
```

`Math.pow` is a general log/exp exponentiation routine — far costlier than a single multiply.

## Change

```java
int dr = color[0] - vbColor[0];
int dg = color[1] - vbColor[1];
int db = color[2] - vbColor[2];
d2 = Math.sqrt(dr * dr + dg * dg + db * db);
```

## Behaviour

Identical. The component deltas are ints in `[-255, 255]`, so `dr*dr + dg*dg + db*db` ≤ ~195k and cannot overflow `int`. `Math.pow(d, 2.0)` for an exact integer `d` returns exactly `d*d` as a double, so the summed distance and its `sqrt` are unchanged — the selected nearest colour is the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)