### PR TITLE
Fix admonition syntax for the filters note callout

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -6,7 +6,9 @@ Scrimage comes with a wide array of filters. A filter modifies the pixels of an 
 Most of these filters I have not written myself, but rather collected from other open source imaging libraries (for
 compliance with licenses and / or attribution - see file headers), and either wrapped them, fixed bugs or improved them.
 
-!!! note These filters require the `scrimage-filters` module to be added to your build.
+!!! note
+
+    These filters require the `scrimage-filters` module to be added to your build.
 
 Applying a filter returns a new image. The original image is unmodified.
 Some filters have options which can be set when creating the filters.


### PR DESCRIPTION
## Problem

In `docs/filters.md` the note callout doesn't render — it shows up as a titled box with no body:

```
!!! note These filters require the `scrimage-filters` module to be added to your build.
```

The MkDocs Material **admonition** extension (enabled in `mkdocs.yml`) treats whatever follows the type on the same line as the *title*, and requires the body to be on the following **indented** line(s). So the whole sentence became the title and the body was empty.

## Fix

```
!!! note

    These filters require the `scrimage-filters` module to be added to your build.
```

Body content is now on a 4-space-indented line under the marker, which renders correctly as a note admonition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)