### PR TITLE
Add clean-room Instagram vesper filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/VesperFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/VesperFilter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "vesper" filter:
+ * sepia(.35) contrast(1.15) brightness(1.2) saturate(1.3) + rgba(125,105,24,.25) overlay.
+ */
+public class VesperFilter extends InstagramFilter {
+   public VesperFilter() {
+      super(Arrays.asList(sepia(0.35f), contrast(1.15f), brightness(1.2f), saturate(1.3f)), Overlay.solid(125, 105, 24, 0.25f, BlendMode.OVERLAY));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -183,6 +183,7 @@ object ExampleGenerator {
       "twirl" to { _, s -> TwirlFilter((Math.PI / 4).toFloat(), s.radius().toFloat()) },
       "unsharp" to { _, _ -> UnsharpFilter() },
       "valencia" to { _, _ -> ValenciaFilter() },
+      "vesper" to { _, _ -> VesperFilter() },
       "vignette" to { _, _ -> VignetteFilter(0.7f, 0.95f, 0.3f, Color.BLACK) },
       "vintage" to { _, _ -> VintageFilter() },
       "walden" to { _, _ -> WaldenFilter() },

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/VesperFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/VesperFilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class VesperFilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("vesper preserves the image dimensions and alters the image") {
+      val out = image.filter(VesperFilter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `vesper` filter (`VesperFilter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)