### PR TITLE
Add missing @return javadoc tags

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AutocropOps.java
@@ -18,6 +18,8 @@ public class AutocropOps {
    /**
     * Starting with the given column index, will return the first column index
     * which contains a colour that does not match the given color.
+    *
+    * @return the index of the first column from the left that does not match the given color
     */
    public static int scanright(Color color, int height, int width, int col, PixelsExtractor f, int tolerance) {
       while (col < width && PixelTools.colorMatches(color, tolerance, f.apply(new Rectangle(col, 0, 1, height))))

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -53,6 +53,8 @@ public class AwtImage {
 
    /**
     * Returns the [BufferedImage] that this Image is wrapping.
+    *
+    * @return the wrapped BufferedImage
     */
    public BufferedImage awt() {
       return awt;
@@ -60,6 +62,8 @@ public class AwtImage {
 
    /**
     * The centre coordinates for the image.
+    *
+    * @return the centre point of the image
     */
    public Point center() {
       return new Point(width / 2, height / 2);
@@ -75,6 +79,8 @@ public class AwtImage {
 
    /**
     * The radius of the image defined as the centre to the corners.
+    *
+    * @return the radius of the image in pixels
     */
    public int radius() {
       return (int) Math.sqrt(Math.pow(width / 2.0, 2) + Math.pow(height / 2.0, 2));
@@ -94,6 +100,8 @@ public class AwtImage {
 
    /**
     * Returns the AWT type of this image.
+    *
+    * @return the AWT image type
     */
    public int getType() {
       return awt().getType();
@@ -101,6 +109,8 @@ public class AwtImage {
 
    /**
     * Returns the colors of this image represented as an array of RGBColor.
+    *
+    * @return an array of the image's colors as RGBColor
     */
    public RGBColor[] colors() {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
@@ -113,6 +123,8 @@ public class AwtImage {
 
    /**
     * Returns the pixels of this image represented as an array of Pixels.
+    *
+    * @return an array of the image's pixels
     */
    public Pixel[] pixels() {
       DataBuffer buffer = awt().getRaster().getDataBuffer();
@@ -216,6 +228,8 @@ public class AwtImage {
     * iterate over all the coordinates.
     * <p>
     * If you want the actual pixel values of every point then use pixels().
+    *
+    * @return an array of every point in the image
     */
    public Point[] points() {
       Point[] points = new Point[width * height];
@@ -261,6 +275,8 @@ public class AwtImage {
 
    /**
     * Returns an array of rows, where each row is itself an array of pixels in that row.
+    *
+    * @return an array of rows, each an array of pixels
     */
    public Pixel[][] rows() {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
@@ -430,6 +446,8 @@ public class AwtImage {
     * <p>
     * Legal values for `x` and `y` are in [0, width) and [0, height),
     * respectively.
+    *
+    * @return the interpolated sub-pixel as a packed ARGB int
     */
    public int subpixel(double x, double y) {
       return new LinearSubpixelInterpolator(this).subpixel(x, y);
@@ -440,6 +458,8 @@ public class AwtImage {
     * alignment (no subpixel extraction).
     * <p>
     * The patches are returned as an array of of pixel matrices arrays.
+    *
+    * @return an array of patches, each an array of pixels
     */
    public Pixel[][] patches(int patchWidth, int patchHeight) {
       // Sliding-window enumeration: a patch starting at (col, row) is valid
@@ -547,6 +567,8 @@ public class AwtImage {
     * If the source has BufferedImage.TYPE_CUSTOM (type 0) — which can't be
     * fed back into the BufferedImage(width, height, type) constructor —
     * falls back to TYPE_INT_ARGB, matching ImmutableImage.fromAwt's policy.
+    *
+    * @return a new uninitialized AwtImage with the same dimensions
     */
    public AwtImage empty() {
       int type = awt.getType();
@@ -587,6 +609,8 @@ public class AwtImage {
 
    /**
     * Returns a new AWT BufferedImage scaled using nearest-neighbour.
+    *
+    * @return a new scaled BufferedImage
     */
    protected BufferedImage fastScaleAwt(int targetWidth, int targetHeight) {
       return scale(targetWidth, targetHeight, new AwtNearestNeighbourScale());
@@ -594,6 +618,8 @@ public class AwtImage {
 
    /**
     * Returns a new AWT Image rotated with the given angle (in radians)
+    *
+    * @return a new rotated BufferedImage
     */
    protected BufferedImage rotateByRadians(Radians angle, Color bgcolor) {
 
@@ -617,6 +643,8 @@ public class AwtImage {
 
    /**
     * Returns true if the given predicate holds for all pixels in the image.
+    *
+    * @return true if the predicate holds for every pixel
     */
    public boolean forAll(Predicate<Pixel> predicate) {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
@@ -631,6 +659,8 @@ public class AwtImage {
 
    /**
     * Programatically returns the origin point of top left.
+    *
+    * @return the pixel at the top left of the image
     */
    public Pixel topLeftPixel() {
       return pixel(0, 0);
@@ -650,6 +680,8 @@ public class AwtImage {
 
    /**
     * Returns true if this image supports transparency/alpha in its underlying data model.
+    *
+    * @return true if the image supports alpha
     */
    public boolean hasAlpha() {
       return awt().getColorModel().hasAlpha();
@@ -657,6 +689,8 @@ public class AwtImage {
 
    /**
     * Returns true if this image supports transparency/alpha in its underlying data model.
+    *
+    * @return true if the image supports alpha
     */
    @Deprecated()
    public boolean hasTransparency() {
@@ -665,6 +699,8 @@ public class AwtImage {
 
    /**
     * Returns the average colour of all pixels in this image
+    *
+    * @return the average colour of the image
     */
    public RGBColor average() {
       return Arrays.stream(pixels()).map(Pixel::toColor).reduce(com.sksamuel.scrimage.color.Color::average).get();
@@ -674,6 +710,7 @@ public class AwtImage {
     * Returns true if all the pixels on this image are a single color.
     *
     * @param color the color to test pixels against
+    * @return true if every pixel matches the given color
     */
    public boolean isFilled(Color color) {
       int target = color.getRGB();
@@ -709,6 +746,7 @@ public class AwtImage {
     * the supplied writer.
     *
     * @deprecated pointless method that simply wraps bytes()
+    * @return a stream of the image's bytes written by the given writer
     */
    @Deprecated
    public ByteArrayInputStream stream(ImageWriter writer) throws IOException {
@@ -717,6 +755,8 @@ public class AwtImage {
 
    /**
     * Returns a copy of this image with the backing image type set to the given value.
+    *
+    * @return a copy of this image with the given backing type
     */
    public AwtImage clone(int imageType) {
       if (imageType <= 0) throw new IllegalArgumentException("Image type must be > 0");

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
@@ -38,6 +38,8 @@ public class DimensionTools {
    /**
     * Returns width and height that allow the given source width, height to fit inside the target width, height
     * without losing aspect ratio
+    *
+    * @return the dimensions that fit the source inside the target while preserving aspect ratio
     */
    public static Dimension dimensionsToFit(Dimension target, Dimension source) {
 

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -186,6 +186,7 @@ public class ImmutableImage extends MutableImage {
     * Creates a new [ImmutableImage] from a file.
     * This method will also attach metadata.
     *
+    * @return a new ImmutableImage loaded from the given file
     * @deprecated use ImmutableImage.loader().fromFile(file);
     */
    @Deprecated
@@ -197,6 +198,7 @@ public class ImmutableImage extends MutableImage {
     * Creates a new [ImmutableImage] from a path.
     * This method will also attach metadata.
     *
+    * @return a new ImmutableImage loaded from the given path
     * @deprecated use ImmutableImage.loader().fromPath(path);
     */
    @Deprecated
@@ -327,6 +329,7 @@ public class ImmutableImage extends MutableImage {
    /**
     * Creates a new Image from the resource on the classpath.
     *
+    * @return a new Image loaded from the classpath resource
     * @deprecated use ImmutableImage.loader().fromResource(file);
     */
    @Deprecated
@@ -335,6 +338,7 @@ public class ImmutableImage extends MutableImage {
    }
 
    /**
+    * @return a new Image loaded from the classpath resource using the given image type
     * @deprecated use ImmutableImage.loader().fromResource(file);
     */
    @Deprecated
@@ -434,6 +438,7 @@ public class ImmutableImage extends MutableImage {
     * @param color          the color to match
     * @param colorTolerance the amount of tolerance to use when determining whether
     *                       the color matches the reference color [0..255]
+    * @return a new cropped Image with the matching rows and columns removed
     */
    public ImmutableImage autocrop(Color color, int colorTolerance) {
       int x1 = AutocropOps.scanright(color, height, width, 0, pixelExtractor(), colorTolerance);
@@ -470,6 +475,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for bound(w, h, ScaleMethod.Bicubic)
+    *
+    * @return a new Image bounded to the given width and height
     */
    public ImmutableImage bound(int w, int h) {
       return bound(w, h, ScaleMethod.Bicubic);
@@ -496,6 +503,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image with the brightness adjusted.
+    *
+    * @return a new Image with the brightness adjusted by the given factor
     */
    public ImmutableImage brightness(double factor) {
       ImmutableImage target = copy();
@@ -521,6 +530,8 @@ public class ImmutableImage extends MutableImage {
    /**
     * Returns a copy of this image with the underlying image type set to the given value.
     * The type value is one of the AWT standard image types, taken from BufferedImage.
+    *
+    * @return a copy of this image using the given underlying image type
     */
    public ImmutableImage copy(int type) {
       return fromAwt(awt(), type).associateMetadata(metadata);
@@ -546,6 +557,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image with the contrast adjusted.
+    *
+    * @return a new Image with the contrast adjusted by the given factor
     */
    public ImmutableImage contrast(double factor) {
       ImmutableImage target = copy();
@@ -555,6 +568,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for cover(targetWidth, targetHeight, ScaleMethod.Bicubic, Position.Center)
+    *
+    * @return a new Image scaled to cover the given dimensions
     */
    public ImmutableImage cover(int targetWidth,
                                int targetHeight) {
@@ -563,6 +578,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for cover(targetWidth, targetHeight, ScaleMethod.Bicubic, position)
+    *
+    * @return a new Image scaled to cover the given dimensions at the given position
     */
    public ImmutableImage cover(int targetWidth,
                                int targetHeight,
@@ -704,6 +721,8 @@ public class ImmutableImage extends MutableImage {
    /**
     * Convenience method for:
     * fit(canvasWidth, canvasHeight, Colors.Transparent.toAWT(), ScaleMethod.Bicubic, Position.Center)
+    *
+    * @return a new Image scaled to fit inside the given canvas dimensions
     */
    public ImmutableImage fit(int canvasWidth,
                              int canvasHeight) {
@@ -788,6 +807,7 @@ public class ImmutableImage extends MutableImage {
     * Returns the most n used colours in this image.
     *
     * @param colours how many colours to quantize for.
+    * @return an array of the most used colours in this image
     */
    public RGBColor[] quantize(int colours) {
       MMCQ.CMap cmap = ColorThief.getColorMap(this.awt(), colours);
@@ -796,6 +816,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Applies an affine transform in place.
+    *
+    * @return the BufferedImage resulting from applying the affine transform
     */
    private BufferedImage affineTransform(AffineTransform tx) {
       AffineTransformOp op = new AffineTransformOp(tx, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
@@ -826,6 +848,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for max(maxW, maxH, ScaleMethod.Bicubic)
+    *
+    * @return a new Image constrained to the given maximum width and height
     */
    public ImmutableImage max(int maxW, int maxH) {
       return max(maxW, maxH, ScaleMethod.Bicubic);
@@ -1110,6 +1134,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a copy of this image rotated 90 degrees anti-clockwise (counter clockwise to US English speakers).
+    *
+    * @return a copy of this image rotated 90 degrees anti-clockwise
     */
    public ImmutableImage rotateLeft() {
       Radians angle = new Radians(-Math.PI / 2);
@@ -1118,6 +1144,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a copy of this image rotated 90 degrees clockwise.
+    *
+    * @return a copy of this image rotated 90 degrees clockwise
     */
    public ImmutableImage rotateRight() {
       Radians angle = new Radians(Math.PI / 2);
@@ -1280,6 +1308,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new ImmutableImage with transparency replaced with the given color.
+    *
+    * @return a new ImmutableImage with transparency replaced by the given color
     */
    public ImmutableImage removeTransparency(Color color) {
       ImmutableImage target = copy();
@@ -1289,6 +1319,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for scaleToWidth(targetWith, scaleMethod)
+    *
+    * @return a new Image scaled to the given target width
     */
    public ImmutableImage scaleToWidth(int targetWidth) {
       return scaleToWidth(targetWidth, ScaleMethod.Bicubic);
@@ -1319,6 +1351,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for scaleToHeight(targetHeight, ScaleMethod.Bicubic)
+    *
+    * @return a new Image scaled to the given target height
     */
    public ImmutableImage scaleToHeight(int targetHeight) {
       return scaleToHeight(targetHeight, ScaleMethod.Bicubic);
@@ -1326,6 +1360,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for scaleToHeight(targetHeight, scaleMethod, true)
+    *
+    * @return a new Image scaled to the given target height using the given scale method
     */
    public ImmutableImage scaleToHeight(int targetHeight, ScaleMethod scaleMethod) {
       return scaleToHeight(targetHeight, scaleMethod, true);
@@ -1381,6 +1417,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Convenience method for scaleTo(targetWidth, targetHeight, ScaleMethod.Bicubic);
+    *
+    * @return a new Image scaled to the given target width and height
     */
    public ImmutableImage scaleTo(int targetWidth,
                                  int targetHeight) {
@@ -1449,6 +1487,8 @@ public class ImmutableImage extends MutableImage {
     * <p>
     * Fully opaque images take the original path unchanged, so their output is
     * byte-for-byte identical to before.
+    *
+    * @return a new Image resampled to the given target width and height
     */
    private ImmutableImage resample(ResampleFilter filter, int targetWidth, int targetHeight) {
       ResampleOp resampleOp = new ResampleOp(filter, targetWidth, targetHeight);
@@ -1504,6 +1544,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Extracts a subimage, but using subpixel interpolation.
+    *
+    * @return a new Image extracted using subpixel interpolation
     */
    public ImmutableImage subpixelSubimage(double x,
                                           double y,
@@ -1550,6 +1592,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Extract a patch, centered at a subpixel point.
+    *
+    * @return a new Image patch centered at the given subpixel point
     */
    public ImmutableImage subpixelSubimageCenteredAtPoint(double x,
                                                          double y,
@@ -1606,6 +1650,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image which is the source image, but only keeping a max of k columns from the left.
+    *
+    * @return a new Image keeping at most k columns from the left
     */
    public ImmutableImage takeLeft(int k) {
       return subimage(0, 0, Math.min(k, width), height);
@@ -1613,6 +1659,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image which is the source image, but only keeping a max of k columns from the right.
+    *
+    * @return a new Image keeping at most k columns from the right
     */
    public ImmutableImage takeRight(int k) {
       // trim k to the max we can use, which is the width
@@ -1622,6 +1670,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image which is the source image, but only keeping a max of k rows from the top.
+    *
+    * @return a new Image keeping at most k rows from the top
     */
    public ImmutableImage takeTop(int k) {
       return subimage(0, 0, width, Math.min(k, height));
@@ -1629,6 +1679,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a new Image which is the source image, but only keeping a max of k rows from the bottom.
+    *
+    * @return a new Image keeping at most k rows from the bottom
     */
    public ImmutableImage takeBottom(int k) {
       // trim k to the max we can use, which is the height
@@ -1783,6 +1835,8 @@ public class ImmutableImage extends MutableImage {
     * Returns this image, with metadata attached.
     * <p>
     * Both the original and the new image will share a buffer
+    *
+    * @return a new ImmutableImage sharing this image's buffer with the given metadata attached
     */
    public ImmutableImage associateMetadata(ImageMetadata metadata) {
       return new ImmutableImage(awt(), metadata);
@@ -1820,6 +1874,7 @@ public class ImmutableImage extends MutableImage {
     * The function accepts a pixel being transformed and returns a new (or same) color.
     *
     * @param mapper the function to transform pixel x,y with existing value p into new pixel value p' (p prime)
+    * @return a new Image with the mapper function applied to each pixel
     */
    public ImmutableImage map(Function<Pixel, Color> mapper) {
       ImmutableImage target = copy();
@@ -1829,6 +1884,8 @@ public class ImmutableImage extends MutableImage {
 
    /**
     * Returns a Canvas that wraps this image.
+    *
+    * @return a new Canvas that wraps this image
     */
    public Canvas toCanvas() {
       return new Canvas(this);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/Position.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/Position.java
@@ -24,11 +24,15 @@ public interface Position {
 
     /**
      * Returns the x coordinate for where a target should be placed inside the source.
+     *
+     * @return the x coordinate for the target within the source.
      */
     int calculateX(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight);
 
     /**
      * Returns the y coordinate for where an image should be placed inside the canvas.
+     *
+     * @return the y coordinate for the target within the source.
      */
     int calculateY(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight);
 

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
@@ -11,6 +11,8 @@ public class ProgressiveScale {
 
    /**
     * Scales an image progressively, by starting with the original scale and halving it, until the target size is reached.
+    *
+    * @return the progressively scaled BufferedImage at the target dimensions
     */
    public static BufferedImage scale(BufferedImage image,
                                      int targetWidth,

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/Canvas.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/Canvas.java
@@ -21,6 +21,8 @@ public class Canvas {
 
    /**
     * Returns the image that backs this canvas.
+    *
+    * @return the ImmutableImage that backs this canvas
     */
    public ImmutableImage getImage() {
       return image;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/GraphicsContext.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/GraphicsContext.java
@@ -6,6 +6,8 @@ public interface GraphicsContext {
 
     /**
      * An implementation of [GraphicsContext] that does not change the Graphics object.
+     *
+     * @return a GraphicsContext that leaves the Graphics object unmodified.
      */
     static GraphicsContext identity() {
         return g2 -> {

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/LinearGradient.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/painters/LinearGradient.java
@@ -7,6 +7,8 @@ public class LinearGradient implements Painter {
    /**
     * Returns a left-to-right gradient — the colour varies along the horizontal
     * axis, color1 on the left and color2 on the right.
+    *
+    * @return a horizontal LinearGradient from color1 on the left to color2 on the right
     */
    public static LinearGradient horizontal(Color color1, Color color2) {
       return new LinearGradient(Integer.MIN_VALUE, 0, color1, Integer.MAX_VALUE, 0, color2);
@@ -15,6 +17,8 @@ public class LinearGradient implements Painter {
    /**
     * Returns a top-to-bottom gradient — the colour varies along the vertical
     * axis, color1 at the top and color2 at the bottom.
+    *
+    * @return a vertical LinearGradient from color1 at the top to color2 at the bottom
     */
    public static LinearGradient vertical(Color color1, Color color2) {
       return new LinearGradient(0, Integer.MIN_VALUE, color1, 0, Integer.MAX_VALUE, color2);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -9,12 +9,16 @@ public interface Color {
    /**
     * Returns a conversion of this Color into an RGBColor.
     * If this colour is already an instance of RGBColor then the same instance will be returned.
+    *
+    * @return this colour as an RGBColor
     */
    RGBColor toRGB();
 
    /**
     * Returns a conversion of this color into a CYMK color.
     * If this colour is already a CYMK then the same instance will be returned.
+    *
+    * @return this colour as a CMYKColor
     */
    default CMYKColor toCMYK() {
       return toRGB().toCMYK();
@@ -38,6 +42,8 @@ public interface Color {
 
    /**
     * Returns a HEX String of this colour. Eg for 0,255,0, this method will return 00FF00.
+    *
+    * @return the six-character uppercase hex representation of this colour
     */
    default String toHex() {
       StringBuilder hex = new StringBuilder(Integer.toHexString(toRGB().toARGBInt() & 0xffffff).toUpperCase());
@@ -54,6 +60,8 @@ public interface Color {
    /**
     * Returns this instance as a java.awt.Color.
     * AWT Colors use the RGB color model.
+    *
+    * @return this colour as a java.awt.Color
     */
    default java.awt.Color toAWT() {
       RGBColor rgb = toRGB();
@@ -70,6 +78,8 @@ public interface Color {
     * Takes into account alpha and returns the average as an RGB value.
     * <p>
     * See https://stackoverflow.com/questions/1944095/how-to-mix-two-argb-pixels
+    *
+    * @return the alpha-weighted average of this colour and the other colour as an RGBColor
     */
    default RGBColor average(Color other) {
       RGBColor c1 = this.toRGB();
@@ -87,6 +97,8 @@ public interface Color {
 
    /**
     * Returns this colour as an AWT Paint.
+    *
+    * @return this colour as an AWT Paint
     */
    default Paint paint() {
       return new java.awt.Color(toRGB().toARGBInt(), true);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -72,6 +72,8 @@ public class RGBColor implements Color {
     * Returns as an int the value of this color.
     * The RGB and alpha components are packed as rgba.
     * Use toARGBInt() for clarity.
+    *
+    * @return the packed ARGB integer value of this color
     */
    @Deprecated
    public int toInt() {
@@ -109,6 +111,8 @@ public class RGBColor implements Color {
    /**
     * Returns a conversion of this color into a CYMK color.
     * If this colour is already a CYMK then the same instance will be returned.
+    *
+    * @return this color converted to a CMYKColor
     */
    public CMYKColor toCMYK() {
       float max = Math.max(Math.max(red, green), blue) / 255f;

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/Filter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/Filter.java
@@ -25,6 +25,8 @@ public interface Filter {
    /**
     * Some filters only work for certain types.
     * Override this method to return the supported types.
+    *
+    * @return the image types supported by this filter.
     */
    default int[] types() {
       return new int[0];

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/PipelineFilter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/PipelineFilter.java
@@ -26,6 +26,8 @@ public class PipelineFilter implements Filter {
     * created a *new* ImmutableImage and discarded it after the filters ran,
     * so for any non-INT-ARGB/RGB source the entire pipeline silently became
     * a no-op (NashvilleFilter on TYPE_4BYTE_ABGR did nothing).
+    *
+    * @return the BufferedImage types this filter operates on
     */
    @Override
    public int[] types() {

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Orientation.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/Orientation.java
@@ -30,6 +30,8 @@ public enum Orientation {
 
    /**
     * Returns the [Orientation] enum that matches the given raw value.
+    *
+    * @return an Optional containing the matching Orientation, or empty if none matches
     */
    public static Optional<Orientation> fromRawValue(int i) {
       return Arrays.stream(Orientation.values()).filter(o -> o.value == i).findFirst();

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageReaders.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageReaders.java
@@ -43,6 +43,7 @@ public class ImageReaders {
     * @param source    the image source
     * @param rectangle an optional subset of the image to read.
     * @param readers   the readers that should be used to attempt to load this image.
+    * @return the image read from the given source
     */
    public static ImmutableImage read(ImageSource source, Rectangle rectangle, List<ImageReader> readers) throws IOException {
       List<Throwable> errors = new ArrayList<>();

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImmutableImageLoader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImmutableImageLoader.java
@@ -33,6 +33,8 @@ public class ImmutableImageLoader {
    /**
     * Set to true to reorientate the image if applicable. Requires metadata to be enabled.
     * Default true.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader detectOrientation(boolean reorientate) {
       this.reorientate = reorientate;
@@ -43,6 +45,8 @@ public class ImmutableImageLoader {
     * Set to true to load metadata from the file.
     * Set to false to skip metadata load.
     * Default true.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader detectMetadata(boolean metadata) {
       this.metadata = metadata;
@@ -52,6 +56,8 @@ public class ImmutableImageLoader {
    /**
     * Specifies a region of the image to be loaded. Specifying a region here, rather than resizing
     * the canvas after load can result in a performance gain under certain loaders.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader sourceRegion(Rectangle rectangle) {
       this.rectangle = rectangle;
@@ -62,6 +68,8 @@ public class ImmutableImageLoader {
     * Set the BufferedImage type for the backing image. If the specified type is different
     * from the type detected on load, this can result in an image copy operation.
     * Default is to use the type in the underlying format.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader type(int type) {
       this.type = type;
@@ -72,6 +80,8 @@ public class ImmutableImageLoader {
     * Specifies the ImageReader's to use when trying to decode an image.
     * If not specified, then Scrimage will default to detecting the image readers on the classpath,
     * through the Java Service Loader API.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader withImageReaders(List<ImageReader> readers) {
       this.readers = readers;
@@ -81,6 +91,8 @@ public class ImmutableImageLoader {
    /**
     * Specifies to use [javax.image.ImageReader] implementations only.
     * The javax.image.ImageReader to use will be detected by the JDK based on the stream contents.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader withJavaxImageReaders() {
       this.readers = Collections.singletonList(new ImageIOReader());
@@ -89,6 +101,8 @@ public class ImmutableImageLoader {
 
    /**
     * Specifies to use the given [javax.image.ImageReader] implementations only.
+    *
+    * @return this loader for method chaining
     */
    public ImmutableImageLoader withJavaxImageReaders(List<javax.imageio.ImageReader> readers) {
       this.readers = Collections.singletonList(new ImageIOReader(readers));
@@ -136,6 +150,8 @@ public class ImmutableImageLoader {
    /**
     * Configures this loader to read from the provided input stream.
     * The stream should be closed by the caller after this method has returned.
+    *
+    * @return the loaded ImmutableImage read from the input stream
     */
    public ImmutableImage fromStream(InputStream in) throws IOException {
       if (in == null)

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
@@ -63,6 +63,8 @@ public class Pixel {
 
    /**
     * Returns this pixel as a packed ARGB int.
+    *
+    * @return the packed ARGB int value of this pixel
     */
    public int toARGBInt() {
       return argb;
@@ -71,6 +73,8 @@ public class Pixel {
    /**
     * Returns a copy of this pixel, with the same red, green, blue values, but with alpha
     * set to the given value.
+    *
+    * @return a new pixel with the given alpha value
     */
    public Pixel alpha(int a) {
       return new Pixel(x, y, red(), green(), blue(), a);
@@ -79,6 +83,8 @@ public class Pixel {
    /**
     * Returns a copy of this pixel, with the same red, green, blue values, but with alpha
     * set to fully opaque (255).
+    *
+    * @return a new fully opaque copy of this pixel
     */
    public Pixel noalpha() {
       return alpha(255);
@@ -87,6 +93,8 @@ public class Pixel {
    /**
     * Returns a copy of this pixel, with the same red, green, blue values, but with alpha
     * set to fully transparent (0).
+    *
+    * @return a new fully transparent copy of this pixel
     */
    public Pixel fullalpha() {
       return alpha(0);
@@ -94,6 +102,8 @@ public class Pixel {
 
    /**
     * Returns a copy of this pixel with the red component set to the given value.
+    *
+    * @return a new pixel with the given red component
     */
    public Pixel red(int r) {
       return new Pixel(x, y, r, green(), blue(), alpha());
@@ -101,6 +111,8 @@ public class Pixel {
 
    /**
     * Returns a copy of this pixel with the green component set to the given value.
+    *
+    * @return a new pixel with the given green component
     */
    public Pixel green(int g) {
       return new Pixel(x, y, red(), g, blue(), alpha());
@@ -108,6 +120,8 @@ public class Pixel {
 
    /**
     * Returns a copy of this pixel with the blue component set to the given value.
+    *
+    * @return a new pixel with the given blue component
     */
    public Pixel blue(int b) {
       return new Pixel(x, y, red(), green(), b, alpha());
@@ -115,6 +129,8 @@ public class Pixel {
 
    /**
     * Returns this pixel as an array of ARGB values.
+    *
+    * @return an array of the alpha, red, green and blue components
     */
    public int[] toARGB() {
       return new int[]{alpha(), red(), green(), blue()};
@@ -123,6 +139,8 @@ public class Pixel {
    /**
     * Returns a copy of this Pixel with the colour as grayscale using the average method.
     * The Average method takes the average value of R, G, and B as the grayscale value.
+    *
+    * @return a new grayscale copy of this pixel using the average method
     */
    public Pixel toAverageGrayscale() {
       int gray = (red() + green() + blue()) / 3;
@@ -131,6 +149,8 @@ public class Pixel {
 
    /**
     * Returns this pixel as an array of RGB values, ignoring any alpha value.
+    *
+    * @return an array of the red, green and blue components
     */
    public int[] toRGB() {
       return new int[]{red(), green(), blue()};

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -23,6 +23,8 @@ public class PixelTools {
 
    /**
     * Returns an encoded rgb int, with alpha 255, from the given components.
+    *
+    * @return the encoded rgb int with alpha 255
     */
    public static int rgb(int r, int g, int b) {
       return argb(255, r, g, b);
@@ -30,6 +32,8 @@ public class PixelTools {
 
    /**
     * Returns an encoded argb int from the given components.
+    *
+    * @return the encoded argb int
     */
    public static int argb(int a, int r, int g, int b) {
       return (a & 0xFF) << 24 | (r & 0xFF) << 16 | (g & 0xFF) << 8 | (b & 0xFF);
@@ -37,6 +41,8 @@ public class PixelTools {
 
    /**
     * Returns the alpha component of a pixel as a value between 0 and 255.
+    *
+    * @return the alpha component of the pixel, between 0 and 255
     */
    public static int alpha(int pixel) {
       return pixel >> 24 & 0xFF;
@@ -44,6 +50,8 @@ public class PixelTools {
 
    /**
     * Returns the red component of a pixel as a value between 0 and 255.
+    *
+    * @return the red component of the pixel, between 0 and 255
     */
    public static int red(int pixel) {
       return pixel >> 16 & 0xFF;
@@ -51,6 +59,8 @@ public class PixelTools {
 
    /**
     * Returns the green component of a pixel as a value between 0 and 255.
+    *
+    * @return the green component of the pixel, between 0 and 255
     */
    public static int green(int pixel) {
       return pixel >> 8 & 0xFF;
@@ -58,6 +68,8 @@ public class PixelTools {
 
    /**
     * Returns the blue component of a pixel as a value between 0 and 255.
+    *
+    * @return the blue component of the pixel, between 0 and 255
     */
    public static int blue(int pixel) {
       return pixel & 0xFF;
@@ -65,6 +77,8 @@ public class PixelTools {
 
    /**
     * Returns the gray value of a pixel as a value between 0 and 255.
+    *
+    * @return the gray value of the pixel, between 0 and 255
     */
    public static int gray(int pixel) {
       return (red(pixel) + green(pixel) + blue(pixel)) / 3;
@@ -78,6 +92,8 @@ public class PixelTools {
     * Clamps the given value to [0, 255] and truncates it to an int, avoiding the
     * autoboxing the {@link #truncate(Double)} overload incurs when called in a
     * per-pixel loop.
+    *
+    * @return the value clamped to [0, 255] and truncated to an int
     */
    public static int truncate(double value) {
       if (value < 0) return 0;
@@ -87,6 +103,8 @@ public class PixelTools {
 
    /**
     * Returns true if all pixels in the array have the same color, or both are fully transparent.
+    *
+    * @return true if all pixels match the given color, false otherwise
     */
    public static boolean uniform(Color color, Pixel[] pixels) {
       RGBColor target = RGBColor.fromAwt(color);
@@ -100,6 +118,8 @@ public class PixelTools {
 
    /**
     * Scales the brightness of a pixel.
+    *
+    * @return the encoded rgb int of the brightness-scaled pixel
     */
    public static int scale(Double factor, int pixel) {
       // Clamp each channel to [0, 255]. Without clamping, a factor > 1 (or
@@ -122,6 +142,8 @@ public class PixelTools {
    /**
     * Returns true if the colors of all pixels in the array are within the given tolerance
     * compared to the referenced color
+    *
+    * @return true if all pixels are within tolerance of the given color, false otherwise
     */
    public static boolean approx(Color color, int tolerance, Pixel[] pixels) {
 
@@ -143,6 +165,8 @@ public class PixelTools {
     * compared to the referenced color.
     * <p>
     * If the given colour and target colour are both fully transparent, then they will match.
+    *
+    * @return true if all pixels match the given color within tolerance, false otherwise
     */
    public static boolean colorMatches(Color color, int tolerance, Pixel[] pixels) {
       if (tolerance < 0 || tolerance > 255)
@@ -165,6 +189,8 @@ public class PixelTools {
     * Given a width and an offset returns the coordinate for that offset.
     * In other words, starting at 0,0 and moving along each row before starting the next row,
     * it gives the coordinate that is kth from the start.
+    *
+    * @return the point corresponding to the given offset
     */
    public static Point offsetToPoint(int offset, int width) {
       return new Point(offset % width, offset / width);
@@ -172,6 +198,8 @@ public class PixelTools {
 
    /**
     * Returns a new Pixel with the transparency in the given pixel replaced by the given color.
+    *
+    * @return a new Pixel with its transparency replaced by the given color
     */
    public static Pixel replaceTransparencyWithColor(Pixel p, Color color) {
       int argb = replaceTransparencyWithColor(p.argb, color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
@@ -184,6 +212,8 @@ public class PixelTools {
     * but works on packed ints, avoiding per-pixel Pixel allocation when used in a loop. The
     * colour components are passed in so callers can hoist the java.awt.Color accessors out of
     * their loop.
+    *
+    * @return the packed ARGB int with its transparency replaced by the given colour components
     */
    public static int replaceTransparencyWithColor(int pixel, int colorRed, int colorGreen, int colorBlue, int colorAlpha) {
       int a = alpha(pixel);

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/CssFilters.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/CssFilters.java
@@ -19,7 +19,11 @@ public final class CssFilters {
       return v < 0f ? 0f : (v > 1f ? 1f : v);
    }
 
-   /** {@code brightness(amount)} multiplies each channel by amount. */
+   /**
+    * {@code brightness(amount)} multiplies each channel by amount.
+    *
+    * @return a CssOp applying the brightness adjustment
+    */
    public static CssOp brightness(float amount) {
       return rgb -> {
          rgb[0] = clamp(rgb[0] * amount);
@@ -28,7 +32,11 @@ public final class CssFilters {
       };
    }
 
-   /** {@code contrast(amount)} scales each channel around the 0.5 midpoint. */
+   /**
+    * {@code contrast(amount)} scales each channel around the 0.5 midpoint.
+    *
+    * @return a CssOp applying the contrast adjustment
+    */
    public static CssOp contrast(float amount) {
       return rgb -> {
          rgb[0] = clamp((rgb[0] - 0.5f) * amount + 0.5f);
@@ -37,22 +45,38 @@ public final class CssFilters {
       };
    }
 
-   /** {@code saturate(amount)}; 0 is greyscale, 1 is identity, &gt;1 over-saturates. */
+   /**
+    * {@code saturate(amount)}; 0 is greyscale, 1 is identity, &gt;1 over-saturates.
+    *
+    * @return a CssOp applying the saturation adjustment
+    */
    public static CssOp saturate(float amount) {
       return matrix(saturateMatrix(amount));
    }
 
-   /** {@code grayscale(amount)}; 1 is fully grey. Equivalent to saturate(1 - amount). */
+   /**
+    * {@code grayscale(amount)}; 1 is fully grey. Equivalent to saturate(1 - amount).
+    *
+    * @return a CssOp applying the grayscale adjustment
+    */
    public static CssOp grayscale(float amount) {
       return matrix(saturateMatrix(1f - amount));
    }
 
-   /** {@code sepia(amount)}; 0 is identity, 1 is full sepia. */
+   /**
+    * {@code sepia(amount)}; 0 is identity, 1 is full sepia.
+    *
+    * @return a CssOp applying the sepia adjustment
+    */
    public static CssOp sepia(float amount) {
       return matrix(sepiaMatrix(amount));
    }
 
-   /** {@code hue-rotate(degrees)} rotates the hue around the colour wheel. */
+   /**
+    * {@code hue-rotate(degrees)} rotates the hue around the colour wheel.
+    *
+    * @return a CssOp applying the hue rotation
+    */
    public static CssOp hueRotate(float degrees) {
       return matrix(hueRotateMatrix(degrees));
    }

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/Overlay.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/Overlay.java
@@ -27,13 +27,21 @@ public final class Overlay {
       this.o1 = o1; this.r1 = r1; this.g1 = g1; this.b1 = b1; this.a1 = a1;
    }
 
-   /** A flat colour overlay (r, g, b in [0, 255], alpha in [0, 1]). */
+   /**
+    * A flat colour overlay (r, g, b in [0, 255], alpha in [0, 1]).
+    *
+    * @return a solid colour Overlay.
+    */
    public static Overlay solid(int r, int g, int b, float alpha, BlendMode blend) {
       float rf = r / 255f, gf = g / 255f, bf = b / 255f;
       return new Overlay(Kind.SOLID, blend, 0f, rf, gf, bf, alpha, 1f, rf, gf, bf, alpha);
    }
 
-   /** A top-to-bottom linear gradient between two RGBA stops. */
+   /**
+    * A top-to-bottom linear gradient between two RGBA stops.
+    *
+    * @return a linear gradient Overlay.
+    */
    public static Overlay linear(BlendMode blend,
                                 float o0, int r0, int g0, int b0, float a0,
                                 float o1, int r1, int g1, int b1, float a1) {
@@ -42,7 +50,11 @@ public final class Overlay {
          o1, r1 / 255f, g1 / 255f, b1 / 255f, a1);
    }
 
-   /** A centred radial gradient (sized to the closest corner) between two RGBA stops. */
+   /**
+    * A centred radial gradient (sized to the closest corner) between two RGBA stops.
+    *
+    * @return a radial gradient Overlay.
+    */
    public static Overlay radial(BlendMode blend,
                                 float o0, int r0, int g0, int b0, float a0,
                                 float o1, int r1, int g1, int b1, float a1) {


### PR DESCRIPTION
Adds `@return` Javadoc tags to documented non-void methods that were missing them, across `com.sksamuel.scrimage` in scrimage-core and scrimage-filters — **116 methods over 20 files**.

Only methods that already had a Javadoc comment and return a non-void type were touched. Void methods, constructors, and class/field/enum docs were left as-is. Verified `:scrimage-core:javadoc` and `:scrimage-filters:javadoc` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)