### PR TITLE
Reset ImageInputStream position between reader attempts in ImageIOReader

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
@@ -28,6 +28,16 @@ public class ImageIOReader implements ImageReader {
 
    private ImmutableImage tryLoad(javax.imageio.ImageReader reader, ImageInputStream iis, Rectangle rectangle) throws IOException {
       try {
+         // Rewind the stream to the start before each reader attempt. The same
+         // ImageInputStream is reused across multiple readers in read(...)'s
+         // fallback loop; a previous reader may have consumed/advanced the
+         // stream (or partially read before throwing), leaving the position
+         // past the start. Without seeking back, subsequent fallback readers
+         // would read from a consumed/garbage position and fail spuriously.
+         // The MemoryCacheImageInputStream created over a ByteArrayInputStream
+         // is seekable, and seek(0) is a no-op for the common single-reader
+         // success case.
+         iis.seek(0);
          reader.setInput(iis);
 
          // Skip a redundant header pass: setDestinationType(imageTypes.next())

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImageIOReaderFallbackTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImageIOReaderFallbackTest.kt
@@ -1,0 +1,52 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.ImageIOReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldNotBe
+import javax.imageio.ImageIO
+import javax.imageio.spi.ImageReaderSpi
+import javax.imageio.stream.ImageInputStream
+
+/**
+ * Verifies the multi-reader fallback path in ImageIOReader rewinds the shared
+ * ImageInputStream between attempts. A bad reader that consumes the stream and
+ * then fails must not prevent a subsequent good reader from decoding the full
+ * image data: tryLoad calls iis.seek(0) before each setInput.
+ */
+class ImageIOReaderFallbackTest : FunSpec({
+
+   val jpegBytes = javaClass.getResourceAsStream("/com/sksamuel/scrimage/bird.jpg")!!.readBytes()
+
+   // A reader that consumes part of the stream (advancing its position) and
+   // then throws, simulating a reader that partially reads before failing.
+   class ConsumingFailingReader(spi: ImageReaderSpi?) : javax.imageio.ImageReader(spi) {
+      override fun setInput(input: Any?, seekForwardOnly: Boolean, ignoreMetadata: Boolean) {
+         super.setInput(input, seekForwardOnly, ignoreMetadata)
+         // advance the underlying stream so a later reader, if not rewound,
+         // would read from a garbage position
+         (input as ImageInputStream).skipBytes(64)
+      }
+
+      override fun getNumImages(allowSearch: Boolean): Int = 1
+      override fun getWidth(imageIndex: Int): Int = throw java.io.IOException("boom")
+      override fun getHeight(imageIndex: Int): Int = throw java.io.IOException("boom")
+      override fun getImageTypes(imageIndex: Int) = throw java.io.IOException("boom")
+      override fun getStreamMetadata() = null
+      override fun getImageMetadata(imageIndex: Int) = null
+      override fun read(imageIndex: Int, param: javax.imageio.ImageReadParam?) =
+         throw java.io.IOException("boom: this reader cannot decode the image")
+   }
+
+   test("falls back to a working reader after a previous reader consumed the stream") {
+      val realReader = ImageIO.getImageReadersByFormatName("jpeg").next()
+      val readers = listOf(ConsumingFailingReader(null), realReader)
+
+      val image = ImageIOReader(readers).read(jpegBytes, null)
+      image shouldNotBe null
+      image.width shouldBeGreaterThan 0
+      image.height shouldBeGreaterThan 0
+   }
+})


### PR DESCRIPTION
## Problem

`ImageIOReader.read(byte[], Rectangle)` reuses a single `ImageInputStream` (`iis`) across multiple reader attempts in its fallback `while` loop — `tryLoad` is invoked for each reader from the iterator against the *same* stream.

When the first reader's `tryLoad` advances/consumes the stream (or partially reads before throwing), the next reader receives a stream whose position is no longer at the start. The subsequent fallback readers then read from a consumed/garbage position and fail spuriously. As a result the multi-reader fallback path never gets a fair chance to try each reader against the full image data.

## Fix

In `tryLoad`, call `iis.seek(0)` immediately before `reader.setInput(iis)`. The `MemoryCacheImageInputStream` returned by `ImageIO.createImageInputStream` over a `ByteArrayInputStream` is seekable, so rewinding to the start guarantees every reader sees the full image data.

Low risk: `seek(0)` is a no-op for the common single-reader success case (the stream is already at position 0).

## Test

Adds `ImageIOReaderFallbackTest`: a stub `ImageReader` that advances the shared stream and then throws, followed by a real JPEG reader. Without the fix the JPEG reader reads from the advanced position and fails; with the fix the stream is rewound and decoding succeeds. Verified the test fails on master and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)