### PR TITLE
Generate filter examples at the original image size

### DIFF
--- a/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
+++ b/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
@@ -114,11 +114,11 @@ object ExampleGenerator extends App {
     ("watermark_stamp", (_, _) => new WatermarkStampFilter("watermark", font, true, 0.2, Color.White.toAWT))
   ).sortBy(_._1)
 
-  // One unfiltered "original" thumbnail per sample image.
+  // One unfiltered "original" thumbnail per sample image. The large click-through
+  // image is the full-size original; only the inline thumbnail is downscaled.
   for ((name, img) <- images) {
-    val r = img.scaleToWidth(1200)
-    r.output(new File("examples/filters/" + name + "_original_large.jpeg"))(JpegWriter.compression(95))
-    r.scaleToWidth(thumbWidth).forWriter(PngWriter.MaxCompression)
+    img.output(new File("examples/filters/" + name + "_original_large.jpeg"))(JpegWriter.compression(95))
+    img.scaleToWidth(thumbWidth).forWriter(PngWriter.MaxCompression)
       .write(new File("examples/filters/" + name + "_original_small.png"))
   }
 
@@ -133,7 +133,9 @@ object ExampleGenerator extends App {
 
   filters.zipWithIndex.foreach { case ((filterName, factory), i) =>
     val (imgName, img) = images(i % images.size)
-    val source = img.scaleToWidth(1200).copy(java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    // Filter the full-size original; the large click-through image keeps the
+    // original dimensions and only the inline thumbnail is downscaled.
+    val source = img.copy(java.awt.image.BufferedImage.TYPE_INT_ARGB)
     println("Generating example " + imgName + " " + filterName)
     source.filter(factory(imgName, source)).output(new File("examples/filters/" + imgName + "_" + filterName + "_large.jpeg"))(JpegWriter.compression(95))
     source.filter(factory(imgName, source)).scaleToWidth(thumbWidth).forWriter(PngWriter.MaxCompression)


### PR DESCRIPTION
## What

The filter examples generator downscaled every source to 1200px wide before applying the filter. This changes it to filter the **full-size original**, so the large click-through example images keep the source's original dimensions. The inline table thumbnails are still downscaled (`thumbWidth`) for display.

Both scale points are updated:
- the per-sample "original" large image, and
- the per-filter large image.

## Note

This is a generator change. The committed example images are regenerated at full size the next time the generator is run (I didn't bulk-regenerate the ~80 full-resolution example JPEGs in this PR to avoid committing a large amount of binary data — happy to do so if you'd prefer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)