### PR TITLE
Avoid per-call ExifIFD0Directory allocation in OrientationTools

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/OrientationTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/metadata/OrientationTools.java
@@ -1,6 +1,5 @@
 package com.sksamuel.scrimage.metadata;
 
-import com.drew.metadata.exif.ExifIFD0Directory;
 import com.sksamuel.scrimage.ImmutableImage;
 
 import java.util.Arrays;
@@ -9,6 +8,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class OrientationTools {
+
+   // ExifIFD0Directory.getName() always returns this literal constant. Hold it as a
+   // static final value rather than allocating a new ExifIFD0Directory (and its
+   // descriptor) on every imageOrientationsOf call just to read the name.
+   private static final String EXIF_IFD0_DIR_NAME = "Exif IFD0";
 
    public static Boolean requiresReorientation(ImageMetadata metadata) {
 
@@ -59,10 +63,8 @@ public class OrientationTools {
    // check the name, if there is more than one.
    static Set<Orientation> imageOrientationsOf(ImageMetadata metadata) {
 
-      String exifIFD0DirName = new ExifIFD0Directory().getName();
-
       Tag[] tags = Arrays.stream(metadata.getDirectories())
-         .filter(dir -> dir.getName().equals(exifIFD0DirName))
+         .filter(dir -> dir.getName().equals(EXIF_IFD0_DIR_NAME))
          .findFirst()
          .map(Directory::getTags)
          .orElseGet(() -> new Tag[0]);


### PR DESCRIPTION
## Problem

`OrientationTools.imageOrientationsOf` obtained the EXIF IFD0 directory name via:

```java
String exifIFD0DirName = new ExifIFD0Directory().getName();
```

`ExifIFD0Directory.getName()` simply returns the literal constant `"Exif IFD0"` (verified against metadata-extractor 2.20.0 bytecode — `getName` just `ldc`s the constant and returns it). However, the `new ExifIFD0Directory()` constructor allocates the `Directory` and a new `ExifIFD0Descriptor` on every call.

This method runs from `getOrientation()`, `requiresReorientation()` and `reorient()`, so the allocation happens on a path that is hit per image (and during batch processing, per image processed).

## Fix

Replace the per-call allocation with a `private static final` constant holding the same value, and drop the now-unused import:

```java
private static final String EXIF_IFD0_DIR_NAME = "Exif IFD0";
```

Same value, no allocation. Behaviour is identical.

## Testing

- `./gradlew :scrimage-core:compileJava` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)