### PR TITLE
Add @Override to BufferedOpFilter.apply implementing Filter.apply

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/BufferedOpFilter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/BufferedOpFilter.java
@@ -13,6 +13,7 @@ public abstract class BufferedOpFilter implements Filter {
 
   public abstract BufferedImageOp op();
 
+  @Override
   public void apply(ImmutableImage image) {
     op().filter(image.awt(), image.awt());
   }


### PR DESCRIPTION
## Summary

`BufferedOpFilter.apply(ImmutableImage)` implements the `Filter` interface method `void apply(ImmutableImage image)` but lacked the `@Override` annotation. Every other `Filter` implementation in the codebase (`CaptionFilter`, `WatermarkFilter`, `BorderFilter`, etc.) annotates `apply` with `@Override`.

Adding `@Override` here is a zero-risk consistency fix that lets the compiler catch any future signature drift against the interface. Behaviour is unchanged.

## Testing

- `./gradlew :scrimage-core:compileJava` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)