### PR TITLE
Add regression tests for GIF writer fast paths (#695 follow-up)

### DIFF
--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
@@ -3,10 +3,13 @@
 package com.sksamuel.scrimage.core.nio
 
 import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.AnimatedGifReader
 import com.sksamuel.scrimage.nio.GifSequenceWriter
+import com.sksamuel.scrimage.nio.ImageSource
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import org.apache.commons.io.IOUtils
+import java.awt.Color
 
 class GifSequenceWriterTest : WordSpec({
 
@@ -23,6 +26,19 @@ class GifSequenceWriterTest : WordSpec({
          repeat(100) {
             GifSequenceWriter().bytes(frames)
          }
+      }
+      "write frames smaller than the output buffer size hint floor" {
+         // The output buffer is pre-sized from the first frame's pixel count,
+         // clamped to a minimum of 1024; a tiny image must still round-trip.
+         val tiny1 = ImmutableImage.filled(2, 2, Color.RED)
+         val tiny2 = ImmutableImage.filled(2, 2, Color.BLUE)
+         val bytes = GifSequenceWriter().withFrameDelay(100).bytes(arrayOf(tiny1, tiny2))
+         val decoded = AnimatedGifReader.read(ImageSource.of(bytes))
+         decoded.frameCount shouldBe 2
+         decoded.getFrame(0).width shouldBe 2
+         decoded.getFrame(0).height shouldBe 2
+         decoded.getFrame(1).width shouldBe 2
+         decoded.getFrame(1).height shouldBe 2
       }
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
@@ -10,8 +10,11 @@ import com.sksamuel.scrimage.nio.StreamingGifWriter
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.spec.style.wordSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.apache.commons.io.IOUtils
 import java.awt.image.BufferedImage
+import java.awt.image.DataBufferByte
+import java.awt.image.DataBufferInt
 import java.io.ByteArrayOutputStream
 import java.time.Duration
 
@@ -67,6 +70,125 @@ class StreamingGifWriterTest : WordSpec({
             frame2.setColor(x, y, color)
          }
          frame2.setColor(3, 3, RGBColor(255, 0, 0, 255))
+
+         val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(frame1)
+         stream.writeFrame(frame2)
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 2
+         decoded.getFrame(0).width shouldBe w
+         decoded.getFrame(0).height shouldBe h
+         decoded.getFrame(1).width shouldBe w
+         decoded.getFrame(1).height shouldBe h
+      }
+
+      "compressed-mode write of DataBufferByte frames round-trips through reader" {
+         // Hits the new DataBufferByte fast path: TYPE_4BYTE_ABGR images are
+         // backed by a byte buffer, which previously fell through to the slow
+         // generic getElem/setElem loop. Behaviour must be unchanged: the diff
+         // is applied, the frames encode, and decoding reconstructs both
+         // frames at the original dimensions.
+         val w = 8; val h = 8
+         val frame1 = ImmutableImage.create(w, h, BufferedImage.TYPE_4BYTE_ABGR)
+         val frame2 = ImmutableImage.create(w, h, BufferedImage.TYPE_4BYTE_ABGR)
+         for (y in 0 until h) for (x in 0 until w) {
+            val color = RGBColor(x * 30, y * 30, 128, 255)
+            frame1.setColor(x, y, color)
+            frame2.setColor(x, y, color)
+         }
+         frame2.setColor(3, 3, RGBColor(255, 0, 0, 255))
+
+         // sanity: these frames must actually be byte-backed so the fast path is taken
+         frame1.awt().raster.dataBuffer.shouldBeInstanceOf<DataBufferByte>()
+         frame2.awt().raster.dataBuffer.shouldBeInstanceOf<DataBufferByte>()
+
+         val snap1: IntArray = frame1.pixels().map { it.argb }.toIntArray()
+         val snap2: IntArray = frame2.pixels().map { it.argb }.toIntArray()
+
+         val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(frame1)
+         stream.writeFrame(frame2)
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 2
+         decoded.getFrame(0).width shouldBe w
+         decoded.getFrame(0).height shouldBe h
+         decoded.getFrame(1).width shouldBe w
+         decoded.getFrame(1).height shouldBe h
+
+         // the caller's byte-backed images must not be mutated by the diff step
+         frame1.pixels().map { it.argb }.toIntArray().toList() shouldBe snap1.toList()
+         frame2.pixels().map { it.argb }.toIntArray().toList() shouldBe snap2.toList()
+      }
+
+      "compressed mode decodes identically for byte-backed and int-backed frames" {
+         // The DataBufferByte fast path must produce output equivalent to the
+         // DataBufferInt fast path for pixel-identical input. The changed pixel
+         // differs in every channel (including alpha) so the byte-wise and
+         // int-wise diffs zero exactly the same pixels.
+         val w = 8; val h = 8
+         fun frames(type: Int): Pair<ImmutableImage, ImmutableImage> {
+            val f1 = ImmutableImage.create(w, h, type)
+            val f2 = ImmutableImage.create(w, h, type)
+            for (y in 0 until h) for (x in 0 until w) {
+               val color = RGBColor(x * 30, y * 30, 128, 255)
+               f1.setColor(x, y, color)
+               f2.setColor(x, y, color)
+            }
+            f2.setColor(3, 3, RGBColor(255, 0, 0, 254))
+            return f1 to f2
+         }
+
+         fun write(f1: ImmutableImage, f2: ImmutableImage): ByteArray {
+            val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
+            val output = ByteArrayOutputStream()
+            val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+            stream.writeFrame(f1)
+            stream.writeFrame(f2)
+            stream.close()
+            return output.toByteArray()
+         }
+
+         val (byte1, byte2) = frames(BufferedImage.TYPE_4BYTE_ABGR)
+         val (int1, int2) = frames(BufferedImage.TYPE_INT_ARGB)
+         byte1.awt().raster.dataBuffer.shouldBeInstanceOf<DataBufferByte>()
+         int1.awt().raster.dataBuffer.shouldBeInstanceOf<DataBufferInt>()
+
+         val byteGif = AnimatedGifReader.read(ImageSource.of(write(byte1, byte2)))
+         val intGif = AnimatedGifReader.read(ImageSource.of(write(int1, int2)))
+
+         byteGif.frameCount shouldBe intGif.frameCount
+         for (i in 0 until byteGif.frameCount) {
+            byteGif.getFrame(i).pixels() shouldBe intGif.getFrame(i).pixels()
+         }
+      }
+
+      "compressed-mode write of non-int non-byte frames uses the generic fallback" {
+         // TYPE_USHORT_565_RGB frames are backed by a DataBufferUShort, so the
+         // compressed diff must take the generic getElem/setElem fallback
+         // (where getSize() is now hoisted out of the loop). The write must
+         // still succeed and decode with the original frame count/dimensions.
+         val w = 8; val h = 8
+         val frame1 = ImmutableImage.create(w, h, BufferedImage.TYPE_USHORT_565_RGB)
+         val frame2 = ImmutableImage.create(w, h, BufferedImage.TYPE_USHORT_565_RGB)
+         for (y in 0 until h) for (x in 0 until w) {
+            val color = RGBColor(x * 30, y * 30, 128, 255)
+            frame1.setColor(x, y, color)
+            frame2.setColor(x, y, color)
+         }
+         frame2.setColor(3, 3, RGBColor(255, 0, 0, 255))
+
+         // sanity: neither fast path applies to these frames
+         val buffer = frame1.awt().raster.dataBuffer
+         (buffer is DataBufferInt) shouldBe false
+         (buffer is DataBufferByte) shouldBe false
 
          val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofMillis(100))
          val output = ByteArrayOutputStream()


### PR DESCRIPTION
Follow-up to #695, which added a `DataBufferByte` fast path to the compressed frame-diff loop in `StreamingGifWriter` and a size hint for `GifSequenceWriter`'s output buffer. Those paths had no direct test coverage (existing compressed-mode tests only exercised `DataBufferInt` frames).

## Tests

- **StreamingGifWriterTest**
  - `compressed-mode write of DataBufferByte frames round-trips through reader` — drives the new byte-buffer fast path with `TYPE_4BYTE_ABGR` frames, asserts a successful round-trip and that the caller's images are not mutated by the diff step.
  - `compressed mode decodes identically for byte-backed and int-backed frames` — writes pixel-identical frames as `TYPE_4BYTE_ABGR` and `TYPE_INT_ARGB` and asserts both gifs decode to identical pixels, proving the byte fast path is equivalent to the int fast path.
  - `compressed-mode write of non-int non-byte frames uses the generic fallback` — `TYPE_USHORT_565_RGB` frames exercise the generic `getElem`/`setElem` loop (where `getSize()` is now hoisted).
- **GifSequenceWriterTest**
  - `write frames smaller than the output buffer size hint floor` — round-trips 2x2 frames, covering the `Math.max(1024, ...)` clamp on the new initial-capacity hint.

`./gradlew :scrimage-tests:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)