### PR TITLE
Add clean-room Instagram toaster filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ToasterFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/ToasterFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "toaster" filter:
+ * sepia(.25) contrast(1.5) brightness(.95) hue-rotate(-15deg) + radial #804e0f->rgba(0,0,0,.25) screen.
+ */
+public class ToasterFilter extends InstagramFilter {
+   public ToasterFilter() {
+      super(Arrays.asList(sepia(0.25f), contrast(1.5f), brightness(0.95f), hueRotate(-15f)), Overlay.radial(BlendMode.SCREEN, 0f, 128, 78, 15, 1.0f, 1f, 0, 0, 0, 0.25f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ToasterFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/ToasterFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class ToasterFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("toaster preserves the image dimensions and alters the image") {
+      val out = image.filter(ToasterFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})

--- a/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
+++ b/scrimage-filters/src/test/scala/com/sksamuel/scrimage/ExampleGenerator.scala
@@ -113,6 +113,7 @@ object ExampleGenerator extends App {
     ("swim", (_, _) => new SwimFilter()),
     ("television", (_, _) => new TelevisionFilter),
     ("threshold", (_, _) => new ThresholdFilter(127)),
+    ("toaster", (_, _) => new ToasterFilter()),
     ("tritone", (_, _) => new TritoneFilter(new java.awt.Color(0xFF000044), new java.awt.Color(0xFF0066FF), java.awt.Color.WHITE)),
     ("twirl", (_, s) => new TwirlFilter((Math.PI / 4).toFloat, s.radius.toFloat)),
     ("unsharp", (_, _) => new UnsharpFilter()),


### PR DESCRIPTION
Adds the clean-room Instagram `toaster` filter (`ToasterFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)