### PR TITLE
Add RepeaterFilter that tiles the image into a larger grid

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/RepeaterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/RepeaterFilter.java
@@ -1,0 +1,65 @@
+/*
+   Copyright 2013 Stephen K Samuel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package com.sksamuel.scrimage.filter;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.transform.Transform;
+
+import java.awt.Graphics2D;
+
+/**
+ * Repeats (tiles) the source image across a grid, producing a larger image.
+ * Given {@code columns} and {@code rows}, the output is {@code columns} times
+ * the source width and {@code rows} times the source height, with the source
+ * drawn at full size into every cell.
+ * <p>
+ * For example {@code new RepeaterFilter(2, 3)} produces an image twice as wide
+ * and three times as tall as the source, tiled 2 across and 3 down.
+ * <p>
+ * Because the result changes the image dimensions it is a {@link Transform}
+ * (applied via {@code image.transform(...)}) rather than a size-preserving
+ * {@link Filter}.
+ */
+public class RepeaterFilter implements Transform {
+
+   private final int columns;
+   private final int rows;
+
+   public RepeaterFilter(int columns, int rows) {
+      if (columns < 1 || rows < 1)
+         throw new IllegalArgumentException("columns and rows must both be >= 1");
+      this.columns = columns;
+      this.rows = rows;
+   }
+
+   @Override
+   public ImmutableImage apply(ImmutableImage input) {
+      int w = input.width;
+      int h = input.height;
+      ImmutableImage output = ImmutableImage.create(w * columns, h * rows);
+      Graphics2D g = (Graphics2D) output.awt().getGraphics();
+      try {
+         for (int c = 0; c < columns; c++) {
+            for (int r = 0; r < rows; r++) {
+               g.drawImage(input.awt(), c * w, r * h, null);
+            }
+         }
+      } finally {
+         g.dispose();
+      }
+      return output;
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/RepeaterFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/RepeaterFilterTest.kt
@@ -1,0 +1,43 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class RepeaterFilterTest : FunSpec({
+
+   test("RepeaterFilter enlarges the image to columns x rows of the source") {
+      val image = ImmutableImage.create(40, 30)
+      val out = image.transform(RepeaterFilter(2, 3))
+      out.width shouldBe 80
+      out.height shouldBe 90
+   }
+
+   test("each tile is a copy of the source image") {
+      // 2x2 image with a distinct colour per pixel
+      val pixels = arrayOf(
+         Pixel(0, 0, 255, 0, 0, 255),
+         Pixel(1, 0, 0, 255, 0, 255),
+         Pixel(0, 1, 0, 0, 255, 255),
+         Pixel(1, 1, 255, 255, 0, 255)
+      )
+      val image = ImmutableImage.create(2, 2, pixels)
+      val out = image.transform(RepeaterFilter(2, 3))
+      out.width shouldBe 4
+      out.height shouldBe 6
+      // top-left pixel of every tile equals the source top-left (red)
+      for (c in 0 until 2) {
+         for (r in 0 until 3) {
+            out.pixel(c * 2, r * 2).argb shouldBe image.pixel(0, 0).argb
+            out.pixel(c * 2 + 1, r * 2 + 1).argb shouldBe image.pixel(1, 1).argb
+         }
+      }
+   }
+
+   test("RepeaterFilter rejects non-positive grid dimensions") {
+      shouldThrow<IllegalArgumentException> { RepeaterFilter(0, 2) }
+      shouldThrow<IllegalArgumentException> { RepeaterFilter(2, 0) }
+   }
+})


### PR DESCRIPTION
## What

`RepeaterFilter(columns, rows)` tiles the source image into a **larger** image: the output is `columns × source-width` wide and `rows × source-height` tall, with the source drawn at full size into each cell. So `RepeaterFilter(2, 3)` produces an image 2× as wide and 3× as tall, repeated 2 across and 3 down.

```java
ImmutableImage tiled = image.transform(new RepeaterFilter(2, 3));
```

## Note on the type

Because the result changes the image dimensions, it's implemented as a `Transform` (applied via `image.transform(...)`) rather than a `Filter`. Scrimage `Filter`s are size-preserving — `image.filter(f)` always returns an image of the original dimensions — so an enlarging tile can't be a `Filter`. (This replaces the earlier same-canvas version of this PR.)

## Tests

`RepeaterFilterTest` verifies the output is `columns·w × rows·h`, that every tile is a copy of the source, and that non-positive grid sizes are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)