### PR TITLE
Add clean-room Instagram gingham filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/GinghamFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/GinghamFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "gingham" filter:
+ * contrast(1.1) brightness(1.1) + #e6e6e6 soft-light.
+ */
+public class GinghamFilter extends InstagramFilter {
+   public GinghamFilter() {
+      super(Arrays.asList(contrast(1.1f), brightness(1.1f)), Overlay.solid(230, 230, 230, 1.0f, BlendMode.SOFT_LIGHT));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -101,6 +101,7 @@ object ExampleGenerator {
       "gain_bias" to { _, _ -> GainBiasFilter(0.7f, 0.6f) },
       "gamma" to { _, _ -> GammaFilter(2.0) },
       "gaussian" to { _, _ -> GaussianBlurFilter(10) },
+      "gingham" to { _, _ -> GinghamFilter() },
       "glint" to { _, _ -> GlintFilter(0.5f, 0.3f, 10, 0.0f) },
       "glow" to { _, _ -> GlowFilter() },
       "gotham" to { _, _ -> GothamFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/GinghamFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/GinghamFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GinghamFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("gingham preserves the image dimensions and alters the image") {
+      val out = image.filter(GinghamFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `gingham` filter (`GinghamFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)