### PR TITLE
Avoid per-pixel scratch array allocations in BlendComposite

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/romainguy/BlendComposite.java
+++ b/scrimage-core/src/main/java/thirdparty/romainguy/BlendComposite.java
@@ -123,6 +123,7 @@ public final class BlendComposite implements Composite {
 
          int[] srcPixel = new int[4];
          int[] dstPixel = new int[4];
+         int[] result = new int[4];
          int[] srcPixels = new int[width];
          int[] dstPixels = new int[width];
 
@@ -144,7 +145,7 @@ public final class BlendComposite implements Composite {
                dstPixel[2] = (pixel) & 0xFF;
                dstPixel[3] = (pixel >> 24) & 0xFF;
 
-               int[] result = blender.blend(srcPixel, dstPixel);
+               blender.blend(srcPixel, dstPixel, result);
 
                // Mix the blended result with the destination, scaling the
                // composite opacity by the source pixel's own alpha. The blend
@@ -166,7 +167,13 @@ public final class BlendComposite implements Composite {
    }
 
    private static abstract class Blender {
-      public abstract int[] blend(int[] src, int[] dst);
+
+      /**
+       * Blends the src and dst pixels, writing the blended channels into
+       * {@code result}. The result array is supplied by the caller so it
+       * can be reused across pixels rather than allocated per invocation.
+       */
+      public abstract void blend(int[] src, int[] dst, int[] result);
 
       private static void RGBtoHSL(int r, int g, int b, float[] hsl) {
          float var_R = (r / 255f);
@@ -280,413 +287,353 @@ public final class BlendComposite implements Composite {
             case ADD:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.min(255, src[0] + dst[0]),
-                        Math.min(255, src[1] + dst[1]),
-                        Math.min(255, src[2] + dst[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.min(255, src[0] + dst[0]);
+                     result[1] = Math.min(255, src[1] + dst[1]);
+                     result[2] = Math.min(255, src[2] + dst[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case AVERAGE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        (src[0] + dst[0]) >> 1,
-                        (src[1] + dst[1]) >> 1,
-                        (src[2] + dst[2]) >> 1,
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = (src[0] + dst[0]) >> 1;
+                     result[1] = (src[1] + dst[1]) >> 1;
+                     result[2] = (src[2] + dst[2]) >> 1;
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case BLUE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0],
-                        src[1],
-                        dst[2],
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0];
+                     result[1] = src[1];
+                     result[2] = dst[2];
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case COLOR:
                return new Blender() {
+                  private final float[] srcHSL = new float[3];
+                  private final float[] dstHSL = new float[3];
+
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     float[] srcHSL = new float[3];
+                  public void blend(int[] src, int[] dst, int[] result) {
                      RGBtoHSL(src[0], src[1], src[2], srcHSL);
-                     float[] dstHSL = new float[3];
                      RGBtoHSL(dst[0], dst[1], dst[2], dstHSL);
 
-                     int[] result = new int[4];
                      HSLtoRGB(srcHSL[0], srcHSL[1], dstHSL[2], result);
                      result[3] = Math.min(255, src[3] + dst[3]);
-
-                     return result;
                   }
                };
             case COLOR_BURN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - dst[0]) << 8) / src[0])),
-                        src[1] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - dst[1]) << 8) / src[1])),
-                        src[2] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - dst[2]) << 8) / src[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - dst[0]) << 8) / src[0]));
+                     result[1] = src[1] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - dst[1]) << 8) / src[1]));
+                     result[2] = src[2] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - dst[2]) << 8) / src[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case COLOR_DODGE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0] == 255 ? 255 :
-                           Math.min((dst[0] << 8) / (255 - src[0]), 255),
-                        src[1] == 255 ? 255 :
-                           Math.min((dst[1] << 8) / (255 - src[1]), 255),
-                        src[2] == 255 ? 255 :
-                           Math.min((dst[2] << 8) / (255 - src[2]), 255),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0] == 255 ? 255 :
+                        Math.min((dst[0] << 8) / (255 - src[0]), 255);
+                     result[1] = src[1] == 255 ? 255 :
+                        Math.min((dst[1] << 8) / (255 - src[1]), 255);
+                     result[2] = src[2] == 255 ? 255 :
+                        Math.min((dst[2] << 8) / (255 - src[2]), 255);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case DARKEN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.min(src[0], dst[0]),
-                        Math.min(src[1], dst[1]),
-                        Math.min(src[2], dst[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.min(src[0], dst[0]);
+                     result[1] = Math.min(src[1], dst[1]);
+                     result[2] = Math.min(src[2], dst[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case DIFFERENCE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.abs(dst[0] - src[0]),
-                        Math.abs(dst[1] - src[1]),
-                        Math.abs(dst[2] - src[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.abs(dst[0] - src[0]);
+                     result[1] = Math.abs(dst[1] - src[1]);
+                     result[2] = Math.abs(dst[2] - src[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case EXCLUSION:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] + src[0] - (dst[0] * src[0] >> 7),
-                        dst[1] + src[1] - (dst[1] * src[1] >> 7),
-                        dst[2] + src[2] - (dst[2] * src[2] >> 7),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] + src[0] - (dst[0] * src[0] >> 7);
+                     result[1] = dst[1] + src[1] - (dst[1] * src[1] >> 7);
+                     result[2] = dst[2] + src[2] - (dst[2] * src[2] >> 7);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case FREEZE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0] == 0 ? 0 : Math.max(0, 255 - (255 - dst[0]) * (255 - dst[0]) / src[0]),
-                        src[1] == 0 ? 0 : Math.max(0, 255 - (255 - dst[1]) * (255 - dst[1]) / src[1]),
-                        src[2] == 0 ? 0 : Math.max(0, 255 - (255 - dst[2]) * (255 - dst[2]) / src[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0] == 0 ? 0 : Math.max(0, 255 - (255 - dst[0]) * (255 - dst[0]) / src[0]);
+                     result[1] = src[1] == 0 ? 0 : Math.max(0, 255 - (255 - dst[1]) * (255 - dst[1]) / src[1]);
+                     result[2] = src[2] == 0 ? 0 : Math.max(0, 255 - (255 - dst[2]) * (255 - dst[2]) / src[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case GLOW:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] == 255 ? 255 : Math.min(255, src[0] * src[0] / (255 - dst[0])),
-                        dst[1] == 255 ? 255 : Math.min(255, src[1] * src[1] / (255 - dst[1])),
-                        dst[2] == 255 ? 255 : Math.min(255, src[2] * src[2] / (255 - dst[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] == 255 ? 255 : Math.min(255, src[0] * src[0] / (255 - dst[0]));
+                     result[1] = dst[1] == 255 ? 255 : Math.min(255, src[1] * src[1] / (255 - dst[1]));
+                     result[2] = dst[2] == 255 ? 255 : Math.min(255, src[2] * src[2] / (255 - dst[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case GREEN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0],
-                        dst[1],
-                        src[2],
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0];
+                     result[1] = dst[1];
+                     result[2] = src[2];
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case HARD_LIGHT:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0] < 128 ? dst[0] * src[0] >> 7 :
-                           255 - ((255 - src[0]) * (255 - dst[0]) >> 7),
-                        src[1] < 128 ? dst[1] * src[1] >> 7 :
-                           255 - ((255 - src[1]) * (255 - dst[1]) >> 7),
-                        src[2] < 128 ? dst[2] * src[2] >> 7 :
-                           255 - ((255 - src[2]) * (255 - dst[2]) >> 7),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0] < 128 ? dst[0] * src[0] >> 7 :
+                        255 - ((255 - src[0]) * (255 - dst[0]) >> 7);
+                     result[1] = src[1] < 128 ? dst[1] * src[1] >> 7 :
+                        255 - ((255 - src[1]) * (255 - dst[1]) >> 7);
+                     result[2] = src[2] < 128 ? dst[2] * src[2] >> 7 :
+                        255 - ((255 - src[2]) * (255 - dst[2]) >> 7);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case HEAT:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] == 0 ? 0 : Math.max(0, 255 - (255 - src[0]) * (255 - src[0]) / dst[0]),
-                        dst[1] == 0 ? 0 : Math.max(0, 255 - (255 - src[1]) * (255 - src[1]) / dst[1]),
-                        dst[2] == 0 ? 0 : Math.max(0, 255 - (255 - src[2]) * (255 - src[2]) / dst[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] == 0 ? 0 : Math.max(0, 255 - (255 - src[0]) * (255 - src[0]) / dst[0]);
+                     result[1] = dst[1] == 0 ? 0 : Math.max(0, 255 - (255 - src[1]) * (255 - src[1]) / dst[1]);
+                     result[2] = dst[2] == 0 ? 0 : Math.max(0, 255 - (255 - src[2]) * (255 - src[2]) / dst[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case HUE:
                return new Blender() {
+                  private final float[] srcHSL = new float[3];
+                  private final float[] dstHSL = new float[3];
+
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     float[] srcHSL = new float[3];
+                  public void blend(int[] src, int[] dst, int[] result) {
                      RGBtoHSL(src[0], src[1], src[2], srcHSL);
-                     float[] dstHSL = new float[3];
                      RGBtoHSL(dst[0], dst[1], dst[2], dstHSL);
 
-                     int[] result = new int[4];
                      HSLtoRGB(srcHSL[0], dstHSL[1], dstHSL[2], result);
                      result[3] = Math.min(255, src[3] + dst[3]);
-
-                     return result;
                   }
                };
             case INVERSE_COLOR_BURN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - src[0]) << 8) / dst[0])),
-                        dst[1] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - src[1]) << 8) / dst[1])),
-                        dst[2] == 0 ? 0 :
-                           Math.max(0, 255 - (((255 - src[2]) << 8) / dst[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - src[0]) << 8) / dst[0]));
+                     result[1] = dst[1] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - src[1]) << 8) / dst[1]));
+                     result[2] = dst[2] == 0 ? 0 :
+                        Math.max(0, 255 - (((255 - src[2]) << 8) / dst[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case INVERSE_COLOR_DODGE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] == 255 ? 255 :
-                           Math.min((src[0] << 8) / (255 - dst[0]), 255),
-                        dst[1] == 255 ? 255 :
-                           Math.min((src[1] << 8) / (255 - dst[1]), 255),
-                        dst[2] == 255 ? 255 :
-                           Math.min((src[2] << 8) / (255 - dst[2]), 255),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] == 255 ? 255 :
+                        Math.min((src[0] << 8) / (255 - dst[0]), 255);
+                     result[1] = dst[1] == 255 ? 255 :
+                        Math.min((src[1] << 8) / (255 - dst[1]), 255);
+                     result[2] = dst[2] == 255 ? 255 :
+                        Math.min((src[2] << 8) / (255 - dst[2]), 255);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case LIGHTEN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.max(src[0], dst[0]),
-                        Math.max(src[1], dst[1]),
-                        Math.max(src[2], dst[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.max(src[0], dst[0]);
+                     result[1] = Math.max(src[1], dst[1]);
+                     result[2] = Math.max(src[2], dst[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case LUMINOSITY:
                return new Blender() {
+                  private final float[] srcHSL = new float[3];
+                  private final float[] dstHSL = new float[3];
+
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     float[] srcHSL = new float[3];
+                  public void blend(int[] src, int[] dst, int[] result) {
                      RGBtoHSL(src[0], src[1], src[2], srcHSL);
-                     float[] dstHSL = new float[3];
                      RGBtoHSL(dst[0], dst[1], dst[2], dstHSL);
 
-                     int[] result = new int[4];
                      HSLtoRGB(dstHSL[0], dstHSL[1], srcHSL[2], result);
                      result[3] = Math.min(255, src[3] + dst[3]);
-
-                     return result;
                   }
                };
             case MULTIPLY:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        (src[0] * dst[0]) >> 8,
-                        (src[1] * dst[1]) >> 8,
-                        (src[2] * dst[2]) >> 8,
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = (src[0] * dst[0]) >> 8;
+                     result[1] = (src[1] * dst[1]) >> 8;
+                     result[2] = (src[2] * dst[2]) >> 8;
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case NEGATION:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        255 - Math.abs(255 - dst[0] - src[0]),
-                        255 - Math.abs(255 - dst[1] - src[1]),
-                        255 - Math.abs(255 - dst[2] - src[2]),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = 255 - Math.abs(255 - dst[0] - src[0]);
+                     result[1] = 255 - Math.abs(255 - dst[1] - src[1]);
+                     result[2] = 255 - Math.abs(255 - dst[2] - src[2]);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case OVERLAY:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] < 128 ? dst[0] * src[0] >> 7 :
-                           255 - ((255 - dst[0]) * (255 - src[0]) >> 7),
-                        dst[1] < 128 ? dst[1] * src[1] >> 7 :
-                           255 - ((255 - dst[1]) * (255 - src[1]) >> 7),
-                        dst[2] < 128 ? dst[2] * src[2] >> 7 :
-                           255 - ((255 - dst[2]) * (255 - src[2]) >> 7),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] < 128 ? dst[0] * src[0] >> 7 :
+                        255 - ((255 - dst[0]) * (255 - src[0]) >> 7);
+                     result[1] = dst[1] < 128 ? dst[1] * src[1] >> 7 :
+                        255 - ((255 - dst[1]) * (255 - src[1]) >> 7);
+                     result[2] = dst[2] < 128 ? dst[2] * src[2] >> 7 :
+                        255 - ((255 - dst[2]) * (255 - src[2]) >> 7);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case RED:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0],
-                        dst[1],
-                        dst[2],
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0];
+                     result[1] = dst[1];
+                     result[2] = dst[2];
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case REFLECT:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        src[0] == 255 ? 255 : Math.min(255, dst[0] * dst[0] / (255 - src[0])),
-                        src[1] == 255 ? 255 : Math.min(255, dst[1] * dst[1] / (255 - src[1])),
-                        src[2] == 255 ? 255 : Math.min(255, dst[2] * dst[2] / (255 - src[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = src[0] == 255 ? 255 : Math.min(255, dst[0] * dst[0] / (255 - src[0]));
+                     result[1] = src[1] == 255 ? 255 : Math.min(255, dst[1] * dst[1] / (255 - src[1]));
+                     result[2] = src[2] == 255 ? 255 : Math.min(255, dst[2] * dst[2] / (255 - src[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case SATURATION:
                return new Blender() {
+                  private final float[] srcHSL = new float[3];
+                  private final float[] dstHSL = new float[3];
+
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     float[] srcHSL = new float[3];
+                  public void blend(int[] src, int[] dst, int[] result) {
                      RGBtoHSL(src[0], src[1], src[2], srcHSL);
-                     float[] dstHSL = new float[3];
                      RGBtoHSL(dst[0], dst[1], dst[2], dstHSL);
 
-                     int[] result = new int[4];
                      HSLtoRGB(dstHSL[0], srcHSL[1], dstHSL[2], result);
                      result[3] = Math.min(255, src[3] + dst[3]);
-
-                     return result;
                   }
                };
             case SCREEN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        255 - ((255 - src[0]) * (255 - dst[0]) >> 8),
-                        255 - ((255 - src[1]) * (255 - dst[1]) >> 8),
-                        255 - ((255 - src[2]) * (255 - dst[2]) >> 8),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = 255 - ((255 - src[0]) * (255 - dst[0]) >> 8);
+                     result[1] = 255 - ((255 - src[1]) * (255 - dst[1]) >> 8);
+                     result[2] = 255 - ((255 - src[2]) * (255 - dst[2]) >> 8);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case SOFT_BURN:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] + src[0] < 256 ?
-                           (dst[0] == 255 ? 255 :
-                              Math.min(255, (src[0] << 7) / (255 - dst[0]))) :
-                           Math.max(0, 255 - (((255 - dst[0]) << 7) / src[0])),
-                        dst[1] + src[1] < 256 ?
-                           (dst[1] == 255 ? 255 :
-                              Math.min(255, (src[1] << 7) / (255 - dst[1]))) :
-                           Math.max(0, 255 - (((255 - dst[1]) << 7) / src[1])),
-                        dst[2] + src[2] < 256 ?
-                           (dst[2] == 255 ? 255 :
-                              Math.min(255, (src[2] << 7) / (255 - dst[2]))) :
-                           Math.max(0, 255 - (((255 - dst[2]) << 7) / src[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] + src[0] < 256 ?
+                        (dst[0] == 255 ? 255 :
+                           Math.min(255, (src[0] << 7) / (255 - dst[0]))) :
+                        Math.max(0, 255 - (((255 - dst[0]) << 7) / src[0]));
+                     result[1] = dst[1] + src[1] < 256 ?
+                        (dst[1] == 255 ? 255 :
+                           Math.min(255, (src[1] << 7) / (255 - dst[1]))) :
+                        Math.max(0, 255 - (((255 - dst[1]) << 7) / src[1]));
+                     result[2] = dst[2] + src[2] < 256 ?
+                        (dst[2] == 255 ? 255 :
+                           Math.min(255, (src[2] << 7) / (255 - dst[2]))) :
+                        Math.max(0, 255 - (((255 - dst[2]) << 7) / src[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case SOFT_DODGE:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        dst[0] + src[0] < 256 ?
-                           (src[0] == 255 ? 255 :
-                              Math.min(255, (dst[0] << 7) / (255 - src[0]))) :
-                           Math.max(0, 255 - (((255 - src[0]) << 7) / dst[0])),
-                        dst[1] + src[1] < 256 ?
-                           (src[1] == 255 ? 255 :
-                              Math.min(255, (dst[1] << 7) / (255 - src[1]))) :
-                           Math.max(0, 255 - (((255 - src[1]) << 7) / dst[1])),
-                        dst[2] + src[2] < 256 ?
-                           (src[2] == 255 ? 255 :
-                              Math.min(255, (dst[2] << 7) / (255 - src[2]))) :
-                           Math.max(0, 255 - (((255 - src[2]) << 7) / dst[2])),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = dst[0] + src[0] < 256 ?
+                        (src[0] == 255 ? 255 :
+                           Math.min(255, (dst[0] << 7) / (255 - src[0]))) :
+                        Math.max(0, 255 - (((255 - src[0]) << 7) / dst[0]));
+                     result[1] = dst[1] + src[1] < 256 ?
+                        (src[1] == 255 ? 255 :
+                           Math.min(255, (dst[1] << 7) / (255 - src[1]))) :
+                        Math.max(0, 255 - (((255 - src[1]) << 7) / dst[1]));
+                     result[2] = dst[2] + src[2] < 256 ?
+                        (src[2] == 255 ? 255 :
+                           Math.min(255, (dst[2] << 7) / (255 - src[2]))) :
+                        Math.max(0, 255 - (((255 - src[2]) << 7) / dst[2]));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case STAMP:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.max(0, Math.min(255, dst[0] + 2 * src[0] - 256)),
-                        Math.max(0, Math.min(255, dst[1] + 2 * src[1] - 256)),
-                        Math.max(0, Math.min(255, dst[2] + 2 * src[2] - 256)),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.max(0, Math.min(255, dst[0] + 2 * src[0] - 256));
+                     result[1] = Math.max(0, Math.min(255, dst[1] + 2 * src[1] - 256));
+                     result[2] = Math.max(0, Math.min(255, dst[2] + 2 * src[2] - 256));
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
             case SUBTRACT:
                return new Blender() {
                   @Override
-                  public int[] blend(int[] src, int[] dst) {
-                     return new int[]{
-                        Math.max(0, src[0] + dst[0] - 256),
-                        Math.max(0, src[1] + dst[1] - 256),
-                        Math.max(0, src[2] + dst[2] - 256),
-                        Math.min(255, src[3] + dst[3])
-                     };
+                  public void blend(int[] src, int[] dst, int[] result) {
+                     result[0] = Math.max(0, src[0] + dst[0] - 256);
+                     result[1] = Math.max(0, src[1] + dst[1] - 256);
+                     result[2] = Math.max(0, src[2] + dst[2] - 256);
+                     result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
          }


### PR DESCRIPTION
## Summary

`BlendingContext.compose` calls `Blender.blend` once per pixel, and every blend mode implementation allocated a fresh `int[4]` result array on each call. The four HSL-based blenders (COLOR, HUE, LUMINOSITY, SATURATION) additionally allocated two `float[3]` scratch arrays per pixel. Compositing a moderately sized image therefore produced millions of short-lived allocations in the hot loop, putting unnecessary pressure on the allocator and GC.

(Note: the `srcPixel`/`dstPixel` unpacking arrays in `compose()` were already hoisted out of the loops; the per-pixel allocations were in `blend()`.)

## Changes

- `Blender.blend` now takes a caller-supplied `result` array instead of returning a freshly allocated one. The array is allocated once per `compose()` call, alongside the existing `srcPixel`/`dstPixel` scratch arrays.
- The HSL-based blenders hoist their `srcHSL`/`dstHSL` `float[3]` scratch arrays to instance fields on the anonymous `Blender` classes.

## Thread safety

`Blender.getBlenderFor` constructs a new `Blender` instance every time, and it is only called from the `BlendingContext` constructor — so each context owns its own Blender instance (they are not shared singletons). A `CompositeContext` is used single-threaded per rendering operation, so instance-level scratch state on the Blenders is safe. The `Blender` class is private to `BlendComposite`, so the signature change has no external impact.

## Behavior

Bit-identical: every blend implementation unconditionally writes all four channels of `result` (`HSLtoRGB` writes indices 0-2 and the alpha channel is set explicitly), so reusing the arrays cannot leak state between pixels.

## Testing

- `./gradlew :scrimage-core:test` — module has no test sources (`NO-SOURCE`); tests live in `scrimage-tests`.
- `./gradlew :scrimage-tests:test` — 574 tests, 0 failures, 0 skipped (includes the composite tests covering all blend modes against reference images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)