### PR TITLE
Add clean-room Instagram reyes filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ReyesFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ReyesFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "reyes" filter:
+ * sepia(.75) contrast(.75) brightness(1.25) saturate(1.4) (no overlay).
+ */
+public class ReyesFilter extends InstagramFilter {
+   public ReyesFilter() {
+      super(Arrays.asList(sepia(0.75f), contrast(0.75f), brightness(1.25f), saturate(1.4f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -153,6 +153,7 @@ object ExampleGenerator {
       "prewitt" to { _, _ -> PrewittFilter() },
       "quantize" to { _, _ -> QuantizeFilter(64) },
       "rays" to { _, _ -> RaysFilter(1.0f, 0.6f, 1.0f) },
+      "reyes" to { _, _ -> ReyesFilter() },
       "rgb" to { _, _ -> RGBFilter(0.4f, 0.6f, 0.5f) },
       "ripple" to { _, _ -> RippleFilter(RippleType.Sine, 4f, 4f, 6f, 6f) },
       "roberts" to { _, _ -> RobertsFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ReyesFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ReyesFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ReyesFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("reyes preserves the image dimensions and alters the image") {
+      val out = image.filter(ReyesFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `reyes` filter (`ReyesFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)