### PR TITLE
Replace disabled-by-default assert range checks in CMYKColor with explicit validation

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
@@ -13,17 +13,26 @@ public class CMYKColor implements Color {
     }
 
     public CMYKColor(float c, float m, float y, float k, float alpha) {
-        assert (0 <= c && c <= 1f);
-        assert (0 <= m && m <= 1f);
-        assert (0 <= y && y <= 1f);
-        assert (0 <= k && k <= 1f);
-        assert (0 <= alpha && alpha <= 1f);
+        // Validate explicitly rather than with `assert`, which is disabled by
+        // default in production JVMs (so out-of-range values would slip through
+        // and produce wrong colours in toRGB()).
+        requireInRange("c", c);
+        requireInRange("m", m);
+        requireInRange("y", y);
+        requireInRange("k", k);
+        requireInRange("alpha", alpha);
 
         this.c = c;
         this.m = m;
         this.y = y;
         this.k = k;
         this.alpha = alpha;
+    }
+
+    private static void requireInRange(String component, float value) {
+        if (value < 0 || value > 1f)
+            throw new IllegalArgumentException(
+                "CMYKColor " + component + " component must be in [0, 1] but was " + value);
     }
 
     public CMYKColor toCMYK() {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/CMYKColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/CMYKColorTest.kt
@@ -1,0 +1,27 @@
+package com.sksamuel.scrimage.core.color
+
+import com.sksamuel.scrimage.color.CMYKColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class CMYKColorTest : StringSpec({
+
+   "valid components in [0, 1] are accepted" {
+      val color = CMYKColor(0.0f, 0.5f, 1.0f, 0.25f, 0.75f)
+      color.c shouldBe 0.0f
+      color.m shouldBe 0.5f
+      color.y shouldBe 1.0f
+      color.k shouldBe 0.25f
+      color.alpha shouldBe 0.75f
+   }
+
+   "out-of-range components are rejected with IllegalArgumentException" {
+      shouldThrow<IllegalArgumentException> { CMYKColor(-0.1f, 0f, 0f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(1.1f, 0f, 0f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, -0.1f, 0f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 1.1f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, -0.1f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, 0f, 1.1f) }
+   }
+})


### PR DESCRIPTION
## Problem

The `CMYKColor(float c, float m, float y, float k, float alpha)` constructor validated each component with `assert`:

```java
assert (0 <= c && c <= 1f);
...
```

Java assertions are **disabled by default** in production JVMs (they require `-ea`). As a result these range checks effectively never run, so out-of-range component values pass through silently and produce wrong colours downstream in `toRGB()` rather than failing fast.

## Fix

Replace the five `assert` statements with explicit `IllegalArgumentException` checks via a small `requireInRange` helper that names the offending component (`c`/`m`/`y`/`k`/`alpha`) and reports the offending value. This mirrors the existing `RGBColor.requireInRange` pattern introduced in 30ac7fe9.

The constructor signature is unchanged.

## Test

Added `CMYKColorTest` (kotest) covering accepted in-range components and rejection of each out-of-range component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)