### PR TITLE
Guard against int overflow in PngReader matrix allocation

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
@@ -36,7 +36,15 @@ public class PngReader implements ImageReader {
       int w = pngr.imgInfo.cols;
       int h = pngr.imgInfo.rows;
 
-      int[] matrix = new int[w * h];
+      // Guard against int overflow: w * h is computed in int arithmetic below, so a PNG
+      // declaring very large dimensions can wrap to a negative size (NegativeArraySizeException)
+      // or a small/wrong positive size, producing an undersized buffer that later trips
+      // ArrayIndexOutOfBoundsException in the row loops. Validate up front with long math.
+      long pixelCount = (long) w * h;
+      if (pixelCount > Integer.MAX_VALUE)
+         throw new IllegalArgumentException("PNG too large: " + w + "x" + h);
+
+      int[] matrix = new int[(int) pixelCount];
 
       if (pngr.imgInfo.indexed) {
          int[] pixels = null;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderOverflowTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderOverflowTest.kt
@@ -1,0 +1,67 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.PngReader
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.string.shouldContain
+import java.io.ByteArrayOutputStream
+import java.util.zip.CRC32
+
+class PngReaderOverflowTest : WordSpec({
+
+   fun ByteArrayOutputStream.writeInt(v: Int) {
+      write((v ushr 24) and 0xFF)
+      write((v ushr 16) and 0xFF)
+      write((v ushr 8) and 0xFF)
+      write(v and 0xFF)
+   }
+
+   fun ByteArrayOutputStream.writeChunk(type: String, data: ByteArray) {
+      writeInt(data.size)
+      val typeBytes = type.toByteArray(Charsets.US_ASCII)
+      write(typeBytes)
+      write(data)
+      val crc = CRC32()
+      crc.update(typeBytes)
+      crc.update(data)
+      writeInt(crc.value.toInt())
+   }
+
+   // builds a structurally complete PNG (IHDR + a small IDAT + IEND) whose IHDR declares the
+   // given dimensions. The image data is not valid pixels for those dimensions, but that does
+   // not matter: the size guard runs before any row is read.
+   fun pngWithDimensions(width: Int, height: Int): ByteArray {
+      val out = ByteArrayOutputStream()
+      // PNG signature
+      out.write(byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A, 0x1A, 0x0A))
+
+      val ihdr = ByteArrayOutputStream()
+      ihdr.writeInt(width)
+      ihdr.writeInt(height)
+      ihdr.write(8)  // bit depth
+      ihdr.write(6)  // colour type RGBA
+      ihdr.write(0)  // compression
+      ihdr.write(0)  // filter
+      ihdr.write(0)  // interlace
+      out.writeChunk("IHDR", ihdr.toByteArray())
+
+      // a non-empty (but bogus) IDAT so the reader has data chunks to find, then IEND.
+      out.writeChunk("IDAT", ByteArray(16))
+      out.writeChunk("IEND", ByteArray(0))
+      return out.toByteArray()
+   }
+
+   "PngReader" should {
+      // 65536 * 65536 == 2^32, which wraps to 0 in int arithmetic, yielding an undersized buffer.
+      "reject PNGs whose declared dimensions overflow int when multiplied" {
+         val bytes = pngWithDimensions(65536, 65536)
+         val ex = shouldThrow<IllegalArgumentException> {
+            PngReader().read(bytes, null)
+         }
+         ex.message!! shouldContain "PNG too large"
+      }
+   }
+
+})


### PR DESCRIPTION
## Problem

In `PngReader.read`, the pixel buffer was allocated as:

```java
int[] matrix = new int[w * h];
```

where `w = pngr.imgInfo.cols` and `h = pngr.imgInfo.rows` come from the PNG's IHDR. The underlying pngj reader caps each dimension individually at 2^24 (16,777,216), so a PNG can legitimately declare dimensions whose product exceeds `Integer.MAX_VALUE`. The `w * h` multiplication is performed in `int` arithmetic and silently overflows, producing either:

- a negative size -> `NegativeArraySizeException`, or
- a small/wrong positive size -> an undersized buffer that later trips `ArrayIndexOutOfBoundsException` inside the row loops (`rowOffset = row * w` can overflow too).

For example, a PNG declaring 65536x65536 yields `w * h == 2^32`, which wraps to `0`.

## Fix

Validate the pixel count up front using `long` arithmetic and throw a clear `IllegalArgumentException` before allocating:

```java
long pixelCount = (long) w * h;
if (pixelCount > Integer.MAX_VALUE)
   throw new IllegalArgumentException("PNG too large: " + w + "x" + h);
int[] matrix = new int[(int) pixelCount];
```

Behaviour is unchanged for all normally-sized images.

## Test

Added `PngReaderOverflowTest`, which builds a structurally valid PNG (CRC-correct IHDR + IDAT + IEND) declaring 65536x65536 and asserts the reader fails fast with a clear `IllegalArgumentException` rather than an opaque `ArrayIndexOutOfBoundsException`/`NegativeArraySizeException`. Existing `PngReaderTest` continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)