### PR TITLE
Add missing @Override to AwtImage.equals(Object)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -588,6 +588,7 @@ public class AwtImage {
       return 31 * result + Arrays.hashCode(argb);
    }
 
+   @Override
    public boolean equals(Object other) {
       if (other instanceof AwtImage) {
          AwtImage that = (AwtImage) other;


### PR DESCRIPTION
## Problem

`AwtImage.equals(Object other)` overrides `Object.equals` but lacks the `@Override` annotation, unlike the adjacent `hashCode()` and `toString()` methods which both have it.

## Fix

Add `@Override` above the `equals` declaration. This lets the compiler verify the override and keeps annotation usage consistent across the class.

Purely an annotation addition; no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)