### PR TITLE
Avoid per-pixel List iterator allocation in InstagramFilter.apply

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/InstagramFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/instagram/InstagramFilter.java
@@ -16,11 +16,11 @@ import java.util.List;
  */
 public abstract class InstagramFilter implements Filter {
 
-   private final List<CssOp> ops;
+   private final CssOp[] ops;
    private final Overlay overlay;
 
    protected InstagramFilter(List<CssOp> ops, Overlay overlay) {
-      this.ops = ops;
+      this.ops = ops.toArray(new CssOp[0]);
       this.overlay = overlay;
    }
 
@@ -45,8 +45,8 @@ public abstract class InstagramFilter implements Filter {
          rgb[0] = ((argb >> 16) & 0xff) / 255f;
          rgb[1] = ((argb >> 8) & 0xff) / 255f;
          rgb[2] = (argb & 0xff) / 255f;
-         for (CssOp op : ops) {
-            op.apply(rgb);
+         for (int j = 0; j < ops.length; j++) {
+            ops[j].apply(rgb);
          }
          px[i] = (al << 24) | (to8(rgb[0]) << 16) | (to8(rgb[1]) << 8) | to8(rgb[2]);
       }


### PR DESCRIPTION
## Summary

`InstagramFilter.apply()` ran `for (CssOp op : ops)` inside the per-pixel loop, where `ops` was a private `List<CssOp>` field. Enhanced-for over a `List` allocates a fresh `Iterator` on **every pixel** — roughly 12M Iterator allocations for a 4000x3000 image. Since `InstagramFilter` is the base class backing all ~50 Instagram filters, this hits every one of them.

## Change

- Store `ops` as a `CssOp[]` (converted once via `ops.toArray(new CssOp[0])` in the constructor).
- Iterate by index in the hot loop instead of via an iterator.

No public API change: the constructor still accepts `List<CssOp>`; only the private field type and iteration change. Behaviour is identical — ops are applied in order, in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)