### PR TITLE
Avoid redundant RGBColor allocation in HSVColor.toRGB()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
@@ -1,5 +1,7 @@
 package com.sksamuel.scrimage.color;
 
+import com.sksamuel.scrimage.pixels.PixelTools;
+
 /**
  * Hue/Saturation/Value
  * <p>
@@ -33,8 +35,7 @@ public class HSVColor implements Color {
 
    public RGBColor toRGB() {
       int rgb = java.awt.Color.HSBtoRGB(hue / 360f, saturation, value);
-      RGBColor noAlpha = RGBColor.fromRGBInt(rgb);
-      return new RGBColor(noAlpha.red, noAlpha.green, noAlpha.blue, Math.round(alpha * 255));
+      return new RGBColor(PixelTools.red(rgb), PixelTools.green(rgb), PixelTools.blue(rgb), Math.round(alpha * 255));
    }
 
    @Override


### PR DESCRIPTION
## Problem

`HSVColor.toRGB()` built an intermediate `RGBColor` via `RGBColor.fromRGBInt(rgb)` solely to read its `red`/`green`/`blue` fields, then allocated a second `RGBColor` carrying the real alpha. The first object was immediately discarded, wasting one `RGBColor` allocation per conversion.

## Fix

Extract the channels directly from the packed int using `PixelTools.red/green/blue` (which is exactly what `fromRGBInt` does internally) and construct the final `RGBColor` once:

```java
int rgb = java.awt.Color.HSBtoRGB(hue / 360f, saturation, value);
return new RGBColor(PixelTools.red(rgb), PixelTools.green(rgb), PixelTools.blue(rgb), Math.round(alpha * 255));
```

Behaviour is identical (same channel extraction, same alpha rounding); one object allocation per call is removed.

Compiles via `./gradlew :scrimage-core:compileJava`.