### PR TITLE
Add clean-room Instagram clarendon filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ClarendonFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ClarendonFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "clarendon" filter:
+ * sepia(.15) contrast(1.25) brightness(1.25) hue-rotate(5deg) + rgba(127,187,227,.4) overlay.
+ */
+public class ClarendonFilter extends InstagramFilter {
+   public ClarendonFilter() {
+      super(Arrays.asList(sepia(0.15f), contrast(1.25f), brightness(1.25f), hueRotate(5f)), Overlay.solid(127, 187, 227, 0.4f, BlendMode.OVERLAY));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -84,6 +84,7 @@ object ExampleGenerator {
       "caption" to { _, _ -> CaptionFilter("Example", Position.BottomLeft, font, Color.WHITE, 1.0, true, true, Color.WHITE, 0.2, Padding(10)) },
       "caustics" to { _, _ -> CausticsFilter(1.2f, 1.0f, 0.3f, 0xff799fff.toInt()) },
       "chrome" to { _, _ -> ChromeFilter(0.3f, 1.0f) },
+      "clarendon" to { _, _ -> ClarendonFilter() },
       "color_halftone" to { _, _ -> ColorHalftoneFilter() },
       "colorize" to { _, _ -> ColorizeFilter(255, 0, 0, 50) },
       "contour" to { _, _ -> ContourFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ClarendonFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ClarendonFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ClarendonFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("clarendon preserves the image dimensions and alters the image") {
+      val out = image.filter(ClarendonFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `clarendon` filter (`ClarendonFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)