### PR TITLE
Add clean-room Instagram earlybird filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/EarlybirdFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/EarlybirdFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "earlybird" filter:
+ * sepia(.25) contrast(1.25) brightness(1.15) saturate(.9) hue-rotate(-5deg) + radial transparent->rgba(125,105,24,.2) multiply.
+ */
+public class EarlybirdFilter extends InstagramFilter {
+   public EarlybirdFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.25f), brightness(1.15f), saturate(0.9f), hueRotate(-5f)), Overlay.radial(BlendMode.MULTIPLY, 0f, 125, 105, 24, 0f, 1f, 125, 105, 24, 0.2f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -100,6 +100,7 @@ object ExampleGenerator {
       "dither" to { _, _ -> DitherFilter() },
       "dogpatch" to { _, _ -> DogpatchFilter() },
       "dominant_gradient" to { _, _ -> DominantGradientFilter() },
+      "earlybird" to { _, _ -> EarlybirdFilter() },
       "edge" to { _, _ -> EdgeFilter() },
       "emboss" to { _, _ -> EmbossFilter() },
       "erode" to { _, _ -> ErodeFilter(8) },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/EarlybirdFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/EarlybirdFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class EarlybirdFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("earlybird preserves the image dimensions and alters the image") {
+      val out = image.filter(EarlybirdFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `earlybird` filter (`EarlybirdFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)