### PR TITLE
Add clean-room Instagram rise filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/RiseFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/RiseFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "rise" filter:
+ * sepia(.25) contrast(1.25) brightness(1.2) saturate(.9) + radial transparent->rgba(230,193,61,.25) lighten.
+ */
+public class RiseFilter extends InstagramFilter {
+   public RiseFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.25f), brightness(1.2f), saturate(0.9f)), Overlay.radial(BlendMode.LIGHTEN, 0f, 230, 193, 61, 0f, 1f, 230, 193, 61, 0.25f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -156,6 +156,7 @@ object ExampleGenerator {
       "reyes" to { _, _ -> ReyesFilter() },
       "rgb" to { _, _ -> RGBFilter(0.4f, 0.6f, 0.5f) },
       "ripple" to { _, _ -> RippleFilter(RippleType.Sine, 4f, 4f, 6f, 6f) },
+      "rise" to { _, _ -> RiseFilter() },
       "roberts" to { _, _ -> RobertsFilter() },
       "rylanders" to { _, _ -> RylandersFilter() },
       "salt_and_pepper" to { _, _ -> SaltAndPepperFilter(0.05, 0.05) },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/RiseFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/RiseFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class RiseFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("rise preserves the image dimensions and alters the image") {
+      val out = image.filter(RiseFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `rise` filter (`RiseFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)