### PR TITLE
Rename TileFilter to TileTransform

### DIFF
--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -62,24 +62,24 @@ Produces a linear gradient copy of the image for the two most dominent colours o
 
 ### Tile
 
-Tiles the source image into a larger image. `TileFilter(columns, rows)` produces an image `columns` times the source width and `rows` times the source height, with the source drawn into every cell — so `TileFilter(3, 2)` repeats the image 3 across and 2 down.
+Tiles the source image into a larger image. `TileTransform(columns, rows)` produces an image `columns` times the source width and `rows` times the source height, with the source drawn into every cell — so `TileTransform(3, 2)` repeats the image 3 across and 2 down.
 
 === "Java"
 
     ```
-    ImmutableImage transformed = image1.transform(new TileFilter(3, 2))
+    ImmutableImage transformed = image1.transform(new TileTransform(3, 2))
     ```
 
 === "Kotlin"
 
     ```
-    val transformed = image1.transform(TileFilter(3, 2))
+    val transformed = image1.transform(TileTransform(3, 2))
     ```
 
 === "Scala"
 
     ```
-    val transformed = image1.transform(new TileFilter(3, 2))
+    val transformed = image1.transform(new TileTransform(3, 2))
     ```
 
 |  Input | Output |

--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/TileTransform.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/TileTransform.java
@@ -26,19 +26,19 @@ import java.awt.Graphics2D;
  * the source width and {@code rows} times the source height, with the source
  * drawn at full size into every cell.
  * <p>
- * For example {@code new TileFilter(2, 3)} produces an image twice as wide
+ * For example {@code new TileTransform(2, 3)} produces an image twice as wide
  * and three times as tall as the source, tiled 2 across and 3 down.
  * <p>
  * Because the result changes the image dimensions it is a {@link Transform}
  * (applied via {@code image.transform(...)}) rather than a size-preserving
  * {@link Filter}.
  */
-public class TileFilter implements Transform {
+public class TileTransform implements Transform {
 
    private final int columns;
    private final int rows;
 
-   public TileFilter(int columns, int rows) {
+   public TileTransform(int columns, int rows) {
       if (columns < 1 || rows < 1)
          throw new IllegalArgumentException("columns and rows must both be >= 1");
       this.columns = columns;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/TileTransformTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/TileTransformTest.kt
@@ -6,11 +6,11 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class TileFilterTest : FunSpec({
+class TileTransformTest : FunSpec({
 
-   test("TileFilter enlarges the image to columns x rows of the source") {
+   test("TileTransform enlarges the image to columns x rows of the source") {
       val image = ImmutableImage.create(40, 30)
-      val out = image.transform(TileFilter(2, 3))
+      val out = image.transform(TileTransform(2, 3))
       out.width shouldBe 80
       out.height shouldBe 90
    }
@@ -24,7 +24,7 @@ class TileFilterTest : FunSpec({
          Pixel(1, 1, 255, 255, 0, 255)
       )
       val image = ImmutableImage.create(2, 2, pixels)
-      val out = image.transform(TileFilter(2, 3))
+      val out = image.transform(TileTransform(2, 3))
       out.width shouldBe 4
       out.height shouldBe 6
       // top-left pixel of every tile equals the source top-left (red)
@@ -36,8 +36,8 @@ class TileFilterTest : FunSpec({
       }
    }
 
-   test("TileFilter rejects non-positive grid dimensions") {
-      shouldThrow<IllegalArgumentException> { TileFilter(0, 2) }
-      shouldThrow<IllegalArgumentException> { TileFilter(2, 0) }
+   test("TileTransform rejects non-positive grid dimensions") {
+      shouldThrow<IllegalArgumentException> { TileTransform(0, 2) }
+      shouldThrow<IllegalArgumentException> { TileTransform(2, 0) }
    }
 })


### PR DESCRIPTION
`TileFilter` implements `Transform` — it changes the image dimensions by tiling the source into a larger grid — so the `Filter` suffix was misleading. Rename the class (and its test) to `TileTransform` and update the transforms documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)