### PR TITLE
Replace disabled-by-default assert with explicit null validation in createTrueType

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/FontUtils.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/FontUtils.java
@@ -19,7 +19,7 @@ public class FontUtils {
    }
 
    public static Font createTrueType(InputStream in, int size) throws IOException, FontFormatException {
-      assert (in != null);
+      if (in == null) throw new IllegalArgumentException("input stream must not be null");
       Font font = Font.createFont(Font.TRUETYPE_FONT, in);
       GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
       ge.registerFont(font);


### PR DESCRIPTION
## Summary

`FontUtils.createTrueType` used `assert (in != null)` to validate its `InputStream` argument. Java assertions are disabled by default in production JVMs, so this check is effectively a no-op: a null `in` falls straight into `Font.createFont(Font.TRUETYPE_FONT, in)`, which throws a bare `NullPointerException` with no message identifying the offending parameter.

This replaces the assert with an explicit `IllegalArgumentException` carrying a clear message, so callers get a meaningful failure regardless of JVM `-ea` settings.

## Rationale

This is the same proven pattern already applied elsewhere in the codebase, e.g. `RGBColor` ("Validate at runtime rather than via assert"). It is the only remaining un-fixed validation-assert in the non-excluded core/filters sources.

## Testing

- `./gradlew :scrimage-core:compileJava` passes.

Behaviour for valid (non-null) input is unchanged; only the null-argument failure mode is improved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)