### PR TITLE
Add clean-room Instagram helena filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HelenaFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HelenaFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "helena" filter:
+ * sepia(.5) contrast(1.05) brightness(1.05) saturate(1.35) + rgba(158,175,30,.25) overlay.
+ */
+public class HelenaFilter extends InstagramFilter {
+   public HelenaFilter() {
+      super(Arrays.asList(sepia(0.5f), contrast(1.05f), brightness(1.05f), saturate(1.35f)), Overlay.solid(158, 175, 30, 0.25f, BlendMode.OVERLAY));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -116,6 +116,7 @@ object ExampleGenerator {
       "gotham" to { _, _ -> GothamFilter() },
       "grayscale" to { _, _ -> GrayscaleFilter() },
       "hefe" to { _, _ -> HefeFilter() },
+      "helena" to { _, _ -> HelenaFilter() },
       "hsb" to { _, _ -> HSBFilter(0.5f, 0f, 0f) },
       "hudson" to { _, _ -> HudsonFilter() },
       "invert" to { _, _ -> InvertFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HelenaFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HelenaFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class HelenaFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("helena preserves the image dimensions and alters the image") {
+      val out = image.filter(HelenaFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `helena` filter (`HelenaFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)