### PR TITLE
Fix Scala filter example to use .filter not .composite

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -32,7 +32,7 @@ To apply a filter, we just use the `filter` method on an image, for example:
 === "Scala"
 
     ```
-    val filtered = image.composite(new DitherFilter())
+    val filtered = image.filter(new DitherFilter())
     ```
 
 


### PR DESCRIPTION
The Scala tab in the filters documentation applied the filter with `image.composite(new DitherFilter())`. Filters are applied with `.filter`, matching the Java and Kotlin examples just above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)