### PR TITLE
Add clean-room Instagram hudson filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HudsonFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/HudsonFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "hudson" filter:
+ * sepia(.25) contrast(1.2) brightness(1.2) saturate(1.05) hue-rotate(-15deg) + radial transparent 25%->rgba(25,62,167,.25) multiply.
+ */
+public class HudsonFilter extends InstagramFilter {
+   public HudsonFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.2f), brightness(1.2f), saturate(1.05f), hueRotate(-15f)), Overlay.radial(BlendMode.MULTIPLY, 0.25f, 25, 62, 167, 0f, 1f, 25, 62, 167, 0.25f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -106,6 +106,7 @@ object ExampleGenerator {
       "gotham" to { _, _ -> GothamFilter() },
       "grayscale" to { _, _ -> GrayscaleFilter() },
       "hsb" to { _, _ -> HSBFilter(0.5f, 0f, 0f) },
+      "hudson" to { _, _ -> HudsonFilter() },
       "invert" to { _, _ -> InvertFilter() },
       "invert_alpha" to { _, _ -> InvertAlphaFilter() },
       "juno" to { _, _ -> JunoFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HudsonFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/HudsonFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class HudsonFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("hudson preserves the image dimensions and alters the image") {
+      val out = image.filter(HudsonFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `hudson` filter (`HudsonFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)