### PR TITLE
Dispose GIF ImageWriter if metadata setup throws in GifSequenceWriter.bytes

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
@@ -63,33 +63,35 @@ public class GifSequenceWriter extends AbstractGifWriter {
    public byte[] bytes(ImmutableImage[] images) throws IOException {
 
       ImageWriter writer = ImageIO.getImageWritersBySuffix("gif").next();
-      ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();
+      try {
+         ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();
 
-      ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromBufferedImageType(images[0].awt().getType());
-      IIOMetadata imageMetaData = writer.getDefaultImageMetadata(imageTypeSpecifier, imageWriteParam);
+         ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromBufferedImageType(images[0].awt().getType());
+         IIOMetadata imageMetaData = writer.getDefaultImageMetadata(imageTypeSpecifier, imageWriteParam);
 
-      String metaFormatName = imageMetaData.getNativeMetadataFormatName();
+         String metaFormatName = imageMetaData.getNativeMetadataFormatName();
 
-      IIOMetadataNode root = (IIOMetadataNode) imageMetaData.getAsTree(metaFormatName);
-      populateGraphicsControlNode(root, Duration.ofMillis(frameDelayMillis));
-      populateCommentsNode(root);
-      if (infiniteLoop)
-         populateApplicationExtensions(root, infiniteLoop);
+         IIOMetadataNode root = (IIOMetadataNode) imageMetaData.getAsTree(metaFormatName);
+         populateGraphicsControlNode(root, Duration.ofMillis(frameDelayMillis));
+         populateCommentsNode(root);
+         if (infiniteLoop)
+            populateApplicationExtensions(root, infiniteLoop);
 
-      imageMetaData.setFromTree(metaFormatName, root);
+         imageMetaData.setFromTree(metaFormatName, root);
 
-      try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-         try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos)) {
-            writer.setOutput(output);
-            writer.prepareWriteSequence(null);
+         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos)) {
+               writer.setOutput(output);
+               writer.prepareWriteSequence(null);
 
-            for (ImmutableImage image : images) {
-               writer.writeToSequence(new IIOImage(image.awt(), null, imageMetaData), imageWriteParam);
+               for (ImmutableImage image : images) {
+                  writer.writeToSequence(new IIOImage(image.awt(), null, imageMetaData), imageWriteParam);
+               }
+
+               writer.endWriteSequence();
+               output.flush();
+               return baos.toByteArray();
             }
-
-            writer.endWriteSequence();
-            output.flush();
-            return baos.toByteArray();
          }
       } finally {
          writer.dispose();


### PR DESCRIPTION
## Problem

In `GifSequenceWriter.bytes(ImmutableImage[])`, the native `javax.imageio.ImageWriter` is acquired up front, but the `try`/`finally` that calls `writer.dispose()` only began after all the metadata setup. The intervening steps — `getDefaultImageMetadata`, `getAsTree`, the `populate*` node manipulation, and notably `imageMetaData.setFromTree` (documented to throw `IIOInvalidTreeException`) — ran outside that protection. If any of them threw, `writer.dispose()` was never reached and the native GIF writer leaked.

## Fix

Move the `try {` to immediately after the writer is acquired, so the existing `finally { writer.dispose(); }` now also covers the metadata setup. The inner try-with-resources for `baos`/`output` is unchanged, and the success-path behaviour is identical.

`./gradlew :scrimage-core:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)