### PR TITLE
Add clean-room Instagram hefe filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HefeFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HefeFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "hefe" filter:
+ * sepia(.4) contrast(1.5) brightness(1.2) saturate(1.4) hue-rotate(-10deg) + radial transparent->rgba(0,0,0,.25) multiply.
+ */
+public class HefeFilter extends InstagramFilter {
+   public HefeFilter() {
+      super(Arrays.asList(sepia(0.4f), contrast(1.5f), brightness(1.2f), saturate(1.4f), hueRotate(-10f)), Overlay.radial(BlendMode.MULTIPLY, 0f, 0, 0, 0, 0f, 1f, 0, 0, 0, 0.25f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -105,6 +105,7 @@ object ExampleGenerator {
       "glow" to { _, _ -> GlowFilter() },
       "gotham" to { _, _ -> GothamFilter() },
       "grayscale" to { _, _ -> GrayscaleFilter() },
+      "hefe" to { _, _ -> HefeFilter() },
       "hsb" to { _, _ -> HSBFilter(0.5f, 0f, 0f) },
       "invert" to { _, _ -> InvertFilter() },
       "invert_alpha" to { _, _ -> InvertAlphaFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HefeFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HefeFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class HefeFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("hefe preserves the image dimensions and alters the image") {
+      val out = image.filter(HefeFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `hefe` filter (`HefeFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)