### PR TITLE
Dispose javax ImageWriter via finally spanning all uses in GifWriter.write

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifWriter.java
@@ -45,19 +45,25 @@ public class GifWriter implements ImageWriter {
     public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
 
         javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName("gif").next();
-        ImageWriteParam params = writer.getDefaultWriteParam();
+        // dispose() in a finally that spans every use of the writer. Acquiring it
+        // here but only disposing inside the write try-block leaked the native
+        // GIF writer if anything in between threw — e.g. getDefaultWriteParam()
+        // or setProgressiveMode() raising a RuntimeException from a writer plugin.
+        try {
+            ImageWriteParam params = writer.getDefaultWriteParam();
 
-        if (params.canWriteProgressive()) {
-          if (progressive) {
-              params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
-          } else {
-              params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
-          }
-        }
+            if (params.canWriteProgressive()) {
+                if (progressive) {
+                    params.setProgressiveMode(ImageWriteParam.MODE_DEFAULT);
+                } else {
+                    params.setProgressiveMode(ImageWriteParam.MODE_DISABLED);
+                }
+            }
 
-        try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {
-            writer.setOutput(output);
-            writer.write(null, new IIOImage(image.awt(), null, null), params);
+            try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(out)) {
+                writer.setOutput(output);
+                writer.write(null, new IIOImage(image.awt(), null, null), params);
+            }
         } finally {
             writer.dispose();
         }


### PR DESCRIPTION
## Problem

In `GifWriter.write()`, the native `javax.imageio.ImageWriter` was acquired, then `getDefaultWriteParam()`, `canWriteProgressive()` and `setProgressiveMode()` ran **outside** the try/finally that disposes the writer (the original try began only at the `MemoryCacheImageOutputStream` line).

If any of those param calls threw a `RuntimeException` (e.g. from a writer plugin), `writer.dispose()` was never called and the native GIF writer's resources leaked.

## Fix

Move the `try {` to immediately after `ImageWriter writer = ...next();` so the outermost `finally { writer.dispose(); }` spans every use of the writer. This mirrors the fixes already applied to `JpegWriter.write` and `PngWriter.write`.

Pure resource-leak hardening — no behavior change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)