### PR TITLE
Collapse two stream passes in Polyline.draw into a single index-based loop

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Polyline.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/canvas/drawables/Polyline.java
@@ -18,9 +18,16 @@ public class Polyline implements Drawable {
 
     @Override
     public void draw(RichGraphics2D g) {
-        int[] xs = points.stream().mapToInt(p -> p.x).toArray();
-        int[] ys = points.stream().mapToInt(p -> p.y).toArray();
-        g.drawPolyline(xs, ys, points.size());
+        int n = points.size();
+        int[] xs = new int[n];
+        int[] ys = new int[n];
+        int i = 0;
+        for (java.awt.Point p : points) {
+            xs[i] = p.x;
+            ys[i] = p.y;
+            i++;
+        }
+        g.drawPolyline(xs, ys, n);
     }
 
     public Polygon close() {


### PR DESCRIPTION
## What

`Polyline.draw` built its x and y coordinate arrays with two separate `IntStream` pipelines:

```java
int[] xs = points.stream().mapToInt(p -> p.x).toArray();
int[] ys = points.stream().mapToInt(p -> p.y).toArray();
g.drawPolyline(xs, ys, points.size());
```

This allocates two stream pipelines, traverses the `points` list twice, and queries `points.size()` separately. This mirrors the same two-pass pattern that already lives in `FilledPolygon`.

## Change

Replace it with a single enhanced-for loop that fills both pre-sized `int[]` arrays in one pass and computes `points.size()` once:

```java
int n = points.size();
int[] xs = new int[n];
int[] ys = new int[n];
int i = 0;
for (java.awt.Point p : points) {
    xs[i] = p.x;
    ys[i] = p.y;
    i++;
}
g.drawPolyline(xs, ys, n);
```

Iterating via the list iterator (rather than indexed `get(i)`) keeps behaviour correct and efficient for any `List` implementation, with no random-access assumption.

## Notes

- Internal-only change. No behaviour or public API difference.
- `:scrimage-core:compileJava` builds cleanly.
- Pure perf/quality change, so no test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)