### PR TITLE
Add clean-room Instagram charmes filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/CharmesFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/CharmesFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "charmes" filter:
+ * sepia(.25) contrast(1.25) brightness(1.25) saturate(1.35) hue-rotate(-5deg) + rgba(125,105,24,.25) darken.
+ */
+public class CharmesFilter extends InstagramFilter {
+   public CharmesFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.25f), brightness(1.25f), saturate(1.35f), hueRotate(-5f)), Overlay.solid(125, 105, 24, 0.25f, BlendMode.DARKEN));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -85,6 +85,7 @@ object ExampleGenerator {
       "bump" to { _, _ -> BumpFilter() },
       "caption" to { _, _ -> CaptionFilter("Example", Position.BottomLeft, font, Color.WHITE, 1.0, true, true, Color.WHITE, 0.2, Padding(10)) },
       "caustics" to { _, _ -> CausticsFilter(1.2f, 1.0f, 0.3f, 0xff799fff.toInt()) },
+      "charmes" to { _, _ -> CharmesFilter() },
       "chrome" to { _, _ -> ChromeFilter(0.3f, 1.0f) },
       "clarendon" to { _, _ -> ClarendonFilter() },
       "color_halftone" to { _, _ -> ColorHalftoneFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/CharmesFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/CharmesFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class CharmesFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("charmes preserves the image dimensions and alters the image") {
+      val out = image.filter(CharmesFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `charmes` filter (`CharmesFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)