### PR TITLE
Fix javadoc failure breaking master deploy (GlintFilter tags)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlintFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlintFilter.java
@@ -56,9 +56,7 @@ public class GlintFilter extends AbstractBufferedImageOp {
 	
 	/**
 	 * Set the amount of glint.
-	 * @param amount the amount
-     * @min-value 0
-     * @max-value 1
+	 * @param amount the amount (min-value 0, max-value 1)
      * @see #getAmount
 	 */
 	public void setAmount( float amount ) {


### PR DESCRIPTION
## Problem

The `deploy-snapshots` job has been failing on master since the GlintFilter port (#555) merged:

```
GlintFilter.java:60: error: unknown tag: min-value
GlintFilter.java:61: error: unknown tag: max-value
2 errors
> Task :scrimage-filters:javadoc FAILED
```

The port retained jhlabs' custom `@min-value`/`@max-value` doclet tags. Standard javadoc treats unknown block tags as errors, so `:scrimage-filters:javadoc` (run during snapshot deploy) fails and breaks the master build.

## Fix

Fold the bounds into the `@param` description text. Verified locally: `:scrimage-filters:javadoc` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)