### PR TITLE
Add missing @Override on MarvinFilter.apply

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/MarvinFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/MarvinFilter.java
@@ -31,6 +31,7 @@ abstract class MarvinFilter implements Filter {
 
   public abstract MarvinAbstractImagePlugin plugin();
 
+  @Override
   public void apply(ImmutableImage image) {
 
     MarvinImage input = new MarvinImage(image.awt());


### PR DESCRIPTION
## Summary

`MarvinFilter` implements `Filter` and provides a concrete `apply(ImmutableImage)` that overrides `Filter.apply(ImmutableImage)`, but it lacked the `@Override` annotation.

This change adds `@Override` to:
- Document the override intent.
- Enable compiler checking (so the override breaks loudly if the `Filter` contract ever changes).

`MarvinFilter` is the base class for all Marvin-delegating filters, so the annotation only needs to be added in this one place.

No behavior or signature change. `scrimage-filters:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)