### PR TITLE
Add clean-room Instagram skyline filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/SkylineFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/SkylineFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "skyline" filter:
+ * sepia(.15) contrast(1.25) brightness(1.25) saturate(1.2) (no overlay).
+ */
+public class SkylineFilter extends InstagramFilter {
+   public SkylineFilter() {
+      super(Arrays.asList(sepia(0.15f), contrast(1.25f), brightness(1.25f), saturate(1.2f)));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -164,6 +164,7 @@ object ExampleGenerator {
       "sharpen" to { _, _ -> SharpenFilter() },
       "sierra" to { _, _ -> SierraFilter() },
       "skeleton" to { _, _ -> SkeletonFilter() },
+      "skyline" to { _, _ -> SkylineFilter() },
       "slumber" to { _, _ -> SlumberFilter() },
       "smear_circles" to { _, _ -> SmearFilter(SmearType.Circles) },
       "snow" to { _, _ -> SnowFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/SkylineFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/SkylineFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SkylineFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("skyline preserves the image dimensions and alters the image") {
+      val out = image.filter(SkylineFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `skyline` filter (`SkylineFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)