### PR TITLE
perf: avoid Pixel[] and stream in AwtImage.colours()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Wraps an AWT BufferedImage with some basic helper functions related to sizes, pixels etc.
@@ -474,7 +474,12 @@ public class AwtImage {
     * @return the set of distinct Colors
     */
    public Set<RGBColor> colours() {
-      return Arrays.stream(pixels()).map(Pixel::toColor).collect(Collectors.toSet());
+      int[] argb = argbints();
+      Set<RGBColor> colours = new HashSet<>();
+      for (int p : argb) {
+         colours.add(RGBColor.fromARGBInt(p));
+      }
+      return colours;
    }
 
    /**


### PR DESCRIPTION
## What

`colours()` built the full `Pixel[]` via `pixels()` — one `Pixel` object per pixel — then ran a stream pipeline to collect a `Set<RGBColor>`:

```java
public Set<RGBColor> colours() {
   return Arrays.stream(pixels()).map(Pixel::toColor).collect(Collectors.toSet());
}
```

The `Pixel` objects and stream machinery are pure overhead — only the colours are needed.

## Change

```java
public Set<RGBColor> colours() {
   int[] argb = argbints();
   Set<RGBColor> colours = new HashSet<>();
   for (int p : argb) {
      colours.add(RGBColor.fromARGBInt(p));
   }
   return colours;
}
```

## Behaviour

Identical result. `argbints()` returns the same packed ARGB ints that `pixels()` exposes (both go through the int raster / `getRGB`, including alpha forced to 255 for RGB types). `RGBColor.fromARGBInt(p)` builds the same component-based `RGBColor` as `Pixel.toColor()`, and `RGBColor.equals`/`hashCode` are component-based, so the `Set<RGBColor>` contains exactly the same elements. Drops the now-unused `Collectors` import.

`AwtImageTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)