### PR TITLE
Add clean-room Instagram juno filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/JunoFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/JunoFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "juno" filter:
+ * sepia(.35) contrast(1.15) brightness(1.15) saturate(1.8) + rgba(127,187,227,.2) overlay.
+ */
+public class JunoFilter extends InstagramFilter {
+   public JunoFilter() {
+      super(Arrays.asList(sepia(0.35f), contrast(1.15f), brightness(1.15f), saturate(1.8f)), Overlay.solid(127, 187, 227, 0.2f, BlendMode.OVERLAY));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/JunoFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/JunoFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class JunoFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("juno preserves the image dimensions and alters the image") {
+      val out = image.filter(JunoFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})

--- a/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
+++ b/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
@@ -74,6 +74,7 @@ object ExampleGenerator extends App {
     ("hsb", (_, _) => new HSBFilter(0.5f, 0, 0)),
     ("invert", (_, _) => new InvertFilter),
     ("invert_alpha", (_, _) => new InvertAlphaFilter),
+    ("juno", (_, _) => new JunoFilter()),
     ("kaleidoscope", (_, _) => new KaleidoscopeFilter()),
     ("laplace", (_, _) => new LaplaceFilter()),
     ("lensblur", (_, _) => new LensBlurFilter()),


### PR DESCRIPTION
Adds the clean-room Instagram `juno` filter (`JunoFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)