### PR TITLE
Add autocrop fuzziness (colorTolerance) overload

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -426,6 +426,19 @@ public class ImmutableImage extends MutableImage {
    }
 
    /**
+    * Crops the image by removing borders of the default (transparent) colour,
+    * tolerating up to {@code colorTolerance} drift per channel from the base
+    * colour (the "fuzziness"). For example a tolerance of 1 treats a channel
+    * value of 254 as matching a base of 255.
+    *
+    * @param colorTolerance the per-channel tolerance to allow [0..255]
+    * @return a new cropped Image with the matching rows and columns removed
+    */
+   public ImmutableImage autocrop(int colorTolerance) {
+      return autocrop(Colors.Transparent.awt(), colorTolerance);
+   }
+
+   /**
     * Crops an image by removing cols and rows that are composed only of a single
     * given color.
     * <p>

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/AutocropFuzzinessTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/AutocropFuzzinessTest.kt
@@ -1,0 +1,57 @@
+package com.sksamuel.scrimage
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Verifies the per-channel "fuzziness" tolerance of autocrop: a border colour
+ * that drifts from the base colour by up to the tolerance (per channel) is
+ * still cropped.
+ */
+class AutocropFuzzinessTest : FunSpec({
+
+   // 6x6 image: a 1px border of [border], a different interior.
+   fun bordered(border: Color, interior: Color): ImmutableImage =
+      ImmutableImage.create(6, 6).map { p ->
+         if (p.x == 0 || p.y == 0 || p.x == 5 || p.y == 5) border else interior
+      }
+
+   test("zero tolerance does not crop a border that is near but not exactly the base colour") {
+      val img = bordered(Color(250, 250, 250), Color(0, 0, 255))
+      val out = img.autocrop(Color.WHITE, 0)
+      out.width shouldBe 6
+      out.height shouldBe 6
+   }
+
+   test("a per-channel drift within the tolerance is cropped") {
+      // border is 250 on every channel; base is 255; drift of 5 per channel
+      val img = bordered(Color(250, 250, 250), Color(0, 0, 255))
+      val out = img.autocrop(Color.WHITE, 5)
+      out.width shouldBe 4
+      out.height shouldBe 4
+   }
+
+   test("a per-channel drift larger than the tolerance is not cropped") {
+      val img = bordered(Color(250, 250, 250), Color(0, 0, 255))
+      val out = img.autocrop(Color.WHITE, 4) // drift is 5, tolerance only 4
+      out.width shouldBe 6
+      out.height shouldBe 6
+   }
+
+   test("tolerance of 1 treats 254 as matching a base of 255") {
+      val img = bordered(Color(254, 254, 254), Color(0, 0, 0))
+      img.autocrop(Color.WHITE, 0).width shouldBe 6   // 254 != 255 exactly
+      img.autocrop(Color.WHITE, 1).width shouldBe 4   // 254 within 255 +/- 1
+   }
+
+   test("autocrop(tolerance) delegates to the default transparent background") {
+      // border fully transparent, interior opaque red
+      val img = ImmutableImage.create(6, 6).map { p ->
+         if (p.x == 0 || p.y == 0 || p.x == 5 || p.y == 5) Color(0, 0, 0, 0) else Color(255, 0, 0, 255)
+      }
+      val out = img.autocrop(0)
+      out.width shouldBe 4
+      out.height shouldBe 4
+   }
+})


### PR DESCRIPTION
`autocrop`'s per-channel **fuzziness** — how far each channel may drift from the base colour (e.g. a tolerance of 1 treats a channel value of 254 as matching a base of 255) — was already implemented via `PixelTools.approx`, but only reachable through `autocrop(Color, int colorTolerance)`.

This adds the missing **`autocrop(int colorTolerance)`** overload, which applies the tolerance against the default transparent background (so you can crop with fuzziness without specifying the colour).

Tests (`AutocropFuzzinessTest`) cover: zero-tolerance requires an exact match; a per-channel drift within tolerance is cropped; a drift beyond tolerance is not; tolerance 1 treats 254 as matching 255; and the new overload delegates to the transparent background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)