### PR TITLE
ci: render JMH output in the benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,16 +10,63 @@ on:
       - '*.md'
       - 'mkdocs.yml'
   workflow_dispatch:
+    inputs:
+      include:
+        description: 'JMH benchmark regex filter (e.g. ResizeBenchmarks)'
+        required: false
+        default: ''
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Run benchmarks
-        run: ./gradlew jmh
+        run: |
+          if [ -n "${{ inputs.include }}" ]; then
+            ./gradlew :scrimage-benchmarks:jmh -Pjmh.includes='${{ inputs.include }}'
+          else
+            ./gradlew :scrimage-benchmarks:jmh
+          fi
+
+      - name: Render results to step summary
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          RESULTS=scrimage-benchmarks/build/results/jmh/results.json
+          {
+            echo "## JMH Benchmark Results"
+            echo
+            echo "Commit: \`${{ github.sha }}\`"
+            echo
+            if [ ! -s "$RESULTS" ]; then
+              echo "_No JMH results produced at \`$RESULTS\`._"
+              exit 0
+            fi
+            echo "| Benchmark | Mode | Score | Error | Unit |"
+            echo "|---|---|---:|---:|---|"
+            jq -r '
+              .[]
+              | [
+                  (.benchmark | sub("^com\\.sksamuel\\.scrimage\\."; "")),
+                  .mode,
+                  (.primaryMetric.score | . * 1000 | round / 1000 | tostring),
+                  ("± " + (.primaryMetric.scoreError | . * 1000 | round / 1000 | tostring)),
+                  .primaryMetric.scoreUnit
+                ]
+              | "| " + join(" | ") + " |"
+            ' "$RESULTS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw JMH results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: jmh-results
+          path: scrimage-benchmarks/build/results/jmh/
 
 env:
   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"


### PR DESCRIPTION
## What

Follow-up to #539. That PR added the push trigger to `benchmarks.yml` but was merged at its first commit, so the **render-output** stage never made it to master. This adds it.

After running the benchmarks, the workflow now:

- **Renders results to the step summary** — `jq` over `scrimage-benchmarks/build/results/jmh/results.json` into a markdown table (Benchmark / Mode / Score / Error / Unit), with a graceful fallback if no results were produced. Runs even on cancellation (`if: ${{ !cancelled() }}`).
- **Uploads the raw results** as the `jmh-results` artifact.

Also runs `:scrimage-benchmarks:jmh` directly so the results land at the expected path, and adds a `workflow_dispatch` `include` regex filter and a 60-minute timeout — mirroring `jmh.yml`.

## Verification

`benchmarks.yml` parses as valid YAML, and the `jq` filter was tested locally against a real `results.json` — it emits a clean table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)