### PR TITLE
Reduce I/O and allocation overhead in GIF writers

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
@@ -79,7 +79,10 @@ public class GifSequenceWriter extends AbstractGifWriter {
 
          imageMetaData.setFromTree(metaFormatName, root);
 
-         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+         // Size hint to avoid repeated growth of the default 32 byte buffer; GIF output for a
+         // frame is at most one byte per pixel before LZW compression, and usually much smaller.
+         int initialCapacity = (int) Math.min(16L * 1024 * 1024, Math.max(1024L, (long) images[0].width * images[0].height));
+         try (ByteArrayOutputStream baos = new ByteArrayOutputStream(initialCapacity)) {
             try (MemoryCacheImageOutputStream output = new MemoryCacheImageOutputStream(baos)) {
                writer.setOutput(output);
                writer.prepareWriteSequence(null);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -12,6 +12,7 @@ import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
+import java.awt.image.DataBufferByte;
 import java.awt.image.DataBufferInt;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -172,8 +173,18 @@ public class StreamingGifWriter extends AbstractGifWriter {
                         workData[i] = 0;
                      }
                   }
+               } else if (workBuffer instanceof DataBufferByte && lastBuffer instanceof DataBufferByte) {
+                  byte[] workData = ((DataBufferByte) workBuffer).getData();
+                  byte[] lastData = ((DataBufferByte) lastBuffer).getData();
+                  int n = Math.min(workData.length, lastData.length);
+                  for (int i = 0; i < n; i++) {
+                     if (workData[i] == lastData[i]) {
+                        workData[i] = 0;
+                     }
+                  }
                } else {
-                  for (int i = 0; i < workBuffer.getSize(); i++) {
+                  int size = workBuffer.getSize();
+                  for (int i = 0; i < size; i++) {
                      if (workBuffer.getElem(i) == lastBuffer.getElem(i)) {
                         workBuffer.setElem(i, 0);
                      }


### PR DESCRIPTION
Pure I/O/allocation optimizations in the GIF writers. GIF output bytes are unchanged.

## Applied

**StreamingGifWriter — byte-backed fast path in the compressed frame-diff loop.** The diff loop already had a `DataBufferInt` fast path, but byte-backed images (e.g. `TYPE_3BYTE_BGR` / `TYPE_4BYTE_ABGR`, which is what JPEG-loaded images typically are) fell through to per-element `DataBuffer.getElem(i)`/`setElem(i)` virtual calls. Added a `DataBufferByte` branch that works on the underlying `byte[]` directly (semantically identical: `getElem` returns `data[i] & 0xff`, and unsigned equality equals signed byte equality). Also hoisted `getSize()` out of the remaining generic fallback loop.

**GifSequenceWriter — sensible initial capacity for the output buffer.** `bytes(...)` accumulated the encoded GIF in a `ByteArrayOutputStream` with the default 32-byte capacity, causing repeated grow-and-copy cycles. It is now sized from the first frame's pixel count (`width * height`, clamped to [1 KB, 16 MB], computed in `long` to avoid overflow). The BAOS itself is fine since the bytes are ultimately needed as a `byte[]` — only the capacity hint was missing.

## Dropped (verified, not applied)

**Wrapping `FileOutputStream` in `BufferedOutputStream` in `StreamingGifWriter.prepareStream(File, int)`.** The stream is wrapped in `MemoryCacheImageOutputStream`, whose backing `javax.imageio.stream.MemoryCache` (`BUFFER_LENGTH = 8192`) caches all writes in 8 KB blocks and flushes to the underlying stream in chunks of up to 8 KB (`MemoryCache.writeToStream`). Writes to the `FileOutputStream` are therefore already amortized; an extra 8 KB `BufferedOutputStream` would add nothing.

**Removing the `last = image.copy()` per-frame copies in the compressed path.** `ImmutableImage` extends `MutableImage` and inherits public in-place mutators (`mapInPlace`, `fillInPlace`, `setPixel`, ...), so a caller can legally mutate a frame's backing buffer after `writeFrame` returns. Retaining `last = image` without a copy would let such mutation corrupt the next frame's diff. The `work = image.copy()` is also required since the diff zero-fills it. Both copies stay.

## Tests

- `./gradlew :scrimage-tests:test` — full suite passes (`:scrimage-core:test` has no test sources; the GIF tests live in `scrimage-tests`).
- GIF-specific tests all pass, including `StreamingGifWriterTest` (compressed-mode round-trip, caller-image non-mutation, transparency) and `GifSequenceWriterTest`.

## Tests

Permanent regression coverage for the paths changed here was added in follow-up PR #697: the `DataBufferByte` compressed-diff fast path (`TYPE_4BYTE_ABGR` frames), decode parity between byte-backed and int-backed frames, the generic `getElem`/`setElem` fallback (`TYPE_USHORT_565_RGB`), and the `GifSequenceWriter` output-buffer size hint floor with tiny frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
