### PR TITLE
perf: back subpixelSubimage with one cached interpolator and a bulk pixel read

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -46,6 +46,8 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.awt.image.BufferedImageOp;
+import com.sksamuel.scrimage.subpixel.LinearSubpixelInterpolator;
+
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
 import java.awt.image.WritableRaster;
@@ -1456,10 +1458,16 @@ public class ImmutableImage extends MutableImage {
       // which itself re-extracted the argb from each Pixel — a wasted round
       // trip now that subpixel() already returns a packed ARGB int.
       int[] argb = new int[subWidth * subHeight];
+      // Reuse a single interpolator backed by one bulk read of the source
+      // pixels, rather than constructing a fresh interpolator (each issuing
+      // scalar getRGB calls) for every output cell via the inherited
+      // subpixel(x, y).
+      int[] sourcePixels = awt().getRGB(0, 0, width, height, null, 0, width);
+      LinearSubpixelInterpolator interpolator = new LinearSubpixelInterpolator(this, sourcePixels);
       int k = 0;
       for (int yIndex = 0; yIndex < subHeight; yIndex++) {
          for (int xIndex = 0; xIndex < subWidth; xIndex++) {
-            argb[k++] = subpixel(xIndex + x, yIndex + y);
+            argb[k++] = interpolator.subpixel(xIndex + x, yIndex + y);
          }
       }
       ImmutableImage result = ImmutableImage.create(subWidth, subHeight, DEFAULT_DATA_TYPE);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
@@ -8,11 +8,23 @@ public class LinearSubpixelInterpolator implements SubpixelInterpolator {
     private final AwtImage awt;
     private final int width;
     private final int height;
+    private final int[] pixels;
 
     public LinearSubpixelInterpolator(AwtImage awt) {
+        this(awt, null);
+    }
+
+    /**
+     * Creates an interpolator backed by a pre-read, row-major ARGB buffer of the
+     * whole image (as returned by getRGB(0, 0, width, height, ...)). When many
+     * subpixel() calls are made against the same image this avoids a scalar
+     * getRGB call per neighbour. Pass null to read each neighbour on demand.
+     */
+    public LinearSubpixelInterpolator(AwtImage awt, int[] pixels) {
         this.awt = awt;
         width = awt.width;
         height = awt.height;
+        this.pixels = pixels;
     }
 
     @Override
@@ -61,7 +73,7 @@ public class LinearSubpixelInterpolator implements SubpixelInterpolator {
                 double yw = (yi == 0) ? yw0 : yw1;
                 double weight = xw * yw;
                 if (weight == 0) continue;
-                int p = awt.awt().getRGB(xc, yc);
+                int p = (pixels != null) ? pixels[yc * width + xc] : awt.awt().getRGB(xc, yc);
                 sumA += weight * ((p >>> 24) & 0xFF);
                 sumR += weight * ((p >> 16) & 0xFF);
                 sumG += weight * ((p >> 8) & 0xFF);


### PR DESCRIPTION
## What

`subpixelSubimage` called the inherited `subpixel(x, y)` once per output cell. That method is `new LinearSubpixelInterpolator(this).subpixel(x, y)`, so every cell constructed a fresh interpolator, and each interpolator issued up to four scalar `BufferedImage.getRGB(x, y)` calls. For an N×M extraction that's N·M interpolator allocations and up to 4·N·M scalar colour-model conversions.

## Change

- Add a `LinearSubpixelInterpolator(AwtImage, int[] pixels)` constructor that reads neighbours from a pre-supplied row-major ARGB buffer. The existing single-arg constructor passes `null` and keeps the on-demand scalar `getRGB` behaviour — so one-off `AwtImage.subpixel()` calls are **unchanged** (no full-image read forced on that path).
- `subpixelSubimage` now does a single bulk `getRGB` of the source and reuses one interpolator across the loop.

```java
int[] sourcePixels = awt().getRGB(0, 0, width, height, null, 0, width);
LinearSubpixelInterpolator interpolator = new LinearSubpixelInterpolator(this, sourcePixels);
...
argb[k++] = interpolator.subpixel(xIndex + x, yIndex + y);
```

## Behaviour

Identical. `pixels[yc*width+xc]` is exactly what `getRGB(xc, yc)` returns given the row-major bulk layout, and the bilinear math is untouched.

`LinearSubpixelInterpolatorTest` and `SubpixelSubimageBoundsTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)