### PR TITLE
Add clean-room Instagram brannan filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/BrannanFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/BrannanFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "brannan" filter:
+ * sepia(.4) contrast(1.25) brightness(1.1) saturate(.9) hue-rotate(-2deg) (no overlay).
+ */
+public class BrannanFilter extends InstagramFilter {
+   public BrannanFilter() {
+      super(Arrays.asList(sepia(0.4f), contrast(1.25f), brightness(1.1f), saturate(0.9f), hueRotate(-2f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -79,6 +79,7 @@ object ExampleGenerator {
       "black_threshold" to { _, _ -> BlackThresholdFilter(38.0) },
       "blur" to { _, _ -> BlurFilter() },
       "border" to { _, _ -> BorderFilter(8, Color.GRAY) },
+      "brannan" to { _, _ -> BrannanFilter() },
       "brightness" to { _, _ -> BrightnessFilter(1.3f) },
       "brooklyn" to { _, _ -> BrooklynFilter() },
       "bump" to { _, _ -> BumpFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/BrannanFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/BrannanFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class BrannanFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("brannan preserves the image dimensions and alters the image") {
+      val out = image.filter(BrannanFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `brannan` filter (`BrannanFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)