### PR TITLE
Round instead of truncate in average() grayscale calculations

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -101,7 +101,8 @@ public class RGBColor implements Color {
    }
 
    public int average() {
-      return (red + green + blue) / 3;
+      // round, rather than truncate, for consistency with LumaGrayscale and WeightedGrayscale
+      return Math.round((red + green + blue) / 3f);
    }
 
    public int[] toArray() {

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/Pixel.java
@@ -44,7 +44,8 @@ public class Pixel {
    }
 
    public int average() {
-      return (red() + green() + blue()) / 3;
+      // round, rather than truncate, for consistency with LumaGrayscale and WeightedGrayscale
+      return Math.round((red() + green() + blue()) / 3f);
    }
 
    public int x() {
@@ -143,7 +144,7 @@ public class Pixel {
     * @return a new grayscale copy of this pixel using the average method
     */
    public Pixel toAverageGrayscale() {
-      int gray = (red() + green() + blue()) / 3;
+      int gray = average();
       return new Pixel(x, y, gray, gray, gray, alpha());
    }
 

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -81,7 +81,8 @@ public class PixelTools {
     * @return the gray value of the pixel, between 0 and 255
     */
    public static int gray(int pixel) {
-      return (red(pixel) + green(pixel) + blue(pixel)) / 3;
+      // round, rather than truncate, for consistency with LumaGrayscale and WeightedGrayscale
+      return Math.round((red(pixel) + green(pixel) + blue(pixel)) / 3f);
    }
 
    public static int truncate(Double value) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToAverageGrayscaleTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ToAverageGrayscaleTest.kt
@@ -52,7 +52,7 @@ class ToAverageGrayscaleTest : FunSpec({
 
    test("toAverageGrayscale on pure red returns 85 (255/3)") {
       val p = Pixel(0, 0, 255, 0, 0, 255)
-      // 255 / 3 = 85 (integer division)
+      // 255 / 3 = 85 (exact)
       p.toAverageGrayscale().red() shouldBe 85
    }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/AverageRoundingTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/AverageRoundingTest.kt
@@ -1,0 +1,74 @@
+package com.sksamuel.scrimage.core.color
+
+import com.sksamuel.scrimage.color.RGBColor
+import com.sksamuel.scrimage.pixels.Pixel
+import com.sksamuel.scrimage.pixels.PixelTools
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression tests for the average() grayscale calculation.
+ *
+ * RGBColor.average(), Pixel.average(), Pixel.toAverageGrayscale() and
+ * PixelTools.gray() previously truncated the arithmetic mean using integer
+ * division ((r + g + b) / 3), while the sibling grayscale methods
+ * LumaGrayscale and WeightedGrayscale both round via Math.round.
+ *
+ * These tests pin the rounded behaviour, e.g. RGB(0, 0, 2) averages to
+ * round(2/3) = 1, not 0.
+ */
+class AverageRoundingTest : FunSpec({
+
+   test("RGBColor.average rounds rather than truncates") {
+      RGBColor(0, 0, 2).average() shouldBe 1   // 2/3  = 0.67 -> 1
+      RGBColor(0, 0, 5).average() shouldBe 2   // 5/3  = 1.67 -> 2
+      RGBColor(0, 0, 1).average() shouldBe 0   // 1/3  = 0.33 -> 0
+      RGBColor(1, 1, 2).average() shouldBe 1   // 4/3  = 1.33 -> 1
+      RGBColor(255, 255, 254).average() shouldBe 255 // 764/3 = 254.67 -> 255
+   }
+
+   test("RGBColor.average is exact when the sum divides evenly") {
+      RGBColor(0, 0, 0).average() shouldBe 0
+      RGBColor(100, 150, 200).average() shouldBe 150
+      RGBColor(255, 255, 255).average() shouldBe 255
+   }
+
+   test("Pixel.average rounds rather than truncates") {
+      Pixel(0, 0, 0, 0, 2, 255).average() shouldBe 1
+      Pixel(0, 0, 0, 0, 5, 255).average() shouldBe 2
+      Pixel(0, 0, 0, 0, 1, 255).average() shouldBe 0
+      Pixel(0, 0, 255, 255, 254, 255).average() shouldBe 255
+   }
+
+   test("Pixel.toAverageGrayscale rounds rather than truncates") {
+      val gray = Pixel(0, 0, 0, 0, 2, 255).toAverageGrayscale()
+      gray.red() shouldBe 1
+      gray.green() shouldBe 1
+      gray.blue() shouldBe 1
+
+      val gray2 = Pixel(0, 0, 0, 0, 5, 128).toAverageGrayscale()
+      gray2.red() shouldBe 2
+      gray2.green() shouldBe 2
+      gray2.blue() shouldBe 2
+      gray2.alpha() shouldBe 128
+   }
+
+   test("PixelTools.gray rounds rather than truncates") {
+      PixelTools.gray(PixelTools.argb(255, 0, 0, 2)) shouldBe 1
+      PixelTools.gray(PixelTools.argb(255, 0, 0, 5)) shouldBe 2
+      PixelTools.gray(PixelTools.argb(255, 100, 150, 200)) shouldBe 150
+   }
+
+   test("RGBColor.average and Pixel.average agree for the same channels") {
+      val channels = listOf(
+         Triple(0, 0, 2),
+         Triple(0, 0, 5),
+         Triple(1, 2, 3),
+         Triple(13, 77, 200),
+         Triple(254, 255, 255),
+      )
+      channels.forEach { (r, g, b) ->
+         RGBColor(r, g, b).average() shouldBe Pixel(0, 0, r, g, b, 255).average()
+      }
+   }
+})


### PR DESCRIPTION
## Summary

The "average" grayscale path truncates the arithmetic mean with integer division, while the sibling grayscale methods round:

- `LumaGrayscale.toGrayscale` — `Math.round(0.2126R + 0.7152G + 0.0722B)`
- `WeightedGrayscale.toGrayscale` — `Math.round(0.299R + 0.587G + 0.114B)`
- average methods — `(r + g + b) / 3` (integer division, truncates)

So `RGB(0, 0, 2).average()` returned `0` instead of `1`, and `RGB(0, 0, 5)` returned `1` instead of `2`. This PR aligns the average calculation on rounding: `Math.round((r + g + b) / 3f)`.

## Affected methods

- `RGBColor.average()` (also feeds `AverageGrayscale.toGrayscale` / `GrayscaleMethod.AVERAGE`)
- `Pixel.average()`
- `Pixel.toAverageGrayscale()` (now delegates to `Pixel.average()`)
- `PixelTools.gray(int)`

These were the only first-party copies of the `/3` pattern; vendored `thirdparty` filter sources were left untouched.

## Behavior change (flagging explicitly)

This is a tiny but real behavior change: for channel sums not divisible by 3, the average-grayscale value can now be 1 higher than before (round vs floor). If the truncation was intentional (e.g. to match some external reference output), feel free to reject. No golden images needed regenerating — the existing grayscale tests (`ToGrayscaleTest`, `ToAverageGrayscaleTest`) use values that divide evenly by 3 and still pass unchanged.

## Tests

- Added `scrimage-tests/.../core/color/AverageRoundingTest.kt` pinning rounded values (e.g. `RGB(0,0,2) -> 1`, `RGB(0,0,5) -> 2`), exact cases, `toAverageGrayscale` and `PixelTools.gray` behavior, and agreement between `RGBColor.average` and `Pixel.average`.
- `./gradlew :scrimage-tests:test` — 580 tests, 0 failures, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)