### PR TITLE
Add clean-room Instagram lark filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/LarkFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/LarkFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "lark" filter:
+ * sepia(.25) contrast(1.2) brightness(1.3) saturate(1.25) (no overlay).
+ */
+public class LarkFilter extends InstagramFilter {
+   public LarkFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.2f), brightness(1.3f), saturate(1.25f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -126,6 +126,7 @@ object ExampleGenerator {
       "kaleidoscope" to { _, _ -> KaleidoscopeFilter() },
       "kelvin" to { _, _ -> KelvinFilter() },
       "laplace" to { _, _ -> LaplaceFilter() },
+      "lark" to { _, _ -> LarkFilter() },
       "lensblur" to { _, _ -> LensBlurFilter() },
       "lensflare" to { _, _ -> LensFlareFilter() },
       "ludwig" to { _, _ -> LudwigFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/LarkFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/LarkFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class LarkFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("lark preserves the image dimensions and alters the image") {
+      val out = image.filter(LarkFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `lark` filter (`LarkFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)