### PR TITLE
Reuse scratch objects instead of per-pixel allocation in filters

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CellularFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CellularFilter.java
@@ -218,8 +218,6 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 
 	private float checkCube(float x, float y, int cubeX, int cubeY, Point[] results) {
 
-		Noise noise = new Noise();
-
 		int numPoints;
 		random.setSeed(571*cubeX + 23*cubeY);
 		switch (gridType) {
@@ -262,8 +260,8 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 					px = 0.75f; py = 0.5f;
 				}
 				if (randomness != 0) {
-					px += randomness * noise.noise2(271*(cubeX+px), 271*(cubeY+py));
-					py += randomness * noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
+					px += randomness * Noise.noise2(271*(cubeX+px), 271*(cubeY+py));
+					py += randomness * Noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
 				}
 				break;
 			case OCTAGONAL:
@@ -272,8 +270,8 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 				case 1: px = 0.707f; py = 0.707f; weight = 1.6f; break;
 				}
 				if (randomness != 0) {
-					px += randomness * noise.noise2(271*(cubeX+px), 271*(cubeY+py));
-					py += randomness * noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
+					px += randomness * Noise.noise2(271*(cubeX+px), 271*(cubeY+py));
+					py += randomness * Noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
 				}
 				break;
 			case TRIANGULAR:
@@ -291,8 +289,8 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 					}
 				}
 				if (randomness != 0) {
-					px += randomness * noise.noise2(271*(cubeX+px), 271*(cubeY+py));
-					py += randomness * noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
+					px += randomness * Noise.noise2(271*(cubeX+px), 271*(cubeY+py));
+					py += randomness * Noise.noise2(271*(cubeX+px)+89, 271*(cubeY+py)+137);
 				}
 				break;
 			}

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
@@ -108,8 +108,6 @@ public class FlareFilter extends PointFilter {
     }
 
     public int filterRGB(int x, int y, int rgb) {
-        Noise noise = new Noise();
-
         float dx = x - icentreX;
         float dy = y - icentreY;
         float distance = (float) Math.sqrt(dx * dx + dy * dy);
@@ -132,7 +130,7 @@ public class FlareFilter extends PointFilter {
         a += ring;
 
         float angle = (float) Math.atan2(dx, dy) + ImageMath.PI;
-        angle = (ImageMath.mod(angle / ImageMath.PI * 17 + 1.0f + noise.noise1(angle * 10), 1.0f) - 0.5f) * 2;
+        angle = (ImageMath.mod(angle / ImageMath.PI * 17 + 1.0f + Noise.noise1(angle * 10), 1.0f) - 0.5f) * 2;
         angle = Math.abs(angle);
         angle = (float) Math.pow(angle, 5.0);
 

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CellularFilterRandomnessTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CellularFilterRandomnessTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.image.BufferedImageOp
+import thirdparty.jhlabs.image.CellularFilter
+
+// Regression coverage for the randomness != 0 branches of the jhlabs
+// CellularFilter checkCube method, which perturb hexagonal/octagonal/triangular
+// grid points using the static Noise.noise2 tables. Those tables are seeded from
+// an unseeded Random at class load, so this output cannot be pinned to a golden
+// image across JVMs — but within a JVM it must be fully repeatable: two
+// identically configured runs over the same source must be pixel-identical.
+class CellularFilterRandomnessTest : FunSpec({
+
+   val original = ImmutableImage.fromResource("/bird_small.png")
+
+   fun cellular(gridType: Int): Filter = object : BufferedOpFilter() {
+      override fun op(): BufferedImageOp {
+         val op = CellularFilter()
+         op.gridType = gridType
+         op.randomness = 0.3f
+         op.scale = 16f
+         return op
+      }
+   }
+
+   val gridTypes = mapOf(
+      "random" to CellularFilter.RANDOM,
+      "square" to CellularFilter.SQUARE,
+      "hexagonal" to CellularFilter.HEXAGONAL,
+      "octagonal" to CellularFilter.OCTAGONAL,
+      "triangular" to CellularFilter.TRIANGULAR,
+   )
+
+   for ((name, gridType) in gridTypes) {
+      test("CellularFilter with randomness on $name grid is repeatable within the same JVM") {
+         val a = original.filter(cellular(gridType))
+         val b = original.filter(cellular(gridType))
+         a shouldBe b
+         a.width shouldBe original.width
+         a.height shouldBe original.height
+         a shouldNotBe original
+      }
+   }
+})

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CrystallizeFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CrystallizeFilterTest.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+// Output-regression coverage for CrystallizeFilter, which is backed by the jhlabs
+// CellularFilter. With randomness == 0 the cellular grid is fully deterministic
+// (the internal Random is re-seeded per cube), so output can be pinned against
+// golden images committed in test resources.
+class CrystallizeFilterTest : FunSpec({
+
+   val original = ImmutableImage.fromResource("/bird_small.png")
+
+   test("filter output matches expected") {
+      val actual = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.0))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_crystallize.png")
+      actual shouldBe expected
+   }
+
+   test("support edge thickness") {
+      val actual = original.filter(CrystallizeFilter(16.0, 0.6, 0xff000000.toInt(), 0.0))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_crystallize_edge_thickeness.png")
+      actual shouldBe expected
+   }
+
+   test("support edge colour") {
+      val actual = original.filter(CrystallizeFilter(16.0, 0.6, 0xff00ff00.toInt(), 0.0))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_crystallize_edge_colour.png")
+      actual shouldBe expected
+   }
+
+   test("support scale") {
+      val actual = original.filter(CrystallizeFilter(12.0, 0.4, 0xff000000.toInt(), 0.0))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_crystallize_scale.png")
+      actual shouldBe expected
+   }
+
+   test("support randomness") {
+      original.filter(CrystallizeFilter(16.0, 0.8, 0xff000000.toInt(), 0.2)) shouldNotBe
+         original.filter(CrystallizeFilter(16.0, 0.8, 0xff000000.toInt(), 0.4))
+   }
+
+   // With randomness != 0 the jhlabs CellularFilter perturbs cell points via the
+   // static Noise tables, which are seeded from an unseeded Random at class load,
+   // so output cannot be pinned across JVMs. It must however be stable within a
+   // JVM: two identically configured runs must be pixel-identical.
+   test("randomness output is repeatable within the same JVM") {
+      val a = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.2))
+      val b = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.2))
+      a shouldBe b
+   }
+})

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensFlareFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensFlareFilterTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+// Regression coverage for LensFlareFilter, backed by the jhlabs FlareFilter.
+// FlareFilter shapes its rays with Noise.noise1, and the static Noise tables are
+// seeded from an unseeded Random at class load, so output differs between JVM
+// runs and cannot be pinned to a golden image. Output is deterministic within a
+// JVM though: applying the same configuration twice must be pixel-identical.
+class LensFlareFilterTest : FunSpec({
+
+   val original = ImmutableImage.fromResource("/bird_small.png")
+
+   test("LensFlareFilter preserves dimensions") {
+      val out = original.filter(LensFlareFilter())
+      out.width shouldBe original.width
+      out.height shouldBe original.height
+   }
+
+   test("LensFlareFilter modifies the image") {
+      original.filter(LensFlareFilter()) shouldNotBe original
+   }
+
+   test("LensFlareFilter output is repeatable within the same JVM") {
+      val a = original.filter(LensFlareFilter())
+      val b = original.filter(LensFlareFilter())
+      a shouldBe b
+   }
+})

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/PointillizeFilterTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/PointillizeFilterTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+// Output-regression coverage for PointillizeFilter, which is backed by the jhlabs
+// CellularFilter. PointillizeFilter uses randomness == 0, so every grid type
+// (including the hexagonal/octagonal/triangular checkCube branches) is fully
+// deterministic and can be pinned against golden images in test resources.
+class PointillizeFilterTest : FunSpec({
+
+   val original = ImmutableImage.fromResource("/bird_small.png")
+
+   test("square grid output matches expected") {
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_square.png")
+      original.filter(PointillizeFilter(PointillizeGridType.Square)) shouldBe expected
+   }
+
+   test("hexagonal grid output matches expected") {
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_hexagon.png")
+      original.filter(PointillizeFilter(PointillizeGridType.Hexagonal)) shouldBe expected
+   }
+
+   test("octagonal grid output matches expected") {
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_octagonal.png")
+      original.filter(PointillizeFilter(PointillizeGridType.Octangal)) shouldBe expected
+   }
+
+   test("triangular grid output matches expected") {
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_triangular.png")
+      original.filter(PointillizeFilter(PointillizeGridType.Triangular)) shouldBe expected
+   }
+
+   test("should support scale") {
+      val actual = original.filter(PointillizeFilter(0.0f, 12, 0.4f, 0xff000000.toInt(), false, 0.1f, PointillizeGridType.Hexagonal))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_hexagon_scale.png")
+      actual shouldBe expected
+   }
+
+   test("should support edge thickness") {
+      val actual = original.filter(PointillizeFilter(0.0f, 12, 0.45f, 0xff000000.toInt(), false, 0.1f, PointillizeGridType.Hexagonal))
+      val expected = ImmutableImage.fromResource("/com/sksamuel/scrimage/filters/bird_small_pointillize_hexagon_edge_thickness.png")
+      actual shouldBe expected
+   }
+})


### PR DESCRIPTION
Removes wasteful per-pixel object allocations in two jhlabs filters. `Noise`'s `noise1`/`noise2` methods are static and driven by static lookup tables, so instantiating `Noise` contributes nothing — the allocations were pure garbage-collector pressure. Output is numerically identical (the noise tables are static and shared regardless of instance).

## Fixes

- **FlareFilter.filterRGB**: dropped the `new Noise()` allocated on every call (i.e. once per pixel); calls `Noise.noise1(...)` statically instead.
- **CellularFilter.checkCube**: dropped the `new Noise()` allocated on every call (called up to 9 times per pixel from `evaluate`); calls `Noise.noise2(...)` statically instead.

## Dropped finding

- **VariableBlurFilter.blur**: a report claimed the scratch arrays (`r`, `g`, `b`, `a`, `mask`) were allocated inside the per-row loop. Verified against the code: they are already allocated once per `blur()` call, outside the row loop. No change needed.

## Testing

`./gradlew :scrimage-filters:test` — BUILD SUCCESSFUL, all tests pass.

## Tests

The filters touched here had no active output coverage: the Scala golden tests (`CrystallizeFilterTest`, `PointillizeFilterTest`, `LensFlareFilterTest`) are not wired into the Gradle build — `:scrimage-filters:test` only compiles Kotlin/Java test sources. Added permanent Kotlin/kotest regression tests:

- `scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CrystallizeFilterTest.kt` — pins CrystallizeFilter (CellularFilter-backed) output against the golden PNGs already in test resources for randomness == 0 (deterministic), plus a same-JVM repeatability check for randomness != 0.
- `scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/PointillizeFilterTest.kt` — pins PointillizeFilter output against existing goldens for all grid types (square/hexagonal/octagonal/triangular), exercising the modified `checkCube` paths deterministically.
- `scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CellularFilterRandomnessTest.kt` — exercises the `randomness != 0` branches that hit the changed `Noise.noise2` calls across all five grid types; asserts two identically configured runs are pixel-identical.
- `scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensFlareFilterTest.kt` — FlareFilter coverage: dimensions preserved, image modified, and same-JVM repeatability.

Note on determinism: `Noise`'s static tables are initialised from an **unseeded** `Random` at class load, so FlareFilter output and randomness != 0 CellularFilter output differ between JVM runs and cannot be pinned to golden images; those paths use determinism-aware (same-JVM repeatability) assertions instead. The golden comparisons that are cross-JVM deterministic pass against goldens generated before this change, confirming output is bit-identical.

`./gradlew :scrimage-filters:test` — 182 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
