### PR TITLE
Add clean-room Instagram stinson filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/StinsonFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/StinsonFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "stinson" filter:
+ * sepia(.35) contrast(1.25) brightness(1.1) saturate(1.25) + rgba(125,105,24,.45) lighten.
+ */
+public class StinsonFilter extends InstagramFilter {
+   public StinsonFilter() {
+      super(Arrays.asList(sepia(0.35f), contrast(1.25f), brightness(1.1f), saturate(1.25f)), Overlay.solid(125, 105, 24, 0.45f, BlendMode.LIGHTEN));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -172,6 +172,7 @@ object ExampleGenerator {
       "solarize" to { _, _ -> SolarizeFilter() },
       "sparkle" to { _, _ -> SparkleFilter(1100, 300, 50, 200, 6) },
       "split_channels" to { _, _ -> SplitChannelsFilter(true, false, false) },
+      "stinson" to { _, _ -> StinsonFilter() },
       "summer" to { _, _ -> SummerFilter(true) },
       "sutro" to { _, _ -> SutroFilter() },
       "swim" to { _, _ -> SwimFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/StinsonFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/StinsonFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class StinsonFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("stinson preserves the image dimensions and alters the image") {
+      val out = image.filter(StinsonFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `stinson` filter (`StinsonFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)