### PR TITLE
Fix GREEN blend mode using destination green and source blue channels

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/romainguy/BlendComposite.java
+++ b/scrimage-core/src/main/java/thirdparty/romainguy/BlendComposite.java
@@ -309,8 +309,8 @@ public final class BlendComposite implements Composite {
                   @Override
                   public void blend(int[] src, int[] dst, int[] result) {
                      result[0] = dst[0];
-                     result[1] = src[1];
-                     result[2] = dst[2];
+                     result[1] = dst[1];
+                     result[2] = src[2];
                      result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };
@@ -409,8 +409,8 @@ public final class BlendComposite implements Composite {
                   @Override
                   public void blend(int[] src, int[] dst, int[] result) {
                      result[0] = dst[0];
-                     result[1] = dst[1];
-                     result[2] = src[2];
+                     result[1] = src[1];
+                     result[2] = dst[2];
                      result[3] = Math.min(255, src[3] + dst[3]);
                   }
                };

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/composite/ChannelCompositeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/composite/ChannelCompositeTest.kt
@@ -1,0 +1,55 @@
+package com.sksamuel.scrimage.core.composite
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.composite.BlueComposite
+import com.sksamuel.scrimage.composite.GreenComposite
+import com.sksamuel.scrimage.composite.RedComposite
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Pins the channel selection of the RED/GREEN/BLUE channel-replacement composites.
+ *
+ * Each mode must take exactly one channel from the overlay (the blend source) and keep
+ * the other two channels from the base image (the blend destination):
+ *
+ *   RED   = (src.red, dst.green, dst.blue)
+ *   GREEN = (dst.red, src.green, dst.blue)
+ *   BLUE  = (dst.red, dst.green, src.blue)
+ *
+ * Regression test for the GREEN/BLUE blenders being swapped in
+ * thirdparty.romainguy.BlendComposite (GREEN used the source blue channel and
+ * BLUE used the source green channel).
+ */
+class ChannelCompositeTest : FunSpec({
+
+   // base (blend destination) and overlay (blend source) with distinct values per channel
+   val base = ImmutableImage.filled(10, 10, Color(10, 20, 30))
+   val overlay = ImmutableImage.filled(10, 10, Color(200, 150, 100))
+
+   test("red composite replaces only the red channel with the overlay's red") {
+      val pixel = base.composite(RedComposite(1.0), overlay).pixel(5, 5)
+      pixel.red() shouldBe 200
+      pixel.green() shouldBe 20
+      pixel.blue() shouldBe 30
+      pixel.alpha() shouldBe 255
+   }
+
+   test("green composite replaces only the green channel with the overlay's green") {
+      val pixel = base.composite(GreenComposite(1.0), overlay).pixel(5, 5)
+      pixel.red() shouldBe 10
+      pixel.green() shouldBe 150
+      pixel.blue() shouldBe 30
+      pixel.alpha() shouldBe 255
+   }
+
+   test("blue composite replaces only the blue channel with the overlay's blue") {
+      val pixel = base.composite(BlueComposite(1.0), overlay).pixel(5, 5)
+      pixel.red() shouldBe 10
+      pixel.green() shouldBe 20
+      pixel.blue() shouldBe 100
+      pixel.alpha() shouldBe 255
+   }
+
+})


### PR DESCRIPTION
## Bug

The `GREEN` and `BLUE` blenders in `thirdparty/romainguy/BlendComposite.java` had each other's formulas (arrays are `[R, G, B, A]`):

| Mode | Was (buggy) | Canonical (Romain Guy's original) |
|------|-------------|-----------------------------------|
| RED  | `{src[0], dst[1], dst[2]}` | `{src[0], dst[1], dst[2]}` (correct) |
| GREEN | `{dst[0], dst[1], src[2]}` — destination green, **source blue** | `{dst[0], src[1], dst[2]}` |
| BLUE | `{dst[0], src[1], dst[2]}` — **source green**, destination blue | `{dst[0], dst[1], src[2]}` |

So `GreenComposite` actually replaced the base image's blue channel with the overlay's blue, and `BlueComposite` replaced the green channel — the two modes were swapped relative to their names. The alpha formula (`min(255, src[3] + dst[3])`) was already consistent across all three and is unchanged.

## Fix

Swapped the two blender bodies back so each mode takes exactly its named channel from the overlay (blend source) and keeps the other two from the base image (blend destination).

## Tests

Added `scrimage-tests/.../core/composite/ChannelCompositeTest.kt` (kotest FunSpec) pinning all three channel-replacement composites: it composites an overlay of `(200, 150, 100)` over a base of `(10, 20, 30)` at alpha 1.0 via the public `ImmutableImage.composite` API and asserts exact per-channel output for `RedComposite`, `GreenComposite` and `BlueComposite`.

`./gradlew :scrimage-tests:test` passes (126 test classes, 0 failures).

## Golden images

No test golden image pins the green/blue composite output — `scrimage-tests/src/test/resources/composite/` only contains the two `alpha_composite*.png` references, so nothing needed regenerating. The `examples/composite/green_*` / `blue_*` images are README example assets produced by the fully commented-out `CompositeExampleGenerator.scala`; they now show pre-fix output and could be regenerated separately if desired.

## Note

Open PR #693 (scratch-array allocation refactor) touches the same file; the overlap is a trivial signature/formatting conflict, so whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)