### PR TITLE
Fix zoom() padding with opaque white instead of transparent when zooming out

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1860,13 +1860,16 @@ public class ImmutableImage extends MutableImage {
     * <p>
     * This can be thought of as zooming in on a camera - the viewpane does not change but the image increases
     * in size with the outer columns/rows being dropped as required.
+    * <p>
+    * When zooming out (factor &lt; 1) the canvas area not covered by the scaled image is transparent,
+    * consistent with the defaults used by resizeTo, fit and pad.
     *
     * @param factor how much to zoom by
     * @param method how to apply the scaling method
     * @return the zoomed image
     */
    public ImmutableImage zoom(double factor, ScaleMethod method) {
-      return scale(factor, method).resizeTo(width, height, Position.Center, Color.WHITE).associateMetadata(metadata);
+      return scale(factor, method).resizeTo(width, height, Position.Center, Colors.Transparent.awt()).associateMetadata(metadata);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ZoomTransparentBackgroundTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ZoomTransparentBackgroundTest.kt
@@ -1,0 +1,51 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.PngWriter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression test for zoom(factor < 1) padding the canvas with opaque white.
+ *
+ * zoom is documented as "scaling this image but without changing the canvas
+ * size". When zooming out, the area not covered by the scaled image must be
+ * transparent, consistent with the no-color defaults used elsewhere in the
+ * library (resizeTo, fit, pad all default to Colors.Transparent).
+ *
+ * Previously zoom delegated to resizeTo(..., Color.WHITE), which destroyed
+ * transparency in PNG workflows.
+ */
+class ZoomTransparentBackgroundTest : FunSpec({
+
+   test("zoom(0.5) on a transparent PNG keeps corner pixels transparent") {
+      // fully opaque red source, round-tripped through PNG to mirror real usage
+      val bytes = ImmutableImage.filled(100, 100, Color.RED).bytes(PngWriter.NoCompression)
+      val image = ImmutableImage.loader().fromBytes(bytes)
+
+      val zoomed = image.zoom(0.5)
+
+      zoomed.width shouldBe 100
+      zoomed.height shouldBe 100
+
+      // corners are outside the scaled-down image and must be fully transparent
+      zoomed.pixel(0, 0).alpha() shouldBe 0
+      zoomed.pixel(99, 0).alpha() shouldBe 0
+      zoomed.pixel(0, 99).alpha() shouldBe 0
+      zoomed.pixel(99, 99).alpha() shouldBe 0
+
+      // the centre still contains the scaled image, opaque red
+      zoomed.pixel(50, 50).alpha() shouldBe 255
+      zoomed.pixel(50, 50).red() shouldBe 255
+   }
+
+   test("zoom(0.5) on an image with existing transparency keeps corners at alpha 0") {
+      val image = ImmutableImage.create(80, 80).fill(Color(0, 255, 0, 128))
+
+      val zoomed = image.zoom(0.5)
+
+      zoomed.pixel(0, 0).alpha() shouldBe 0
+      zoomed.pixel(79, 79).alpha() shouldBe 0
+   }
+})


### PR DESCRIPTION
## Problem

`ImmutableImage.zoom(double factor, ScaleMethod method)` delegates to:

```java
return scale(factor, method).resizeTo(width, height, Position.Center, Color.WHITE).associateMetadata(metadata);
```

When `factor < 1` (zooming out), the scaled image no longer covers the canvas and the remainder is padded with **opaque white**, destroying transparency. `image.zoom(0.5)` on a transparent PNG produces opaque white borders.

This contradicts:

- **The method's own contract** — the javadoc promises "scaling this image but without changing the canvas size" and says nothing about a white backdrop. `docs/zoom.md` likewise only describes the camera-zoom analogy.
- **The library-wide convention** — every comparable operation defaults its background to transparent when no color is given: `resizeTo(w, h)` → `Colors.Transparent.awt()`, as do `resize`, `resizeToWidth/Height/Ratio`, `fit()`, `padTo`, `padWith`, `padLeft/Right`, and `autocrop`. `zoom` was the lone outlier hardcoding `Color.WHITE`.

No existing tests or golden images pin the white behavior (the only zoom test checks metadata preservation), so this appears to be an oversight rather than a design choice.

## Fix

`zoom` now pads with `Colors.Transparent.awt()`, matching the rest of the library. The javadoc documents the zoom-out behavior explicitly. Callers wanting a specific background can still compose it themselves via `scale(factor).resizeTo(w, h, position, color)`.

### Before / after

```kotlin
val image = ImmutableImage.loader().fromBytes(transparentPngBytes) // 100x100
val zoomed = image.zoom(0.5)
zoomed.pixel(0, 0).alpha()
// before: 255 (opaque white corner)
// after:  0   (transparent corner)
```

> **Note: behavior change.** Code that relied on the undocumented white padding of `zoom(factor < 1)` will now get transparent padding. Zooming in (`factor >= 1`) is unaffected — the canvas is fully covered either way.

## Testing

- New regression test `scrimage-tests/.../ZoomTransparentBackgroundTest.kt` (kotest FunSpec): `zoom(0.5)` on a PNG round-trip keeps all four corner pixels at alpha 0 while the centre stays opaque; plus an already-transparent source case.
- `./gradlew :scrimage-tests:test` — all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)