### PR TITLE
perf: collect polygon x/y arrays in a single pass in Polygon.draw

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Polygon.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Polygon.java
@@ -31,9 +31,16 @@ public class Polygon implements Drawable {
 
    @Override
    public void draw(RichGraphics2D g) {
-      int[] xs = points.stream().mapToInt(p -> p.x).toArray();
-      int[] ys = points.stream().mapToInt(p -> p.y).toArray();
-      g.drawPolygon(xs, ys, points.size());
+      int n = points.size();
+      int[] xs = new int[n];
+      int[] ys = new int[n];
+      int i = 0;
+      for (java.awt.Point p : points) {
+         xs[i] = p.x;
+         ys[i] = p.y;
+         i++;
+      }
+      g.drawPolygon(xs, ys, n);
    }
 
    public FilledPolygon toFilled() {


### PR DESCRIPTION
## Problem

`Polygon.draw` streamed the `points` list twice to build the coordinate arrays:

```java
int[] xs = points.stream().mapToInt(p -> p.x).toArray();
int[] ys = points.stream().mapToInt(p -> p.y).toArray();
g.drawPolygon(xs, ys, points.size());
```

Each `stream().mapToInt(...).toArray()` call allocates an `IntStream` pipeline plus a boxing spliterator/iterator and iterates the full list, so the points are traversed twice.

## Fix

Replace the two stream passes with a single enhanced-for loop that fills both `xs` and `ys` in one traversal:

```java
int n = points.size();
int[] xs = new int[n];
int[] ys = new int[n];
int i = 0;
for (java.awt.Point p : points) {
   xs[i] = p.x;
   ys[i] = p.y;
   i++;
}
g.drawPolygon(xs, ys, n);
```

This halves the list traversals and drops the stream/boxing overhead. Using an enhanced-for (rather than indexed `get(i)`) keeps it O(n) for any `List` implementation, matching the original streaming behaviour. Output is identical.

The same two-pass pattern exists in `FilledPolygon.java` and `Polyline.java`; this PR scopes to the named primary file only.

Compiles via `./gradlew :scrimage-core:compileJava`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)