### PR TITLE
Validate Grayscale gray/alpha range at construction (mirror RGBColor)

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Grayscale.java
@@ -10,10 +10,26 @@ public class Grayscale implements Color {
     }
 
     public Grayscale(int gray, int alpha) {
+
+        // Validate at runtime rather than via assert (disabled by default in
+        // production JVMs). An out-of-range value would otherwise be stored
+        // unchecked and only fail later inside toRGB() when wrapped in an
+        // RGBColor, turning a clear construction-site error into a confusing
+        // deferred failure. Mirrors the RGBColor validation pattern.
+        requireInRange("gray", gray);
+        requireInRange("alpha", alpha);
+
         this.gray = gray;
         this.alpha = alpha;
     }
 
+    private static void requireInRange(String component, int value) {
+        if (value < 0 || value > 255)
+            throw new IllegalArgumentException(
+                "Grayscale " + component + " component must be in [0, 255] but was " + value);
+    }
+
+    @Override
     public RGBColor toRGB() {
         return new RGBColor(gray, gray, gray, alpha);
     }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/GrayscaleTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/GrayscaleTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.scrimage.core.color
+
+import com.sksamuel.scrimage.color.Grayscale
+import com.sksamuel.scrimage.color.RGBColor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class GrayscaleTest : StringSpec({
+
+   "Grayscale converts to RGB by repeating the gray value across channels" {
+      Grayscale(128).toRGB() shouldBe RGBColor(128, 128, 128, 255)
+      Grayscale(64, 200).toRGB() shouldBe RGBColor(64, 64, 64, 200)
+   }
+
+   // Mirrors the RGBColor validation: an out-of-range component must fail fast at
+   // construction rather than being stored unchecked and only failing later in toRGB().
+   "Grayscale rejects out-of-range gray" {
+      shouldThrow<IllegalArgumentException> { Grayscale(300) }
+      shouldThrow<IllegalArgumentException> { Grayscale(-1) }
+      shouldThrow<IllegalArgumentException> { Grayscale(256, 255) }
+   }
+
+   "Grayscale rejects out-of-range alpha" {
+      shouldThrow<IllegalArgumentException> { Grayscale(0, -1) }
+      shouldThrow<IllegalArgumentException> { Grayscale(0, 256) }
+   }
+
+   "Grayscale accepts the boundary values" {
+      Grayscale(0, 0).toRGB() shouldBe RGBColor(0, 0, 0, 0)
+      Grayscale(255, 255).toRGB() shouldBe RGBColor(255, 255, 255, 255)
+   }
+})


### PR DESCRIPTION
## What

`Grayscale`'s two-arg constructor stored `gray` and `alpha` unchecked, unlike `RGBColor` which validates each component is in `[0, 255]` via `requireInRange` and throws `IllegalArgumentException`.

Because `Grayscale` is a public class with a public constructor, an out-of-range value (e.g. `gray = 300` or `alpha = -1`) was accepted silently and only failed later inside `Grayscale.toRGB()` (`new RGBColor(gray, gray, gray, alpha)`), turning a clear construction-site error into a confusing deferred failure.

## Change

- Add explicit `requireInRange` validation for `gray` and `alpha` in the constructor to fail fast with a clear message, matching the proven `RGBColor` pattern.
- Add the missing `@Override` to `toRGB()`, which implements `Color.toRGB()` (already annotated in `RGBColor` and the `GrayscaleMethod` implementations).

## Test

Added `GrayscaleTest` covering: normal conversion, rejection of out-of-range gray and alpha, and acceptance of the `0` / `255` boundary values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)