### PR TITLE
Add intensity constructor overload to SepiaFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SepiaFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SepiaFilter.java
@@ -20,8 +20,27 @@ import thirdparty.marvin.image.color.Sepia;
 
 public class SepiaFilter extends MarvinFilter {
 
+    private final int intensity;
+
+    /**
+     * Creates a SepiaFilter with the default intensity of 20.
+     */
+    public SepiaFilter() {
+        this(20);
+    }
+
+    /**
+     * Creates a SepiaFilter with the given intensity, which is passed through to
+     * the underlying Sepia plugin.
+     *
+     * @param intensity the sepia intensity
+     */
+    public SepiaFilter(int intensity) {
+        this.intensity = intensity;
+    }
+
     @Override
     public MarvinAbstractImagePlugin plugin() {
-        return new Sepia(20);
+        return new Sepia(intensity);
     }
 }


### PR DESCRIPTION
## What

`SepiaFilter` hardcoded the underlying `Sepia` plugin's intensity to `20`. This adds an overloaded `SepiaFilter(int intensity)` constructor that passes the value through to `new Sepia(intensity)`, and keeps the existing no-arg constructor defaulting to `20`.

```java
public SepiaFilter() { this(20); }
public SepiaFilter(int intensity) { this.intensity = intensity; }

@Override
public MarvinAbstractImagePlugin plugin() { return new Sepia(intensity); }
```

Behaviour for existing callers (`new SepiaFilter()`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)