### PR TITLE
Validate null interpolation hint in ProgressiveScale.scale

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ProgressiveScale.java
@@ -31,6 +31,13 @@ public class ProgressiveScale {
          throw new IllegalArgumentException("target dimensions must be positive, got "
             + targetWidth + "x" + targetHeight);
 
+      // setRenderingHint(KEY_INTERPOLATION, null) throws an opaque
+      // IllegalArgumentException from deep inside AWT, only after we have
+      // already allocated intermediate BufferedImages. Fail fast with a
+      // clear message instead.
+      if (interpolation == null)
+         throw new IllegalArgumentException("interpolation hint must not be null");
+
       int type = getType(image);
       BufferedImage temp = image;
       int w = image.getWidth();


### PR DESCRIPTION
## Problem

`ProgressiveScale.scale(image, targetWidth, targetHeight, interpolation)` passes the `interpolation` argument straight into `g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation)`.

If a caller passes `null`, `setRenderingHint` throws an opaque `IllegalArgumentException` from deep inside AWT with no context about which argument was bad — and only *after* the method has already entered the progressive loop and allocated intermediate `BufferedImage`s.

## Fix

Add an explicit up-front null check that fails fast with a clear diagnostic:

```java
if (interpolation == null)
   throw new IllegalArgumentException("interpolation hint must not be null");
```

This mirrors the validation style already used for the target dimensions just above it. No public API change — same method signature, same behaviour for all valid inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)