### PR TITLE
Replace StringBuilder insert-loop in Color.toHex() with a single zero-padded format

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -46,11 +46,7 @@ public interface Color {
     * @return the six-character uppercase hex representation of this colour
     */
    default String toHex() {
-      StringBuilder hex = new StringBuilder(Integer.toHexString(toRGB().toARGBInt() & 0xffffff).toUpperCase());
-      while (hex.length() < 6) {
-         hex.insert(0, "0");
-      }
-      return hex.toString();
+      return String.format("%06X", toRGB().toARGBInt() & 0xffffff);
    }
 
    default java.awt.Color awt() {


### PR DESCRIPTION
## Summary

`Color.toHex()` built the hex string by calling `Integer.toHexString`, uppercasing the result, then repeatedly inserting `"0"` at index 0 in a loop until the length reached 6.

Each `StringBuilder.insert(0, ...)` shifts the entire buffer, and the approach allocates an intermediate uppercase `String` plus a `StringBuilder`.

This replaces the whole thing with a single allocation:

```java
return String.format("%06X", toRGB().toARGBInt() & 0xffffff);
```

`%06X` produces a zero-padded, six-character uppercase hex string, which is correct for all values in `[0, 0xFFFFFF]`.

## Behaviour

Output is identical to before: six-character uppercase hex (e.g. `00FF00`). The `& 0xffffff` mask is unchanged, so the alpha byte is still dropped exactly as before. Pure quality/clarity change; no API change.

## Testing

`./gradlew :scrimage-core:compileJava` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)