### PR TITLE
Collapse two stream passes in FilledPolygon.draw into a single loop

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/FilledPolygon.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/FilledPolygon.java
@@ -18,9 +18,16 @@ public class FilledPolygon implements Drawable {
 
     @Override
     public void draw(RichGraphics2D g) {
-        int[] xs = points.stream().mapToInt(p -> p.x).toArray();
-        int[] ys = points.stream().mapToInt(p -> p.y).toArray();
-        g.fillPolygon(xs, ys, points.size());
+        int n = points.size();
+        int[] xs = new int[n];
+        int[] ys = new int[n];
+        int i = 0;
+        for (java.awt.Point p : points) {
+            xs[i] = p.x;
+            ys[i] = p.y;
+            i++;
+        }
+        g.fillPolygon(xs, ys, n);
     }
 
     public Polygon toOutline() {


### PR DESCRIPTION
## What

`FilledPolygon.draw` built two separate `IntStream` pipelines and iterated the points list twice:

```java
int[] xs = points.stream().mapToInt(p -> p.x).toArray();
int[] ys = points.stream().mapToInt(p -> p.y).toArray();
g.fillPolygon(xs, ys, points.size());
```

This allocates two stream pipelines plus boxed-lambda overhead and walks the list twice, then calls `points.size()` a third time.

## Change

Replace with a single iterator pass that fills both `xs` and `ys` arrays, reading `size()` exactly once:

```java
int n = points.size();
int[] xs = new int[n];
int[] ys = new int[n];
int i = 0;
for (java.awt.Point p : points) {
    xs[i] = p.x;
    ys[i] = p.y;
    i++;
}
g.fillPolygon(xs, ys, n);
```

An enhanced-for (iterator) pass is used rather than indexed `get(i)` so the loop stays O(n) for any `List` implementation passed to the public constructor (not just random-access lists).

## Impact

- Halves list traversal (one pass instead of two).
- Removes two stream-pipeline + boxed-lambda allocations.
- Evaluates `points.size()` once.
- Pure internal refactor: identical output, no API change.

Compiles via `./gradlew :scrimage-core:compileJava`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)