### PR TITLE
Add clean-room Instagram xpro-ii filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/Xpro2Filter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/Xpro2Filter.java
@@ -1,0 +1,15 @@
+package com.sksamuel.scrimage.filter.instagram;
+
+import java.util.Arrays;
+
+import static com.sksamuel.scrimage.filter.instagram.CssFilters.*;
+
+/**
+ * Clean-room implementation of the Instagram "xpro_ii" filter:
+ * sepia(.45) contrast(1.25) brightness(1.75) saturate(1.3) hue-rotate(-5deg) + radial rgba(0,91,154,.35)->rgba(0,0,0,.65) multiply.
+ */
+public class Xpro2Filter extends InstagramFilter {
+   public Xpro2Filter() {
+      super(Arrays.asList(sepia(0.45f), contrast(1.25f), brightness(1.75f), saturate(1.3f), hueRotate(-5f)), Overlay.radial(BlendMode.MULTIPLY, 0f, 0, 91, 154, 0.35f, 1f, 0, 0, 0, 0.65f));
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/ExampleGenerator.kt
@@ -190,7 +190,8 @@ object ExampleGenerator {
       "watermark" to { _, _ -> WatermarkFilter("watermark", 50, 200, font, true, 0.5, Color.WHITE) },
       "watermark_cover" to { _, _ -> WatermarkCoverFilter("watermark", font, true, 0.2, Color.WHITE) },
       "watermark_stamp" to { _, s -> WatermarkStampFilter("watermark", FontUtils.createFont(Font.SANS_SERIF, s.width / 10), true, 0.2, Color.WHITE) },
-      "willow" to { _, _ -> WillowFilter() }
+      "willow" to { _, _ -> WillowFilter() },
+      "xpro_ii" to { _, _ -> Xpro2Filter() }
    ).sortedBy { it.first }
 
    @JvmStatic

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/Xpro2FilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/instagram/Xpro2FilterTest.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.scrimage.filter.instagram
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class Xpro2FilterTest : FunSpec({
+   val image = ImmutableImage.fromResource("/bird.jpg").scaleToWidth(120)
+   test("xpro_ii preserves the image dimensions and alters the image") {
+      val out = image.filter(Xpro2Filter())
+      out.width shouldBe image.width
+      out.height shouldBe image.height
+      out shouldNotBe image
+   }
+})


### PR DESCRIPTION
Adds the clean-room Instagram `xpro-ii` filter (`Xpro2Filter`) built on the instagram engine, with a unit test. Example-generator wiring will follow in a single examples PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)