### PR TITLE
Hoist loop-invariant math out of filter hot loops

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ColorHalftoneFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ColorHalftoneFilter.java
@@ -121,15 +121,20 @@ public class ColorHalftoneFilter extends AbstractBufferedImageOp {
         float halfGridSize = (float)gridSize/2;
         int[] outPixels = new int[width];
         int[] inPixels = getRGB( src, 0, 0, width, height, null );
+        float[] sins = new float[3];
+        float[] coss = new float[3];
+        for ( int channel = 0; channel < 3; channel++ ) {
+            sins[channel] = (float)Math.sin( angles[channel] );
+            coss[channel] = (float)Math.cos( angles[channel] );
+        }
         for ( int y = 0; y < height; y++ ) {
             for ( int x = 0, ix = y*width; x < width; x++, ix++ )
                 outPixels[x] = (inPixels[ix] & 0xff000000) | 0xffffff;
             for ( int channel = 0; channel < 3; channel++ ) {
                 int shift = 16-8*channel;
                 int mask = 0x000000ff << shift;
-                float angle = angles[channel];
-                float sin = (float)Math.sin( angle );
-                float cos = (float)Math.cos( angle );
+                float sin = sins[channel];
+                float cos = coss[channel];
 
                 for ( int x = 0; x < width; x++ ) {
                     // Transform x,y into halftone screen coordinate space

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EdgeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EdgeFilter.java
@@ -93,11 +93,12 @@ public class EdgeFilter extends WholeImageFilter {
 		int[] outPixels = new int[width * height];
 
 		for (int y = 0; y < height; y++) {
+			int yOffset = y*width;
 			for (int x = 0; x < width; x++) {
 				int r = 0, g = 0, b = 0;
 				int rh = 0, gh = 0, bh = 0;
 				int rv = 0, gv = 0, bv = 0;
-				int a = inPixels[y*width+x] & 0xff000000;
+				int a = inPixels[yOffset+x] & 0xff000000;
 
 				for (int row = -1; row <= 1; row++) {
 					int iy = y+row;
@@ -105,7 +106,7 @@ public class EdgeFilter extends WholeImageFilter {
 					if (0 <= iy && iy < height)
 						ioffset = iy*width;
 					else
-						ioffset = y*width;
+						ioffset = yOffset;
 					int moffset = 3*(row+1)+1;
 					for (int col = -1; col <= 1; col++) {
 						int ix = x+col;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
@@ -29,6 +29,7 @@ public class SparkleFilter extends PointFilter {
 	private int centreX, centreY;
 	private long seed = 371;
 	private float[] rayLengths;
+	private double power;
 	private Random randomNumbers = new Random();
 
 	public SparkleFilter() {
@@ -103,6 +104,7 @@ public class SparkleFilter extends PointFilter {
 		centreX = width/2;
 		centreY = height/2;
 		super.setDimensions(width, height);
+		power = (100-amount) / 50.0;
 		randomNumbers.setSeed(seed);
 		rayLengths = new float[rays];
 		for (int i = 0; i < rays; i++)
@@ -137,7 +139,7 @@ public class SparkleFilter extends PointFilter {
 		if (radius != 0) {
 			float length = ImageMath.lerp(f, rayLengths[i % rays], rayLengths[(i+1) % rays]);
 			float g = length*length / (distance+0.0001f);
-			g = (float)Math.pow(g, (100-amount) / 50.0);
+			g = (float)Math.pow(g, power);
 			f -= 0.5f;
 //			f *= amount/50.0f;
 			f = 1 - f*f;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/FilterGoldenImageTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/FilterGoldenImageTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Golden image regression tests for the filters whose hot loops were optimised
+ * (loop-invariant hoisting in the jhlabs EdgeFilter, SparkleFilter and
+ * ColorHalftoneFilter). The optimisation must be bit-identical, so each filter
+ * output is compared pixel-for-pixel against a golden PNG generated before the
+ * change ([ImmutableImage.equals] compares dimensions and every ARGB value).
+ *
+ * The golden images and default-constructor parameters mirror the Scala specs
+ * (EdgeFilterTest.scala, SparkleFilterTest.scala, ColorHalftoneFilterTest.scala),
+ * which are not wired into the Gradle build. SparkleFilter is deterministic
+ * despite using java.util.Random: the jhlabs implementation seeds it with a
+ * fixed seed (371) in setDimensions before every run.
+ */
+class FilterGoldenImageTest : FunSpec({
+
+   val original = ImmutableImage.loader().fromResource("/bird_small.png")
+
+   test("EdgeFilter output matches golden image pixel-for-pixel") {
+      val expected = ImmutableImage.loader().fromResource("/com/sksamuel/scrimage/filters/bird_small_edge.png")
+      original.filter(EdgeFilter()) shouldBe expected
+   }
+
+   test("SparkleFilter output matches golden image pixel-for-pixel") {
+      val expected = ImmutableImage.loader().fromResource("/com/sksamuel/scrimage/filters/bird_small_sparkle.png")
+      original.filter(SparkleFilter()) shouldBe expected
+   }
+
+   test("ColorHalftoneFilter output matches golden image pixel-for-pixel") {
+      val expected = ImmutableImage.loader().fromResource("/com/sksamuel/scrimage/filters/bird_small_color_halftone.png")
+      original.filter(ColorHalftoneFilter()) shouldBe expected
+   }
+})


### PR DESCRIPTION
Small, output-identical performance fixes in the vendored jhlabs filters: pure loop-invariant subexpressions were being recomputed inside hot loops.

## Changes

- **ColorHalftoneFilter**: `Math.sin(angle)` / `Math.cos(angle)` for the three screen angles were recomputed inside the row loop (once per row per channel, i.e. `2 * 3 * height` trig calls). The angles only depend on the channel, so the three sin/cos pairs are now precomputed once before the row loop (6 trig calls total).
- **SparkleFilter**: `Math.pow(g, (100-amount) / 50.0)` recomputed the exponent for every pixel in `filterRGB`. The exponent is now precomputed once in `setDimensions` (alongside the existing `rayLengths` setup); the `pow` itself remains since `g` varies per pixel. (Note: `(angle+PI)/TWO_PI*rays` was deliberately left alone — refactoring it would change float rounding.)
- **EdgeFilter**: `y*width` was recomputed for every pixel (and again in the kernel row fallback); hoisted to the row loop.

## Output identity

All hoisted expressions are pure and loop-invariant, with the same operations in the same order, so results are bit-identical. Verified by comparing filter output pixel-for-pixel against the existing golden images (`bird_small_edge.png`, `bird_small_sparkle.png`, `bird_small_color_halftone.png`), since the Scala golden-image tests are not wired into the Gradle build.

## Tests

Added a permanent regression test `scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/FilterGoldenImageTest.kt` (kotest, runs with the Gradle build) that applies `EdgeFilter`, `SparkleFilter` and `ColorHalftoneFilter` (default constructors, matching the Scala golden specs) to `bird_small.png` and asserts pixel-for-pixel equality with the golden PNGs. `SparkleFilter` is deterministic — the jhlabs implementation seeds its `Random` with a fixed seed (371) in `setDimensions` before every run — so it is covered too.

`./gradlew :scrimage-filters:test` — BUILD SUCCESSFUL, all tests pass (including the three new golden-image tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
