### PR TITLE
Add clean-room Instagram ashby filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/AshbyFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/AshbyFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "ashby" filter:
+ * sepia(.5) contrast(1.2) saturate(1.8) + rgba(125,105,24,.35) lighten.
+ */
+public class AshbyFilter extends InstagramFilter {
+   public AshbyFilter() {
+      super(Arrays.asList(sepia(0.5f), contrast(1.2f), saturate(1.8f)), Overlay.solid(125, 105, 24, 0.35f, BlendMode.LIGHTEN));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -74,6 +74,7 @@ object ExampleGenerator {
       "aden" to { _, _ -> AdenFilter() },
       "alpha_mask" to { n, s -> AlphaMaskFilter(differentFrom(n, s)) },
       "amaro" to { _, _ -> AmaroFilter() },
+      "ashby" to { _, _ -> AshbyFilter() },
       "background_blend" to { _, _ -> BackgroundBlendFilter() },
       "black_threshold" to { _, _ -> BlackThresholdFilter(38.0) },
       "blur" to { _, _ -> BlurFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/AshbyFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/AshbyFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class AshbyFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("ashby preserves the image dimensions and alters the image") {
+      val out = image.filter(AshbyFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `ashby` filter (`AshbyFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)