### PR TITLE
perf: bulk-read pixels in ColorThief.getPixelsSlow

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/colorthief/ColorThief.java
+++ b/scrimage-core/src/main/java/thirdparty/colorthief/ColorThief.java
@@ -305,10 +305,14 @@ public class ColorThief {
       int[][] res = new int[numRegardedPixels][];
       int r, g, b;
 
+      // Read the whole raster once instead of a slow scalar getRGB(col, row)
+      // per sampled pixel. The flat index i maps directly to the row-major
+      // buffer (i = row * width + col), so rgbAll[i] equals getRGB(i % width,
+      // i / width).
+      int[] rgbAll = sourceImage.getRGB(0, 0, width, height, null, 0, width);
+
       for (int i = 0; i < pixelCount; i += quality) {
-         int row = i / width;
-         int col = i % width;
-         int rgb = sourceImage.getRGB(col, row);
+         int rgb = rgbAll[i];
 
          r = (rgb >> 16) & 0xFF;
          g = (rgb >> 8) & 0xFF;


### PR DESCRIPTION
## What

`ColorThief.getPixelsSlow` (the colour-quantization fallback path used by `ImmutableImage.quantize`) sampled pixels with a scalar `getRGB(col, row)` per iteration plus an integer divide and modulo to derive `col`/`row`:

```java
for (int i = 0; i < pixelCount; i += quality) {
   int row = i / width;
   int col = i % width;
   int rgb = sourceImage.getRGB(col, row);
   ...
}
```

## Change

Read the whole raster once and index it directly:

```java
int[] rgbAll = sourceImage.getRGB(0, 0, width, height, null, 0, width);
for (int i = 0; i < pixelCount; i += quality) {
   int rgb = rgbAll[i];
   ...
}
```

## Behaviour

Identical. The flat index `i` already maps to the row-major buffer (`i = row*width + col`), so `rgbAll[i]` equals the previous `getRGB(i % width, i / width)`. The sampling stride, white-filter, and r/g/b extraction are unchanged. Both scalar and bulk `getRGB` apply the colour model the same way, so this stays correct for the non-standard colour models this slow path exists to handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)