### PR TITLE
Add clean-room Instagram perpetua filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/PerpetuaFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/PerpetuaFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "perpetua" filter:
+ * contrast(1.1) brightness(1.25) saturate(1.1) + linear rgba(0,91,154,.25)->rgba(230,193,61,.25) multiply.
+ */
+public class PerpetuaFilter extends InstagramFilter {
+   public PerpetuaFilter() {
+      super(Arrays.asList(contrast(1.1f), brightness(1.25f), saturate(1.1f)), Overlay.linear(BlendMode.MULTIPLY, 0f, 0, 91, 154, 0.25f, 1f, 230, 193, 61, 0.25f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/PerpetuaFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/PerpetuaFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class PerpetuaFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("perpetua preserves the image dimensions and alters the image") {
+      val out = image.filter(PerpetuaFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})

--- a/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
+++ b/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
@@ -89,6 +89,7 @@ object ExampleGenerator extends App {
     ("oil", (_, _) => new OilFilter()),
     ("old_photo", (_, _) => new OldPhotoFilter()),
     ("opacity", (_, _) => new OpacityFilter(0.5f)),
+    ("perpetua", (_, _) => new PerpetuaFilter()),
     ("pixelate", (_, _) => new PixelateFilter(6)),
     ("pointillize_square", (_, _) => new PointillizeFilter(PointillizeGridType.Square)),
     ("posterize", (_, _) => new PosterizeFilter()),


### PR DESCRIPTION
Adds the clean-room Instagram `perpetua` filter (`PerpetuaFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)