### PR TITLE
Add clean-room Instagram poprocket filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/PoprocketFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/PoprocketFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "poprocket" filter:
+ * sepia(.15) brightness(1.2) + radial rgba(206,39,70,.75) 40%->black 80% screen.
+ */
+public class PoprocketFilter extends InstagramFilter {
+   public PoprocketFilter() {
+      super(Arrays.asList(sepia(0.15f), brightness(1.2f)), Overlay.radial(BlendMode.SCREEN, 0.4f, 206, 39, 70, 0.75f, 0.8f, 0, 0, 0, 1.0f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/PoprocketFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/PoprocketFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class PoprocketFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("poprocket preserves the image dimensions and alters the image") {
+      val out = image.filter(PoprocketFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})

--- a/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
+++ b/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
@@ -91,6 +91,7 @@ object ExampleGenerator extends App {
     ("opacity", (_, _) => new OpacityFilter(0.5f)),
     ("pixelate", (_, _) => new PixelateFilter(6)),
     ("pointillize_square", (_, _) => new PointillizeFilter(PointillizeGridType.Square)),
+    ("poprocket", (_, _) => new PoprocketFilter()),
     ("posterize", (_, _) => new PosterizeFilter()),
     ("prewitt", (_, _) => new PrewittFilter),
     ("quantize", (_, _) => new QuantizeFilter(64)),


### PR DESCRIPTION
Adds the clean-room Instagram `poprocket` filter (`PoprocketFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)