### PR TITLE
Add clean-room Instagram moon filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/MoonFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/MoonFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "moon" filter:
+ * brightness(1.4) contrast(.95) saturate(0) sepia(.35) (no overlay).
+ */
+public class MoonFilter extends InstagramFilter {
+   public MoonFilter() {
+      super(Arrays.asList(brightness(1.4f), contrast(0.95f), saturate(0f), sepia(0.35f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -117,6 +117,7 @@ object ExampleGenerator {
       "maximum" to { _, _ -> MaximumFilter() },
       "minimum" to { _, _ -> MinimumFilter() },
       "mirror" to { _, _ -> MirrorFilter() },
+      "moon" to { _, _ -> MoonFilter() },
       "motionblur" to { _, _ -> MotionBlurFilter(Math.PI / 3.0, 20.0) },
       "nashville" to { _, _ -> NashvilleFilter() },
       "noise" to { _, _ -> NoiseFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/MoonFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/MoonFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class MoonFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("moon preserves the image dimensions and alters the image") {
+      val out = image.filter(MoonFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `moon` filter (`MoonFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)