### PR TITLE
Add clean-room Instagram dogpatch filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/DogpatchFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/DogpatchFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "dogpatch" filter:
+ * sepia(.35) saturate(1.1) contrast(1.5) (no overlay).
+ */
+public class DogpatchFilter extends InstagramFilter {
+   public DogpatchFilter() {
+      super(Arrays.asList(sepia(0.35f), saturate(1.1f), contrast(1.5f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -98,6 +98,7 @@ object ExampleGenerator {
       "diffuse" to { _, _ -> DiffuseFilter(4f) },
       "dissolve" to { _, _ -> DissolveFilter(0.4f) },
       "dither" to { _, _ -> DitherFilter() },
+      "dogpatch" to { _, _ -> DogpatchFilter() },
       "dominant_gradient" to { _, _ -> DominantGradientFilter() },
       "edge" to { _, _ -> EdgeFilter() },
       "emboss" to { _, _ -> EmbossFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/DogpatchFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/DogpatchFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class DogpatchFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("dogpatch preserves the image dimensions and alters the image") {
+      val out = image.filter(DogpatchFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `dogpatch` filter (`DogpatchFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)