### PR TITLE
Add missing @Override on AwtNearestNeighbourScale.scale

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
@@ -4,6 +4,7 @@ import java.awt.image.BufferedImage;
 
 public class AwtNearestNeighbourScale implements Scale {
 
+   @Override
    public BufferedImage scale(BufferedImage in, int w, int h) {
       // Bulk getRGB → manual nearest-neighbour map → bulk setRGB. The
       // previous Graphics2D.drawImage path with NEAREST_NEIGHBOR composited


### PR DESCRIPTION
`AwtNearestNeighbourScale.scale(BufferedImage, int, int)` implements the `Scale.scale` interface method but was missing the `@Override` annotation. The sibling implementation `ScrimageNearestNeighbourScale` already annotates its `scale()` with `@Override`.

This is a zero-risk, behaviour-preserving consistency fix. The `@Override` annotation lets the compiler catch any future drift between the implementation and the `Scale` interface signature.

Compiles cleanly via `./gradlew :scrimage-core:compileJava`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)