### PR TITLE
Add missing @Override on GrayscaleFilter.apply

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GrayscaleFilter.java
@@ -19,6 +19,7 @@ import com.sksamuel.scrimage.ImmutableImage;
 
 public class GrayscaleFilter implements Filter {
 
+   @Override
    public void apply(ImmutableImage image) {
       int w = image.width;
       int h = image.height;


### PR DESCRIPTION
## Summary

`GrayscaleFilter` implements `Filter`, which declares `void apply(ImmutableImage)`, but its `apply` method was missing the `@Override` annotation.

This adds `@Override`, a zero-risk, no-API-change improvement that:
- documents that the method overrides the interface contract, and
- lets the compiler catch any future signature drift from `Filter`.

Most sibling filters (e.g. `BorderFilter`, `ColorizeFilter`, `CaptionFilter`) already annotate `apply()`, so this brings `GrayscaleFilter` in line.

## Testing

`./gradlew :scrimage-filters:compileJava` succeeds. Behaviour is unchanged; no test needed for a pure annotation addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)