### PR TITLE
Defer alpha rounding past zero-alpha early return in LinearSubpixelInterpolator

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/subpixel/LinearSubpixelInterpolator.java
@@ -90,9 +90,9 @@ public class LinearSubpixelInterpolator implements SubpixelInterpolator {
 
         // Un-premultiply: divide the alpha-weighted colour sums by the summed
         // alpha-weight. When the combined alpha is zero the result is fully clear.
-        int alpha = (int) Math.round(sumA);
         if (sumA == 0)
             return PixelTools.argb(0, 0, 0, 0);
+        int alpha = (int) Math.round(sumA);
         return PixelTools.argb(
                 alpha,
                 (int) Math.round(sumR / sumA),


### PR DESCRIPTION
## Problem

In `LinearSubpixelInterpolator.subpixel()`, the alpha value was rounded:

```java
int alpha = (int) Math.round(sumA);
if (sumA == 0)
    return PixelTools.argb(0, 0, 0, 0);
```

The `Math.round(sumA)` was computed *before* the `if (sumA == 0)` early return. When the accumulated alpha is zero (a fully transparent neighbourhood), the rounded value is discarded by the early return, making the rounding wasted work in this per-subpixel hot path.

## Fix

Move the `int alpha = (int) Math.round(sumA)` computation below the zero check so it is only evaluated on the non-zero path. This is a tiny, behaviour-preserving micro-cleanup: when `sumA == 0` we return the fully-clear pixel without rounding; on the non-zero path the same `alpha` is used as before.

No public API change, no behavioural change. `:scrimage-core:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)