### PR TITLE
Use bulk getRGB/setRGB pass in SaltAndPepperFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SaltAndPepperFilter.java
@@ -1,7 +1,6 @@
 package com.sksamuel.scrimage.filter;
 
 import com.sksamuel.scrimage.ImmutableImage;
-import com.sksamuel.scrimage.color.RGBColor;
 
 public class SaltAndPepperFilter implements Filter {
 
@@ -28,15 +27,17 @@ public class SaltAndPepperFilter implements Filter {
       // of being salt of (1 - pepper) * salt rather than the
       // documented `salt` — e.g. SaltAndPepperFilter(0.5, 0.5)
       // produced 50% pepper but only 25% salt.
-      for (int i = 0; i < img.width; i++) {
-         for (int j = 0; j < img.height; j++) {
-            double r = Math.random();
-            if (r < pepper) {
-               img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_BLACK));
-            } else if (r < pepper + salt) {
-               img.setColor(i, j, RGBColor.fromARGBInt(OPAQUE_WHITE));
-            }
+      int w = img.width;
+      int h = img.height;
+      int[] argb = img.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         double r = Math.random();
+         if (r < pepper) {
+            argb[i] = OPAQUE_BLACK;
+         } else if (r < pepper + salt) {
+            argb[i] = OPAQUE_WHITE;
          }
       }
+      img.awt().setRGB(0, 0, w, h, argb, 0, w);
    }
 }


### PR DESCRIPTION
## What

`SaltAndPepperFilter.apply()` looped over every pixel and, for matched pixels, called `img.setColor(i, j, RGBColor.fromARGBInt(...))` — a per-pixel `BufferedImage` write plus an `RGBColor` wrapper allocation each time.

This replaces that with the bulk pattern already used across the package (`GrayscaleFilter`, `OpacityFilter`, `BlackThresholdFilter`, `ErrorSpotterFilter`, `AlphaMaskFilter`):

- one `getRGB(0, 0, w, h, null, 0, w)` bulk read into an `int[]`
- an in-place loop writing the packed `OPAQUE_BLACK` / `OPAQUE_WHITE` constants directly (no `RGBColor` allocation)
- one `setRGB` flush

## Behaviour

Each pixel's outcome is independent and randomized (single `Math.random()` draw partitioned across pepper/salt), so iterating row-major over the flat array instead of column-major over (i,j) does not change the output distribution. The unused `RGBColor` import was removed.

## Testing

`./gradlew :scrimage-filters:compileJava` passes. Pure perf/quality change, no behavioural change, so no new test added.