### PR TITLE
Add clean-room Instagram mayfair filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/MayfairFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/MayfairFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "mayfair" filter:
+ * contrast(1.1) brightness(1.15) saturate(1.1) + radial transparent->rgba(175,105,24,.4) multiply.
+ */
+public class MayfairFilter extends InstagramFilter {
+   public MayfairFilter() {
+      super(Arrays.asList(contrast(1.1f), brightness(1.15f), saturate(1.1f)), Overlay.radial(BlendMode.MULTIPLY, 0f, 175, 105, 24, 0f, 1f, 175, 105, 24, 0.4f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -133,6 +133,7 @@ object ExampleGenerator {
       "ludwig" to { _, _ -> LudwigFilter() },
       "maven" to { _, _ -> MavenFilter() },
       "maximum" to { _, _ -> MaximumFilter() },
+      "mayfair" to { _, _ -> MayfairFilter() },
       "minimum" to { _, _ -> MinimumFilter() },
       "mirror" to { _, _ -> MirrorFilter() },
       "moon" to { _, _ -> MoonFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/MayfairFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/MayfairFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class MayfairFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("mayfair preserves the image dimensions and alters the image") {
+      val out = image.filter(MayfairFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `mayfair` filter (`MayfairFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)