### PR TITLE
Use bulk getRGB in AwtImage.pixels() fallback and read only the region in patch()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -148,12 +148,13 @@ public class AwtImage {
          }
          return pixels;
       } else {
-         Pixel[] pixels = new Pixel[count()];
-         int index = 0;
-         for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-               pixels[index++] = new Pixel(x, y, awt().getRGB(x, y));
-            }
+         // Non int-backed buffers (eg TYPE_BYTE_GRAY, TYPE_3BYTE_BGR, TYPE_4BYTE_ABGR):
+         // a single bulk getRGB converts scanline-at-a-time internally, which is far
+         // faster than invoking the colour-model conversion per pixel.
+         int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+         Pixel[] pixels = new Pixel[argb.length];
+         for (int index = 0; index < argb.length; index++) {
+            pixels[index] = new Pixel(index % width, index / width, argb[index]);
          }
          return pixels;
       }
@@ -421,7 +422,10 @@ public class AwtImage {
          throw new IllegalArgumentException(
             "Patch (" + x + "," + y + " " + patchWidth + "x" + patchHeight + ") falls outside image bounds " + width + "x" + height);
       }
-      return patchFrom(pixels(), x, y, patchWidth, patchHeight);
+      // Read only the requested region rather than materialising every pixel in
+      // the image; pixels(x, y, w, h) returns the patch in the same row-major
+      // order, with the same absolute coordinates, as patchFrom would extract.
+      return pixels(x, y, patchWidth, patchHeight);
    }
 
    // Internal helper, callers (this::patch, this::patches) are responsible

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/invariants/PixelAccessConsistencyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/invariants/PixelAccessConsistencyTest.kt
@@ -42,7 +42,11 @@ class PixelAccessConsistencyTest : FunSpec({
       Triple(1, 8, BufferedImage.TYPE_INT_ARGB),
       Triple(7, 13, BufferedImage.TYPE_INT_ARGB),
       Triple(7, 13, BufferedImage.TYPE_INT_RGB),
+      // Byte-backed buffers exercise the bulk-getRGB fallback in pixels()
+      // rather than the DataBufferInt fast path.
       Triple(7, 13, BufferedImage.TYPE_4BYTE_ABGR),
+      Triple(7, 13, BufferedImage.TYPE_3BYTE_BGR),
+      Triple(7, 13, BufferedImage.TYPE_BYTE_GRAY),
       Triple(32, 16, BufferedImage.TYPE_INT_ARGB),
    )
 
@@ -54,6 +58,8 @@ class PixelAccessConsistencyTest : FunSpec({
             val viaXY = img.pixel(x, y).argb
             val viaIndex = flat[y * w + x].argb
             viaXY shouldBe viaIndex
+            flat[y * w + x].x shouldBe x
+            flat[y * w + x].y shouldBe y
          }
       }
    }
@@ -97,6 +103,31 @@ class PixelAccessConsistencyTest : FunSpec({
          val img = seed(w, h, t)
          for (y in 0 until h) for (x in 0 until w) {
             img.pixel(x, y).argb shouldBe img.pixels(x, y, 1, 1)[0].argb
+         }
+      }
+   }
+
+   test("patch(x,y,w,h) agrees with the corresponding region of pixels()") {
+      // patch() now delegates to the region read pixels(x, y, w, h) instead of
+      // materialising every pixel and slicing; it must still return the same
+      // values, in the same row-major order, with the same absolute coordinates,
+      // as the equivalent region of the full pixels() array — for both the
+      // DataBufferInt fast path and the bulk-getRGB byte-backed fallback.
+      for ((w, h, t) in cases) {
+         val img = seed(w, h, t)
+         val flat = img.pixels()
+         val px = (w - 1) / 2
+         val py = (h - 1) / 2
+         val pw = w - px
+         val ph = h - py
+         val patch = img.patch(px, py, pw, ph)
+         patch.size shouldBe pw * ph
+         for (dy in 0 until ph) for (dx in 0 until pw) {
+            val p = patch[dy * pw + dx]
+            val expected = flat[(py + dy) * w + (px + dx)]
+            p.x shouldBe expected.x
+            p.y shouldBe expected.y
+            p.argb shouldBe expected.argb
          }
       }
    }


### PR DESCRIPTION
Two performance fixes in `AwtImage`, with no behaviour change.

## `pixels()` fallback: per-pixel getRGB → single bulk getRGB

The fast path for `DataBufferInt`-backed images reads the raster buffer directly, but the fallback for other image types (eg `TYPE_BYTE_GRAY`, `TYPE_3BYTE_BGR`, `TYPE_4BYTE_ABGR`) looped over every coordinate calling `awt().getRGB(x, y)` — a full colour-model conversion call per pixel. This is now a single `awt().getRGB(0, 0, width, height, null, 0, width)` bulk call, which converts a scanline at a time internally, followed by a simple loop wrapping the `int[]` into `Pixel` objects. The returned values are identical (same coordinates, same ARGB ints); only the cost changes.

## `patch(x, y, w, h)`: O(width*height) → O(w*h)

`patch` materialised the *entire* image via `pixels()` and then copied out the requested region with `patchFrom`, so extracting a tiny patch from a large image paid the full-image cost in both time and allocation. It now delegates to the existing `pixels(x, y, w, h)` overload, which reads only the region. The result is verified identical to what `patchFrom` produced: same row-major ordering, same absolute pixel coordinates on each `Pixel`, same ARGB values. The up-front bounds validation in `patch` is retained, and `patchFrom` is still used by `patches()`, which legitimately needs the full pixel array.

## Testing

`./gradlew :scrimage-tests:test` (the module containing the core tests; `:scrimage-core:test` has no test sources): **574 tests, 0 failures**, including `AwtImageTest`, `PatchBoundsTest`, `PixelsTest`, and `PixelAccessConsistencyTest`.

## Tests

Added regression coverage in `scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/invariants/PixelAccessConsistencyTest.kt`:

- New `TYPE_3BYTE_BGR` and `TYPE_BYTE_GRAY` cases (alongside the existing `TYPE_4BYTE_ABGR`) so the byte-backed bulk-getRGB fallback in `pixels()` is checked against per-coordinate `pixel(x, y)` reads, including the `(x, y)` coordinates stored on each returned `Pixel`.
- New test asserting `patch(x, y, w, h)` returns the same values, row-major order, and absolute coordinates as the corresponding region of `pixels()`, across both the `DataBufferInt` fast path and the byte-backed fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
