### PR TITLE
Add JMH benchmarks for image operations (crop, resize, rotate, colour, composite)

### DIFF
--- a/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/ColorOpsBenchmarks.java
+++ b/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/ColorOpsBenchmarks.java
@@ -1,0 +1,64 @@
+package com.sksamuel.scrimage.benchmarks;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.color.GrayscaleMethod;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for per-pixel colour operations (grayscale, brightness, contrast
+ * and a custom map). The source image is decoded once per trial.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ColorOpsBenchmarks {
+
+   private ImmutableImage source;
+
+   @Setup(Level.Trial)
+   public void setup() throws IOException {
+      source = ImmutableImage.loader().fromResource("/bench_bird.jpg");
+   }
+
+   @Benchmark
+   public void grayscaleAverage(Blackhole blackhole) {
+      blackhole.consume(source.toGrayscale(GrayscaleMethod.AVERAGE));
+   }
+
+   @Benchmark
+   public void grayscaleLuma(Blackhole blackhole) {
+      blackhole.consume(source.toGrayscale(GrayscaleMethod.LUMA));
+   }
+
+   @Benchmark
+   public void grayscaleWeighted(Blackhole blackhole) {
+      blackhole.consume(source.toGrayscale(GrayscaleMethod.WEIGHTED));
+   }
+
+   @Benchmark
+   public void brightness(Blackhole blackhole) {
+      blackhole.consume(source.brightness(1.2));
+   }
+
+   @Benchmark
+   public void contrast(Blackhole blackhole) {
+      blackhole.consume(source.contrast(1.2));
+   }
+
+   @Benchmark
+   public void mapInvert(Blackhole blackhole) {
+      blackhole.consume(source.map(p -> new Color(255 - p.red(), 255 - p.green(), 255 - p.blue())));
+   }
+}

--- a/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/CompositeBenchmarks.java
+++ b/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/CompositeBenchmarks.java
@@ -1,0 +1,74 @@
+package com.sksamuel.scrimage.benchmarks;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.Position;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.awt.image.RescaleOp;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for canvas/compositing operations (pad, fill, overlay, underlay,
+ * removeTransparency and a generic BufferedImageOp). The source image and a
+ * half-size translucent overlay are built once per trial.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class CompositeBenchmarks {
+
+   private ImmutableImage source;
+   private ImmutableImage overlay;
+
+   @Setup(Level.Trial)
+   public void setup() throws IOException {
+      source = ImmutableImage.loader().fromResource("/bench_bird.jpg");
+      overlay = ImmutableImage.filled(source.width / 2, source.height / 2, new Color(255, 0, 0, 128), BufferedImage.TYPE_INT_ARGB);
+   }
+
+   @Benchmark
+   public void pad(Blackhole blackhole) {
+      blackhole.consume(source.pad(50, Color.BLACK));
+   }
+
+   @Benchmark
+   public void padTo(Blackhole blackhole) {
+      blackhole.consume(source.padTo(source.width + 200, source.height + 200));
+   }
+
+   @Benchmark
+   public void fill(Blackhole blackhole) {
+      blackhole.consume(source.fill(Color.BLUE));
+   }
+
+   @Benchmark
+   public void overlay(Blackhole blackhole) {
+      blackhole.consume(source.overlay(overlay, Position.Center));
+   }
+
+   @Benchmark
+   public void underlay(Blackhole blackhole) {
+      blackhole.consume(source.underlay(overlay));
+   }
+
+   @Benchmark
+   public void removeTransparency(Blackhole blackhole) {
+      blackhole.consume(source.removeTransparency(Color.WHITE));
+   }
+
+   @Benchmark
+   public void op(Blackhole blackhole) {
+      blackhole.consume(source.op(new RescaleOp(1.2f, 0f, null)));
+   }
+}

--- a/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/CropBenchmarks.java
+++ b/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/CropBenchmarks.java
@@ -1,0 +1,63 @@
+package com.sksamuel.scrimage.benchmarks;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for the crop family of operations. The source image is decoded
+ * once per trial so the measurements reflect the operation itself rather than
+ * the JPEG decode.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class CropBenchmarks {
+
+   private ImmutableImage source;
+
+   @Setup(Level.Trial)
+   public void setup() throws IOException {
+      source = ImmutableImage.loader().fromResource("/bench_bird.jpg");
+   }
+
+   @Benchmark
+   public void subimage(Blackhole blackhole) {
+      blackhole.consume(source.subimage(source.width / 4, source.height / 4, source.width / 2, source.height / 2));
+   }
+
+   @Benchmark
+   public void trim(Blackhole blackhole) {
+      blackhole.consume(source.trim(source.width / 8));
+   }
+
+   @Benchmark
+   public void takeLeft(Blackhole blackhole) {
+      blackhole.consume(source.takeLeft(source.width / 2));
+   }
+
+   @Benchmark
+   public void takeTop(Blackhole blackhole) {
+      blackhole.consume(source.takeTop(source.height / 2));
+   }
+
+   @Benchmark
+   public void autocrop(Blackhole blackhole) {
+      blackhole.consume(source.autocrop());
+   }
+
+   @Benchmark
+   public void subpixelSubimage(Blackhole blackhole) {
+      blackhole.consume(source.subpixelSubimage(0.5, 0.5, source.width / 2, source.height / 2));
+   }
+}

--- a/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/ResizeBenchmarks.java
+++ b/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/ResizeBenchmarks.java
@@ -1,0 +1,80 @@
+package com.sksamuel.scrimage.benchmarks;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.ScaleMethod;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for the resize/scale family of operations. "scale" changes the
+ * pixel dimensions (resampling), while "resize" changes the canvas size
+ * (cropping/padding around a position). The source image is decoded once per
+ * trial.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ResizeBenchmarks {
+
+   private ImmutableImage source;
+
+   @Setup(Level.Trial)
+   public void setup() throws IOException {
+      source = ImmutableImage.loader().fromResource("/bench_bird.jpg");
+   }
+
+   @Benchmark
+   public void scaleHalfBicubic(Blackhole blackhole) {
+      blackhole.consume(source.scale(0.5, ScaleMethod.Bicubic));
+   }
+
+   @Benchmark
+   public void scaleHalfFastScale(Blackhole blackhole) {
+      blackhole.consume(source.scale(0.5, ScaleMethod.FastScale));
+   }
+
+   @Benchmark
+   public void scaleToWidth(Blackhole blackhole) {
+      blackhole.consume(source.scaleToWidth(source.width / 2));
+   }
+
+   @Benchmark
+   public void resizeCanvasHalf(Blackhole blackhole) {
+      blackhole.consume(source.resize(0.5));
+   }
+
+   @Benchmark
+   public void cover(Blackhole blackhole) {
+      blackhole.consume(source.cover(source.width / 2, source.height / 2));
+   }
+
+   @Benchmark
+   public void fit(Blackhole blackhole) {
+      blackhole.consume(source.fit(source.width / 2, source.height / 2));
+   }
+
+   @Benchmark
+   public void bound(Blackhole blackhole) {
+      blackhole.consume(source.bound(source.width / 2, source.height / 2));
+   }
+
+   @Benchmark
+   public void max(Blackhole blackhole) {
+      blackhole.consume(source.max(source.width / 2, source.height / 2));
+   }
+
+   @Benchmark
+   public void zoom(Blackhole blackhole) {
+      blackhole.consume(source.zoom(1.5));
+   }
+}

--- a/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/RotateFlipBenchmarks.java
+++ b/scrimage-benchmarks/src/jmh/java/com/sksamuel/scrimage/benchmarks/RotateFlipBenchmarks.java
@@ -1,0 +1,63 @@
+package com.sksamuel.scrimage.benchmarks;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.angles.Degrees;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks for rotation, flipping and translation. The source image is
+ * decoded once per trial.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class RotateFlipBenchmarks {
+
+   private ImmutableImage source;
+
+   @Setup(Level.Trial)
+   public void setup() throws IOException {
+      source = ImmutableImage.loader().fromResource("/bench_bird.jpg");
+   }
+
+   @Benchmark
+   public void rotateLeft(Blackhole blackhole) {
+      blackhole.consume(source.rotateLeft());
+   }
+
+   @Benchmark
+   public void rotateRight(Blackhole blackhole) {
+      blackhole.consume(source.rotateRight());
+   }
+
+   @Benchmark
+   public void rotate45Degrees(Blackhole blackhole) {
+      blackhole.consume(source.rotate(new Degrees(45)));
+   }
+
+   @Benchmark
+   public void flipX(Blackhole blackhole) {
+      blackhole.consume(source.flipX());
+   }
+
+   @Benchmark
+   public void flipY(Blackhole blackhole) {
+      blackhole.consume(source.flipY());
+   }
+
+   @Benchmark
+   public void translate(Blackhole blackhole) {
+      blackhole.consume(source.translate(50, 50));
+   }
+}


### PR DESCRIPTION
## What

Expands the `scrimage-benchmarks` module with JMH coverage for the main per-image operations, grouped into five classes:

| Class | Operations |
|-------|-----------|
| `CropBenchmarks` | `subimage`, `trim`, `takeLeft`, `takeTop`, `autocrop`, `subpixelSubimage` |
| `ResizeBenchmarks` | `scale` (Bicubic/FastScale), `scaleToWidth`, `resize` (canvas), `cover`, `fit`, `bound`, `max`, `zoom` |
| `RotateFlipBenchmarks` | `rotateLeft`, `rotateRight`, `rotate(45°)`, `flipX`, `flipY`, `translate` |
| `ColorOpsBenchmarks` | `toGrayscale` (average/luma/weighted), `brightness`, `contrast`, `map` |
| `CompositeBenchmarks` | `pad`, `padTo`, `fill`, `overlay`, `underlay`, `removeTransparency`, `op` |

## Design

Each class is a `@State(Scope.Benchmark)` that decodes the source image (`bench_bird.jpg`, ~1944×1296) **once per trial** in `@Setup(Level.Trial)`. So the measurement reflects the operation itself rather than the JPEG decode, unlike the existing `ScaleBenchmarks` which intentionally measures decode+scale for library comparison. Results are consumed via `Blackhole`, and the `gc` profiler already configured in `build.gradle` reports allocation rates — handy for the library's allocation-focused tuning.

## Verification

`./gradlew :scrimage-benchmarks:compileJmhJava` is clean, and a smoke run of representative benchmarks (`autocrop`, `subpixelSubimage`, `overlay`, `op`, `map`) completed successfully and produced results.

Run all with:
```
./gradlew :scrimage-benchmarks:jmh -Pjmh.includes='CropBenchmarks|ResizeBenchmarks|RotateFlipBenchmarks|ColorOpsBenchmarks|CompositeBenchmarks'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)