### PR TITLE
Dispose Graphics2D in try/finally in BackgroundBlendFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BackgroundBlendFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/BackgroundBlendFilter.java
@@ -13,8 +13,11 @@ public class BackgroundBlendFilter implements Filter {
     public void apply(ImmutableImage image) {
         ImmutableImage background = image.fill(new RGBColor(51, 0, 0, 255).toAWT());
         Graphics2D g = (Graphics2D) image.awt().getGraphics();
-        g.setComposite(BlendComposite.getInstance(BlendingMode.ADD, 1f));
-        g.drawImage(background.awt(), 0, 0, null);
-        g.dispose();
+        try {
+            g.setComposite(BlendComposite.getInstance(BlendingMode.ADD, 1f));
+            g.drawImage(background.awt(), 0, 0, null);
+        } finally {
+            g.dispose();
+        }
     }
 }


### PR DESCRIPTION
## Problem

In `BackgroundBlendFilter.apply`, the `Graphics2D` obtained from `image.awt().getGraphics()` was disposed unconditionally after `setComposite(...)` and `drawImage(...)`:

```java
Graphics2D g = (Graphics2D) image.awt().getGraphics();
g.setComposite(BlendComposite.getInstance(BlendingMode.ADD, 1f));
g.drawImage(background.awt(), 0, 0, null);
g.dispose();
```

If `setComposite` or `drawImage` throws, `g.dispose()` is skipped and the native graphics context leaks.

## Fix

Wrap the drawing in `try { ... } finally { g.dispose(); }`, matching every other filter in this package (BorderFilter, ColorizeFilter, VintageFilter, WatermarkFilter, etc.).

This is a pure resource-safety fix with no behaviour change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)