### PR TITLE
Add clean-room Instagram ginza filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/GinzaFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/GinzaFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "ginza" filter:
+ * sepia(.25) contrast(1.15) brightness(1.2) saturate(1.35) hue-rotate(-5deg) + rgba(125,105,24,.15) darken.
+ */
+public class GinzaFilter extends InstagramFilter {
+   public GinzaFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.15f), brightness(1.2f), saturate(1.35f), hueRotate(-5f)), Overlay.solid(125, 105, 24, 0.15f, BlendMode.DARKEN));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -110,6 +110,7 @@ object ExampleGenerator {
       "gamma" to { _, _ -> GammaFilter(2.0) },
       "gaussian" to { _, _ -> GaussianBlurFilter(10) },
       "gingham" to { _, _ -> GinghamFilter() },
+      "ginza" to { _, _ -> GinzaFilter() },
       "glint" to { _, _ -> GlintFilter(0.5f, 0.3f, 10, 0.0f) },
       "glow" to { _, _ -> GlowFilter() },
       "gotham" to { _, _ -> GothamFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/GinzaFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/GinzaFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class GinzaFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("ginza preserves the image dimensions and alters the image") {
+      val out = image.filter(GinzaFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `ginza` filter (`GinzaFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)