### PR TITLE
Compute dhash from flat pixel array without intermediate list allocations

### DIFF
--- a/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
+++ b/scrimage-hash/src/main/kotlin/com/sksamuel/scrimage/hash/DifferenceHasher.kt
@@ -2,6 +2,7 @@ package com.sksamuel.scrimage.hash
 
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.color.GrayscaleMethod
+import com.sksamuel.scrimage.pixels.PixelTools
 
 class DifferenceHasher(private val cols: Int, private val rows: Int) {
 
@@ -22,10 +23,22 @@ class DifferenceHasher(private val cols: Int, private val rows: Int) {
       // byte of 0xFF, making the int negative, so on inputs with
       // varying source alpha the dhash sorted by alpha rather than
       // brightness and produced a perceptually meaningless hash.
-      return r.rows()
-         .flatMap { row ->
-            row.toList().windowed(2).map { if (it.first().red() < it.last().red()) 1 else 0 }
+      // Fetch the packed ARGB ints once as a flat row-major array and compare
+      // adjacent pixels with plain index arithmetic. This avoids materialising
+      // a Pixel object per pixel (rows()) plus the per-row List/windowed
+      // intermediate allocations of the previous implementation, while
+      // producing exactly the same bits.
+      val argb = r.argbints()
+      val bits = ArrayList<Int>((cols - 1) * rows)
+      for (y in 0 until rows) {
+         val offset = y * cols
+         for (x in 0 until cols - 1) {
+            val left = PixelTools.red(argb[offset + x])
+            val right = PixelTools.red(argb[offset + x + 1])
+            bits.add(if (left < right) 1 else 0)
          }
+      }
+      return bits
    }
 
 }


### PR DESCRIPTION
## Summary

`DifferenceHasher.dhash` did its adjacent-pixel comparisons via `rows()` + `flatMap { row.toList().windowed(2).map { ... } }`. For each hash computation this:

- materialised a `Pixel[][]` with one `Pixel` object allocated per pixel of the scaled image (`rows()`),
- per row, allocated an intermediate `List<Pixel>` (`toList()`) and a `List<List<Pixel>>` of two-element windows (`windowed(2)`), plus the boxing/iterator churn that comes with them.

This change fetches the packed ARGB ints once as a flat row-major `int[]` via `argbints()` and computes the comparison bits with plain index arithmetic in a simple nested loop — no `Pixel` objects, no per-row intermediate lists.

## Correctness

The hash is bit-for-bit identical to the previous implementation:

- `argbints()` uses the same `awt().getRGB(0, 0, width, height, null, 0, width)` source as `rows()`, so the packed values and row-major ordering are unchanged.
- The comparison still uses the red channel of the already-grayscale image (`PixelTools.red`, i.e. `argb >> 16 & 0xFF`), with the same `left < right → 1` semantics and the same row-by-row bit ordering.
- The grayscale (`GrayscaleMethod.LUMA`) and `scaleTo(cols, rows)` steps are untouched.

I additionally verified equivalence with a temporary test comparing the new output against the old `rows()`/`windowed` implementation bit-for-bit across all four test resource images (`spaceworld.jpg`, `landscape.jpg`, `spaceworld_rot.jpg`, `spaceworld_rot_crop.jpg`) — all matched.

## Test results

`./gradlew :scrimage-hash:test` — BUILD SUCCESSFUL, all 4 tests pass:

- DifferenceHasherAlphaTest > dhash with translucent strips still reflects brightness ordering PASSED
- DifferenceHasherScalingTest > dhash of two images with identical centres but different corners differs PASSED
- DifferenceHasherTest > same image should have equals dhash PASSED
- DifferenceHasherTest > two distinct images should not have the same dhash PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)