### PR TITLE
Add clean-room Instagram kelvin filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/KelvinFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/KelvinFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "kelvin" filter:
+ * sepia(.15) contrast(1.5) brightness(1.1) hue-rotate(-10deg) + radial rgba(128,78,15,.25)->.5 overlay.
+ */
+public class KelvinFilter extends InstagramFilter {
+   public KelvinFilter() {
+      super(Arrays.asList(sepia(0.15f), contrast(1.5f), brightness(1.1f), hueRotate(-10f)), Overlay.radial(BlendMode.OVERLAY, 0f, 128, 78, 15, 0.25f, 1f, 128, 78, 15, 0.5f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -124,6 +124,7 @@ object ExampleGenerator {
       "invert_alpha" to { _, _ -> InvertAlphaFilter() },
       "juno" to { _, _ -> JunoFilter() },
       "kaleidoscope" to { _, _ -> KaleidoscopeFilter() },
+      "kelvin" to { _, _ -> KelvinFilter() },
       "laplace" to { _, _ -> LaplaceFilter() },
       "lensblur" to { _, _ -> LensBlurFilter() },
       "lensflare" to { _, _ -> LensFlareFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/KelvinFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/KelvinFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class KelvinFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("kelvin preserves the image dimensions and alters the image") {
+      val out = image.filter(KelvinFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `kelvin` filter (`KelvinFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)