### PR TITLE
Add missing @Override on OpacityFilter.apply

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/OpacityFilter.java
@@ -25,6 +25,7 @@ public class OpacityFilter implements Filter {
       this.amount = amount;
    }
 
+   @Override
    public void apply(ImmutableImage image) {
       int w = image.width;
       int h = image.height;


### PR DESCRIPTION
## Summary

`OpacityFilter` implements `Filter`, but its `public void apply(ImmutableImage image)` method was missing the `@Override` annotation that the rest of the filter package uses.

Adding `@Override`:
- Provides compile-time verification that the method correctly overrides `Filter.apply(ImmutableImage)`.
- Restores consistency with the other filters in the package.

No behaviour or signature change. The module compiles cleanly with the annotation in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)