### PR TITLE
Replace assert with explicit length validation in create(w,h,Pixel[],type)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -364,7 +364,8 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image
     */
    public static ImmutableImage create(int w, int h, Pixel[] pixels, int type) {
-      assert w * h == pixels.length;
+      if (pixels.length != (long) w * h)
+         throw new IllegalArgumentException("pixels array length " + pixels.length + " does not match " + w + "x" + h + " = " + ((long) w * h));
       ImmutableImage image = ImmutableImage.create(w, h, type);
       int[] argb = new int[pixels.length];
       for (int i = 0; i < pixels.length; i++) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CreateFromPixelsValidationTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CreateFromPixelsValidationTest.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * ImmutableImage.create(w, h, pixels[, type]) used a bare `assert` to check
+ * that the pixel array length matched w*h. Assertions are disabled by default,
+ * so a mismatch would either throw an opaque ArrayIndexOutOfBoundsException
+ * (array too short) or silently drop trailing pixels (array too long).
+ * It now validates explicitly with a clear IllegalArgumentException.
+ */
+class CreateFromPixelsValidationTest : FunSpec({
+
+   fun pixelsOfLength(n: Int): Array<Pixel> =
+      Array(n) { Pixel(0, 0, 0xFF000000.toInt()) }
+
+   test("create succeeds when length matches w*h") {
+      val img = ImmutableImage.create(2, 3, pixelsOfLength(6))
+      img.width shouldBe 2
+      img.height shouldBe 3
+   }
+
+   test("create rejects a too-short pixel array with a clear message") {
+      val e = shouldThrow<IllegalArgumentException> {
+         ImmutableImage.create(2, 3, pixelsOfLength(5))
+      }
+      e.message shouldContain "5"
+      e.message shouldContain "2x3"
+   }
+
+   test("create rejects a too-long pixel array instead of silently dropping pixels") {
+      shouldThrow<IllegalArgumentException> {
+         ImmutableImage.create(2, 3, pixelsOfLength(7))
+      }
+   }
+})


### PR DESCRIPTION
## Problem

`ImmutableImage.create(int w, int h, Pixel[] pixels, int type)` validated the pixel-array length with a bare assertion:

```java
assert w * h == pixels.length;
```

Java assertions are disabled by default (no `-ea`), so in production this check does nothing. A mismatched array then falls through to `image.awt().setRGB(0, 0, w, h, argb, 0, w)`:

- **Too-short array** → opaque `ArrayIndexOutOfBoundsException` deep inside `setRGB`, with no indication of the real cause.
- **Too-long array** → silently succeeds, dropping the trailing pixels.

Additionally `w * h` is computed in `int` arithmetic, so for very large dimensions it can overflow and falsely match `pixels.length`.

## Fix

Replace the assert with an explicit guard that always runs and gives a clear message, computing the product as `long` to avoid overflow:

```java
if (pixels.length != (long) w * h)
   throw new IllegalArgumentException("pixels array length " + pixels.length + " does not match " + w + "x" + h + " = " + ((long) w * h));
```

No public API change. Valid callers are unaffected; invalid callers now get a meaningful exception instead of an obscure one (or silent data loss).

## Test

Added `CreateFromPixelsValidationTest` covering the matching case plus the too-short and too-long rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)