### PR TITLE
Replace disabled-by-default assert range checks in HSLColor with explicit validation

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
@@ -16,14 +16,26 @@ public class HSLColor implements Color {
     public final float alpha;
 
     public HSLColor(float hue, float saturation, float lightness, float alpha) {
-        assert (0 <= hue && hue <= 360F);
-        assert (0 <= saturation && saturation <= 1f);
-        assert (0 <= lightness && lightness <= 1f);
-        assert (0 <= alpha && alpha <= 1f);
+
+        // Validate at runtime rather than via assert (disabled by default in
+        // production JVMs). An out-of-range component would otherwise be stored
+        // unchecked and silently produce a wrong colour when converted via
+        // toRGB(), instead of failing fast on the bad input.
+        requireInRange("hue", hue, 360f);
+        requireInRange("saturation", saturation, 1f);
+        requireInRange("lightness", lightness, 1f);
+        requireInRange("alpha", alpha, 1f);
+
         this.hue = hue;
         this.saturation = saturation;
         this.lightness = lightness;
         this.alpha = alpha;
+    }
+
+    private static void requireInRange(String component, float value, float bound) {
+        if (value < 0 || value > bound)
+            throw new IllegalArgumentException(
+                    "HSLColor " + component + " must be in [0, " + bound + "] but was " + value);
     }
 
     public HSLColor toHSL() {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSLColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSLColorTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.scrimage.core.color
+
+import com.sksamuel.scrimage.color.HSLColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+
+class HSLColorTest : StringSpec({
+
+   // The constructor previously validated arguments with `assert`, which is
+   // disabled by default in production JVMs, allowing out-of-range components
+   // to be stored and silently produce wrong colours in toRGB(). It now fails
+   // fast with an IllegalArgumentException.
+
+   "accepts in-range components including boundaries" {
+      shouldNotThrowAny {
+         HSLColor(0f, 0f, 0f, 0f)
+         HSLColor(360f, 1f, 1f, 1f)
+         HSLColor(180f, 0.5f, 0.5f, 0.5f)
+      }
+   }
+
+   "rejects out-of-range hue" {
+      shouldThrow<IllegalArgumentException> { HSLColor(-1f, 0f, 0f, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(360.1f, 0f, 0f, 0f) }
+   }
+
+   "rejects out-of-range saturation" {
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, -0.1f, 0f, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 1.1f, 0f, 0f) }
+   }
+
+   "rejects out-of-range lightness" {
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, -0.1f, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 1.1f, 0f) }
+   }
+
+   "rejects out-of-range alpha" {
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 0f, -0.1f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 0f, 1.1f) }
+   }
+})


### PR DESCRIPTION
## Problem

The `HSLColor(float hue, float saturation, float lightness, float alpha)` constructor validated its arguments with Java `assert` statements:

```java
assert (0 <= hue && hue <= 360F);
assert (0 <= saturation && saturation <= 1f);
assert (0 <= lightness && lightness <= 1f);
assert (0 <= alpha && alpha <= 1f);
```

Java assertions are disabled by default in production JVMs (unless `-ea` is passed), so these checks never run in normal usage. An out-of-range component is therefore stored unchecked and silently produces a wrong colour when later converted via `toRGB()`, rather than failing fast.

## Fix

Replace the four asserts with explicit `IllegalArgumentException` validation via a small `requireInRange` helper (hue in [0, 360], saturation/lightness/alpha in [0, 1]). This matches the codebase's active pattern already used in `RGBColor` (lines 31-46) and the earlier `VignetteFilter` cleanup (30ac7fe9).

The constructor signature is unchanged. `RGBColor.toHSL()` — the only internal construction site — always passes in-range values, so there is no behaviour regression for valid input.

## Test

Added `HSLColorTest` covering in-range boundaries (accepted) and out-of-range values for each component (rejected with `IllegalArgumentException`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)