### PR TITLE
Don't leak temp frame file when write fails in StreamingWebpWriter

### DIFF
--- a/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/StreamingWebpWriter.java
+++ b/scrimage-webp/src/main/java/com/sksamuel/scrimage/webp/StreamingWebpWriter.java
@@ -182,7 +182,20 @@ public class StreamingWebpWriter {
             // these PNGs are intermediates that get discarded at close().
             byte[] pngBytes = image.bytes(PngWriter.NoCompression);
             Path temp = Files.createTempFile("scrimage_webp_frame_", ".png");
-            Files.write(temp, pngBytes, StandardOpenOption.CREATE);
+            try {
+               Files.write(temp, pngBytes, StandardOpenOption.CREATE);
+            } catch (IOException | RuntimeException e) {
+               // the temp file has not been registered in `inputs` yet, so the
+               // cleanup in close() would never see it; delete it here or it
+               // leaks on disk. Deleting (rather than registering first) also
+               // keeps `inputs` and `delays` in sync if the caller swallows
+               // the exception and carries on.
+               try {
+                  temp.toFile().delete();
+               } catch (Exception ignored) {
+               }
+               throw e;
+            }
             inputs.add(temp);
             delays.add((int) delay.toMillis());
             return this;

--- a/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/StreamingWebpWriterTest.kt
+++ b/scrimage-webp/src/test/kotlin/com/sksamuel/scrimage/webp/StreamingWebpWriterTest.kt
@@ -8,7 +8,10 @@ import io.kotest.matchers.shouldBe
 import java.awt.Color
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.OutputStream
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.time.Duration
 
 class StreamingWebpWriterTest : FunSpec({
@@ -45,6 +48,21 @@ class StreamingWebpWriterTest : FunSpec({
          if (match) { count++; i += needle.size } else i++
       }
       return count
+   }
+
+   /**
+    * Snapshots the scrimage temp files currently sitting in java.io.tmpdir so
+    * tests can diff before/after instead of asserting the directory is empty
+    * (other tests or leftovers from earlier runs may already have files there).
+    */
+   fun scrimageTempFiles(): Set<Path> {
+      val tmpdir = Paths.get(System.getProperty("java.io.tmpdir"))
+      Files.list(tmpdir).use { stream ->
+         return stream
+            .filter { it.fileName.toString().startsWith("scrimage_webp_") }
+            .toList()
+            .toSet()
+      }
    }
 
    val red = ImmutableImage.filled(32, 16, Color.RED)
@@ -149,6 +167,36 @@ class StreamingWebpWriterTest : FunSpec({
       // Second close must not throw, must not re-encode, must not corrupt the
       // already-written output.
       stream.close()
+   }
+
+   test("no scrimage temp files remain after write and close") {
+      val before = scrimageTempFiles()
+      val output = ByteArrayOutputStream()
+      StreamingWebpWriter().prepareStream(output).use { stream ->
+         stream.writeFrame(red)
+         stream.writeFrame(blue)
+      }
+      isAnimatedWebp(output.toByteArray()).shouldBeTrue()
+      (scrimageTempFiles() - before) shouldBe emptySet<Path>()
+   }
+
+   test("no scrimage temp files remain when close fails to write to the destination") {
+      // A destination stream that rejects every write makes Files.copy inside
+      // close() throw after the frames were already buffered to temp PNGs.
+      // The frame temp files (and the encoded output temp file) must still be
+      // cleaned up on that failure path.
+      val failing = object : OutputStream() {
+         override fun write(b: Int): Unit = throw IOException("boom")
+         override fun write(b: ByteArray, off: Int, len: Int): Unit = throw IOException("boom")
+      }
+      val before = scrimageTempFiles()
+      val stream = StreamingWebpWriter().prepareStream(failing)
+      stream.writeFrame(red)
+      stream.writeFrame(blue)
+      shouldThrow<IOException> {
+         stream.close()
+      }
+      (scrimageTempFiles() - before) shouldBe emptySet<Path>()
    }
 
    test("withQ rejects out-of-range values") {


### PR DESCRIPTION
## Bug

In `StreamingWebpWriter.WebpStream.writeFrame`, `Files.createTempFile` succeeded and then `Files.write(temp, pngBytes, ...)` could throw (disk full, permissions, ...) before the temp `Path` was added to the `inputs` list. The cleanup in `close()` only deletes paths registered in `inputs`, so on that failure the `scrimage_webp_frame_*.png` file leaked on disk.

## Fix

If the write fails, delete the just-created temp file and rethrow. Deleting (rather than registering in `inputs` before the write) keeps `inputs` and `delays` in sync if the caller swallows the exception and continues using the stream.

I scanned the rest of the module for the same pattern (`createTempFile` followed by fallible work before registration for cleanup): `CWebpHandler`, `DWebpHandler`, `Gif2WebpHandler`, `AnimDumpHandler`, `WebpMuxHandler` and `Img2WebpHandler` already guard their temp files with nested try/finally (or register in the cleanup list before writing), so `writeFrame` was the only remaining instance.

## Tests

The exact failure point (`Files.write` throwing after `createTempFile` succeeded) can't be triggered realistically through the public API — it requires the JVM temp dir to fill up between the two calls, and `java.io.tmpdir` is cached by `TempFileHelper` at first use so it can't be redirected per-test. Instead the new tests pin the cleanup behaviour that is observable:

- happy path: no `scrimage_webp_*` temp files remain after write + close
- failure path: when `close()` fails writing the encoded animation to the destination `OutputStream`, the buffered frame temp files (and the encoded output temp file) are still cleaned up and the exception propagates

`./gradlew :scrimage-webp:test` passes (30 tests, including the 2 new ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
