### PR TITLE
Validate ratio in resizeToRatio instead of silently producing Integer.MAX_VALUE dimensions

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1054,8 +1054,18 @@ public class ImmutableImage extends MutableImage {
     * @param background  the background color if the canvas was enlarged
     * @param imageType   the AWT image type to create. See BufferedImage.TYPE_*
     * @return a new Image that is the result of resizing the canvas.
+    * @throws IllegalArgumentException if the target ratio is NaN, zero or negative.
     */
    public ImmutableImage resizeToRatio(double targetRatio, Position position, Color background, int imageType) {
+
+      // Validate up front: a zero ratio would divide to Infinity and the int cast
+      // would silently produce Integer.MAX_VALUE (an absurd allocation), a negative
+      // ratio a negative dimension, and NaN a zero dimension - all failing later
+      // with confusing errors instead of failing fast on the bad input.
+      if (Double.isNaN(targetRatio) || targetRatio <= 0)
+         throw new IllegalArgumentException(
+            "Target ratio (width / height) must be a positive number but was " + targetRatio);
+
       double currRatio = ratio();
       if (currRatio == targetRatio) return this;
       else if (currRatio > targetRatio) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ResizeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ResizeTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.scrimage.core.ops
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.Position
 import com.sksamuel.scrimage.color.RGBColor
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.awt.Color
@@ -102,6 +103,24 @@ class ResizeTest : FunSpec({
       actual1 shouldBe image
       actual2.ratio() shouldBe 1.0
       actual3.ratio() shouldBe 2.0
+   }
+
+   test("resizeToRatio should throw IllegalArgumentException for a zero ratio") {
+      shouldThrow<IllegalArgumentException> {
+         image.resizeToRatio(0.0)
+      }
+   }
+
+   test("resizeToRatio should throw IllegalArgumentException for a negative ratio") {
+      shouldThrow<IllegalArgumentException> {
+         image.resizeToRatio(-0.5)
+      }
+   }
+
+   test("resizeToRatio should throw IllegalArgumentException for a NaN ratio") {
+      shouldThrow<IllegalArgumentException> {
+         image.resizeToRatio(Double.NaN)
+      }
    }
 
    test("when resizing by pixels then the output image has the given dimensions") {


### PR DESCRIPTION
## Bug

`ImmutableImage.resizeToRatio(double targetRatio, ...)` used the user-supplied ratio in `(int) (width / targetRatio)` and `(int) (height * targetRatio)` without any validation:

- **`resizeToRatio(0.0)`** — `width / 0.0` is `Infinity`, and the int cast silently saturates to `Integer.MAX_VALUE`. On a 100x100 image the method then tries to build a 100 x 2147483647 canvas, dying with an OOM / negative-array-size error deep inside image allocation.
- **negative ratio** (e.g. `-0.5`) — produces a negative target dimension, failing later inside the `BufferedImage` constructor with a confusing message unrelated to the actual mistake.
- **`Double.NaN`** — both ratio comparisons are false, so the else branch runs and `(int) (height * NaN)` is `0`, producing a zero-width image failure.

In every case the caller gets an absurd allocation attempt or an opaque downstream error instead of being told the ratio was invalid.

## Fix

Validate the ratio up front in the deepest overload (all other overloads delegate to it) and throw `IllegalArgumentException` with a clear message for NaN, zero or negative values. This matches the explicit fail-fast validation style adopted in `HSLColor` (3b069378). Behaviour for valid ratios is unchanged.

The sibling `scaleHeightToRatio` / `scale(double)` methods have similar (less catastrophic) holes; left out to keep this PR scoped to `resizeToRatio` validation.

## Tests

Added regression tests to `scrimage-tests` `ResizeTest`:

- `resizeToRatio(0.0)` throws `IllegalArgumentException`
- `resizeToRatio(-0.5)` throws `IllegalArgumentException`
- `resizeToRatio(Double.NaN)` throws `IllegalArgumentException`
- existing test covers valid ratios (same ratio short-circuit, 1.0, 2.0)

`./gradlew :scrimage-tests:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)