### PR TITLE
Remove per-call allocations in format detection and size ByteArrayOutputStream in WriteContext

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/format/FormatDetector.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/format/FormatDetector.java
@@ -2,11 +2,8 @@ package com.sksamuel.scrimage.format;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Optional;
-
-import static java.util.Arrays.copyOf;
-import static java.util.Arrays.copyOfRange;
-import static java.util.Objects.deepEquals;
 
 public class FormatDetector {
 
@@ -32,17 +29,23 @@ public class FormatDetector {
     }
 
     public static Optional<Format> detect(byte[] bytes) {
-        if (deepEquals(copyOf(bytes, gif.length), gif)) return Optional.of(Format.GIF);
-        if (deepEquals(copyOf(bytes, png.length), png)) return Optional.of(Format.PNG);
-        if (deepEquals(copyOf(bytes, jpeg1.length), jpeg1)) return Optional.of(Format.JPEG);
-        if (deepEquals(copyOf(bytes, jpeg2.length), jpeg2)) return Optional.of(Format.JPEG);
+        if (startsWith(bytes, gif)) return Optional.of(Format.GIF);
+        if (startsWith(bytes, png)) return Optional.of(Format.PNG);
+        if (startsWith(bytes, jpeg1)) return Optional.of(Format.JPEG);
+        if (startsWith(bytes, jpeg2)) return Optional.of(Format.JPEG);
         if (isWebp(bytes)) return Optional.of(Format.WEBP);
         return Optional.empty();
     }
 
     private static boolean isWebp(byte[] bytes) {
-        return deepEquals(copyOf(bytes, webp1.length), webp1) &&
+        return startsWith(bytes, webp1) &&
             bytes.length >= 12 &&
-            deepEquals(copyOfRange(bytes, 8, 12), webp2);
+            Arrays.equals(bytes, 8, 12, webp2, 0, webp2.length);
+    }
+
+    // allocation-free prefix comparison; Arrays.copyOf + equals would copy the prefix per check
+    private static boolean startsWith(byte[] bytes, byte[] prefix) {
+        return bytes.length >= prefix.length &&
+            Arrays.equals(bytes, 0, prefix.length, prefix, 0, prefix.length);
     }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
@@ -13,7 +13,6 @@ import java.awt.image.DataBufferInt;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.ByteArrayInputStream;
-import java.util.Arrays;
 
 public class PngReader implements ImageReader {
 
@@ -108,13 +107,18 @@ public class PngReader implements ImageReader {
       }
    }
 
+   // PNG magic bytes: 0x89 'P' 'N' 'G' 0x0D 0x0A 0x1A 0x0A, compared in place
+   // to avoid allocating two 8-byte arrays per call.
    private boolean isPng(byte[] bytes) {
-      if (bytes.length < 8)
-         return false;
-      byte[] expected = new byte[]{(byte) 0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
-      byte[] actual = new byte[8];
-      System.arraycopy(bytes, 0, actual, 0, 8);
-      return Arrays.equals(expected, actual);
+      return bytes.length >= 8 &&
+         bytes[0] == (byte) 0x89 &&
+         bytes[1] == 'P' &&
+         bytes[2] == 'N' &&
+         bytes[3] == 'G' &&
+         bytes[4] == 0x0D &&
+         bytes[5] == 0x0A &&
+         bytes[6] == 0x1A &&
+         bytes[7] == 0x0A;
    }
 
    @Override

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/WriteContext.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/WriteContext.java
@@ -25,9 +25,20 @@ public class WriteContext {
    }
 
    public byte[] bytes() throws IOException {
-      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      ByteArrayOutputStream bos = new ByteArrayOutputStream(estimatedSize());
       writer.write(image, metadata, bos);
       return bos.toByteArray();
+   }
+
+   /**
+    * Estimates the encoded size so the buffer does not have to grow from the
+    * default 32-byte capacity through repeated array copies. One byte per pixel
+    * is a reasonable guess for compressed formats; the result is clamped to
+    * keep the initial allocation bounded for very small or very large images.
+    */
+   private int estimatedSize() {
+      long pixels = (long) image.width * image.height;
+      return (int) Math.max(1024, Math.min(pixels, 8 * 1024 * 1024));
    }
 
    public ByteArrayInputStream stream() throws IOException {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FormatDetectorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FormatDetectorTest.kt
@@ -27,6 +27,59 @@ class FormatDetectorTest : WordSpec({
       }
    }
 
+   // Regression: detect(byte[]) compares magic bytes with a ranged Arrays.equals
+   // prefix check, which must not read past the end of short inputs. These
+   // verify short/truncated inputs return empty rather than throwing.
+   "detect(byte[]) with short input" should {
+      "return empty for an empty array" {
+         FormatDetector.detect(ByteArray(0)).isPresent shouldBe false
+      }
+      "return empty for 1-3 byte prefixes of magic numbers" {
+         FormatDetector.detect(byteArrayOf(0x89.toByte())).isPresent shouldBe false
+         FormatDetector.detect(byteArrayOf('G'.code.toByte(), 'I'.code.toByte())).isPresent shouldBe false
+         FormatDetector.detect(byteArrayOf(0xFF.toByte(), 0xD8.toByte())).isPresent shouldBe false
+         FormatDetector.detect(byteArrayOf('R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte())).isPresent shouldBe false
+      }
+      "detect gif from exactly the 4 byte magic" {
+         FormatDetector.detect(byteArrayOf('G'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), '8'.code.toByte()))
+            .get() shouldBe Format.GIF
+      }
+      "detect jpeg from exactly the 3 byte magic" {
+         FormatDetector.detect(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())).get() shouldBe Format.JPEG
+      }
+      "detect png from exactly the 8 byte magic" {
+         val png = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A, 0x1A, 0x0A)
+         FormatDetector.detect(png).get() shouldBe Format.PNG
+      }
+      "return empty for 8-11 byte RIFF headers too short to contain the WEBP tag" {
+         // RIFF + partial length/WEBP tag: isWebp must check length before
+         // comparing bytes 8..12 or the ranged equals would throw.
+         val riff = byteArrayOf('R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 'F'.code.toByte())
+         for (extra in 4..7) {
+            FormatDetector.detect(riff + ByteArray(extra)).isPresent shouldBe false
+         }
+      }
+      "detect webp from exactly a 12 byte RIFF/WEBP header" {
+         val header = byteArrayOf(
+            'R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 'F'.code.toByte(),
+            0x1A, 0x2B, 0x3C, 0x4D, // arbitrary riff chunk length
+            'W'.code.toByte(), 'E'.code.toByte(), 'B'.code.toByte(), 'P'.code.toByte(),
+         )
+         FormatDetector.detect(header).get() shouldBe Format.WEBP
+      }
+      "return empty for a RIFF header without the WEBP tag" {
+         val header = byteArrayOf(
+            'R'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 'F'.code.toByte(),
+            0, 0, 0, 0,
+            'W'.code.toByte(), 'A'.code.toByte(), 'V'.code.toByte(), 'E'.code.toByte(),
+         )
+         FormatDetector.detect(header).isPresent shouldBe false
+      }
+      "return empty for unknown bytes" {
+         FormatDetector.detect(ByteArray(16) { 0x42 }).isPresent shouldBe false
+      }
+   }
+
    "image loader" should {
       "output webp warning" {
          shouldThrowAny {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderTest.kt
@@ -28,6 +28,28 @@ class PngReaderTest : WordSpec({
          val image2 = ImmutableImage.loader().fromBytes(png)
          image2.awt().colorModel.hasAlpha() shouldBe true
       }
+      // Regression: isPng compares the 8 magic bytes in place; it must reject
+      // short or non-png input by returning null rather than throwing.
+      "return null for an empty byte array" {
+         PngReader().read(ByteArray(0), null) shouldBe null
+      }
+      "return null for inputs shorter than the 8 byte png magic" {
+         val magic = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A, 0x1A, 0x0A)
+         for (len in 1..7) {
+            PngReader().read(magic.copyOf(len), null) shouldBe null
+         }
+      }
+      "return null for non-png bytes" {
+         PngReader().read(ByteArray(16) { 0x42 }, null) shouldBe null
+      }
+      "return null for jpeg bytes" {
+         val jpeg = javaClass.getResourceAsStream("/com/sksamuel/scrimage/bird.jpg")!!.readBytes()
+         PngReader().read(jpeg, null) shouldBe null
+      }
+      "return null when the magic differs only in the final byte" {
+         val nearlyPng = byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A, 0x1A, 0x0B)
+         PngReader().read(nearlyPng, null) shouldBe null
+      }
    }
 
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/WriteContextTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/WriteContextTest.kt
@@ -1,0 +1,72 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.JpegWriter
+import com.sksamuel.scrimage.nio.PngWriter
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.io.ByteArrayOutputStream
+
+/**
+ * Regression tests for WriteContext.bytes(), which sizes its ByteArrayOutputStream
+ * from the image dimensions (clamped to 1KB-8MB). These exercise images on both
+ * sides of the clamp to verify the output is unaffected by the initial buffer size.
+ */
+class WriteContextTest : WordSpec({
+
+   // 2x2 = 4 pixels, well below the 1024 byte lower clamp; distinct pixel colours
+   val small = ImmutableImage.create(2, 2).map { p -> Color(p.x * 100, p.y * 100, 50) }
+
+   // 3000x3000 = 9M pixels, above the 8MB upper clamp
+   val large = ImmutableImage.filled(3000, 3000, Color(10, 120, 230))
+
+   "WriteContext.bytes" should {
+      "round-trip a small image via png" {
+         val bytes = small.bytes(PngWriter.NoCompression)
+         val read = ImmutableImage.loader().fromBytes(bytes)
+         read.width shouldBe 2
+         read.height shouldBe 2
+         read.pixels().toList() shouldBe small.pixels().toList()
+      }
+      "round-trip a larger-than-clamp image via png" {
+         val bytes = large.bytes(PngWriter.MaxCompression)
+         val read = ImmutableImage.loader().fromBytes(bytes)
+         read.width shouldBe 3000
+         read.height shouldBe 3000
+         // solid fill: spot-check corners and centre rather than 9M pixels
+         listOf(0 to 0, 2999 to 0, 0 to 2999, 2999 to 2999, 1500 to 1500).forEach { (x, y) ->
+            read.pixel(x, y) shouldBe large.pixel(x, y)
+         }
+      }
+      "produce a decodable jpeg with correct dimensions for a small image" {
+         val bytes = small.bytes(JpegWriter())
+         val read = ImmutableImage.loader().fromBytes(bytes)
+         read.width shouldBe 2
+         read.height shouldBe 2
+      }
+      "produce a decodable jpeg with correct dimensions for a larger-than-clamp image" {
+         val bytes = large.bytes(JpegWriter())
+         val read = ImmutableImage.loader().fromBytes(bytes)
+         read.width shouldBe 3000
+         read.height shouldBe 3000
+      }
+      "produce output identical to write(OutputStream) for png" {
+         val streamed = ByteArrayOutputStream()
+         small.forWriter(PngWriter.NoCompression).write(streamed)
+         small.bytes(PngWriter.NoCompression).toList() shouldBe streamed.toByteArray().toList()
+
+         val streamedLarge = ByteArrayOutputStream()
+         large.forWriter(PngWriter.MaxCompression).write(streamedLarge)
+         large.bytes(PngWriter.MaxCompression).toList() shouldBe streamedLarge.toByteArray().toList()
+      }
+      "produce output identical to write(OutputStream) for jpeg" {
+         val streamed = ByteArrayOutputStream()
+         small.forWriter(JpegWriter()).write(streamed)
+         small.bytes(JpegWriter()).toList() shouldBe streamed.toByteArray().toList()
+      }
+   }
+
+})


### PR DESCRIPTION
Three small, behavior-preserving performance fixes in `scrimage-core` I/O paths.

## Changes

**`WriteContext.bytes()`** — the encoded image bytes were collected into a `ByteArrayOutputStream` with the default 32-byte capacity, so every write grew the buffer through repeated array copies. The stream is now sized from the image dimensions (~1 byte per pixel, clamped to 1KB–8MB), eliminating most of the grow-and-copy churn.

**`FormatDetector.detect()`** — each magic-byte check allocated a copy of the input prefix via `Arrays.copyOf`/`copyOfRange` and compared it with `Objects.deepEquals` (up to 6 throwaway arrays per call). Replaced with an allocation-free `startsWith` helper using the ranged `Arrays.equals(byte[], int, int, byte[], int, int)` overload (Java 9+; the project targets Java 11, and this file already uses `InputStream.readNBytes`).

**`PngReader.isPng()`** — allocated two 8-byte arrays (expected signature + a copy of the header) on every read attempt just to call `Arrays.equals`. Now compares the 8 PNG magic bytes in place, with the values spelled out for readability.

Behavior is identical in all three cases, including the short-input edge cases (prefixes shorter than a signature still fail the match without throwing).

## Test results

- `./gradlew :scrimage-tests:test` (the module containing the core tests; `:scrimage-core:test` has no sources): **574 tests, 0 failures, 0 errors**, including `FormatDetectorTest` (8), `PngReaderTest` (2), `PngReaderOverflowTest` (1), `PngWriterTest` (6), `PngWriterValidationTest` (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tests

Added regression tests covering the changed paths (commit c85f2aac):

- **`FormatDetectorTest.kt`** — new `detect(byte[]) with short input` block: empty array, 1–3 byte magic prefixes, exactly-prefix-length inputs (gif 4B, jpeg 3B, png 8B), 8–11 byte RIFF headers too short to contain the WEBP tag (must not throw from the ranged compare), RIFF with a non-WEBP tag, a minimal 12-byte RIFF/WEBP header, and unknown bytes. Detection of all four formats from real files was already covered.
- **`PngReaderTest.kt`** — new `isPng` rejection cases: empty array, 1–7 byte truncated magic, non-png bytes, real jpeg bytes, and a header differing only in the final magic byte — all return `null` without throwing.
- **`WriteContextTest.kt`** (new file) — `bytes()` round-trips for a 2×2 image (below the 1KB lower clamp of `estimatedSize()`) and a 3000×3000 image (above the 8MB upper clamp) via PNG, decodable JPEG output with correct dimensions for both, and byte-identical output between `bytes()` and `write(OutputStream)` for png and jpeg.

`./gradlew :scrimage-tests:test` passes with the new tests included.
