### PR TITLE
Fix ArrayIndexOutOfBoundsException in VariableBlurFilter on 1-pixel-wide or tall images

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/VariableBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/VariableBlurFilter.java
@@ -150,10 +150,18 @@ public class VariableBlurFilter extends AbstractBufferedImageOp {
                 if ( i1 > widthMinus1 ) {
                     int f = i1-widthMinus1;
 					int l = widthMinus1;
-					ta += (a[l]-a[l-1]) * f;
-					tr += (r[l]-r[l-1]) * f;
-					tg += (g[l]-g[l-1]) * f;
-					tb += (b[l]-b[l-1]) * f;
+					if ( l == 0 ) {
+						// only one column: the prefix sum a[0] is the pixel value itself
+						ta += a[0] * f;
+						tr += r[0] * f;
+						tg += g[0] * f;
+						tb += b[0] * f;
+					} else {
+						ta += (a[l]-a[l-1]) * f;
+						tr += (r[l]-r[l-1]) * f;
+						tg += (g[l]-g[l-1]) * f;
+						tb += (b[l]-b[l-1]) * f;
+					}
 					i1 = widthMinus1;
                 }
 				int i2 = x-ra-1;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VariableBlurFilterTinyImageTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VariableBlurFilterTinyImageTest.kt
@@ -1,0 +1,69 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import thirdparty.jhlabs.image.VariableBlurFilter
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+/**
+ * Regression: VariableBlurFilter.blur() crashed with
+ * ArrayIndexOutOfBoundsException (index -1) when the dimension being
+ * blurred was a single pixel and the blur radius at that pixel was > 0.
+ * The right-edge clamp computed the last pixel value from the prefix
+ * sums as a[l] - a[l-1] with l = width-1 = 0, reading a[-1].
+ * Since blur() runs once per axis, both 1-pixel-wide and 1-pixel-tall
+ * images crashed.
+ */
+class VariableBlurFilterTinyImageTest : FunSpec({
+
+   // a blur mask of the same dimensions, fully white, so that the blur
+   // radius is maximal at every pixel (the default blurRadiusAt ramps
+   // from 0, which masks the bug at x == 0)
+   fun filterFor(width: Int, height: Int): VariableBlurFilter {
+      val mask = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+      val g = mask.createGraphics()
+      g.color = Color.WHITE
+      g.fillRect(0, 0, width, height)
+      g.dispose()
+      val filter = VariableBlurFilter()
+      filter.radius = 2
+      filter.blurMask = mask
+      return filter
+   }
+
+   fun image(width: Int, height: Int): ImmutableImage =
+      ImmutableImage.filled(width, height, Color.ORANGE)
+
+   test("variable blur of a 1x1 image completes and preserves dimensions") {
+      val result = image(1, 1).op(filterFor(1, 1))
+      result.width shouldBe 1
+      result.height shouldBe 1
+   }
+
+   test("variable blur of a 1xN image completes and preserves dimensions") {
+      val result = image(1, 7).op(filterFor(1, 7))
+      result.width shouldBe 1
+      result.height shouldBe 7
+   }
+
+   test("variable blur of an Nx1 image completes and preserves dimensions") {
+      val result = image(7, 1).op(filterFor(7, 1))
+      result.width shouldBe 7
+      result.height shouldBe 1
+   }
+
+   test("variable blur of a 2x2 image completes and preserves dimensions") {
+      val result = image(2, 2).op(filterFor(2, 2))
+      result.width shouldBe 2
+      result.height shouldBe 2
+   }
+
+   test("variable blur of a normal-size image is deterministic") {
+      val source = ImmutableImage.loader().fromResource("/bird_small.png")
+      val first = source.op(filterFor(source.width, source.height))
+      val second = source.op(filterFor(source.width, source.height))
+      first.pixels().map { it.argb } shouldBe second.pixels().map { it.argb }
+   }
+})


### PR DESCRIPTION
## Bug

`thirdparty.jhlabs.image.VariableBlurFilter.blur()` crashes when the dimension being blurred is a single pixel and the blur radius at the edge pixel is non-zero (e.g. when a `blurMask` is set, or `blurRadiusAt` is overridden). Since `blur()` runs once per axis (horizontal then vertical with swapped dimensions), both 1-pixel-wide and 1-pixel-tall images are affected.

Reproduction (via the public `ImmutableImage.op` entry point — there is no scrimage `Filter` wrapper for this class):

```kotlin
val mask = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB) // fully white
val filter = VariableBlurFilter().apply { radius = 2; blurMask = mask }
ImmutableImage.filled(1, 1, Color.ORANGE).op(filter)
```

```
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 1
    at thirdparty.jhlabs.image.VariableBlurFilter.blur(VariableBlurFilter.java:153)
    at thirdparty.jhlabs.image.VariableBlurFilter.filter(VariableBlurFilter.java:68)
    at com.sksamuel.scrimage.ImmutableImage.op(ImmutableImage.java:887)
```

## Cause

`blur()` computes box sums from per-row prefix sums. The right-edge clamp replicates the last pixel value using `a[l] - a[l-1]` with `l = width - 1`. When `width == 1`, `l == 0` and the code reads `a[-1]`.

## Fix

Minimal guard inside the clamp branch: when `l == 0` the prefix sum `a[0]` *is* the last (only) pixel value, so use it directly. Widths >= 2 never enter the new branch, so output for all non-degenerate sizes is bit-identical — the main path is untouched. The edge-replication arithmetic for `width == 2` was checked and already survives the clamp (covered by a test anyway).

## Tests

New `VariableBlurFilterTinyImageTest` (kotest FunSpec):

- 1x1, 1xN, Nx1, 2x2 images complete without exception and preserve dimensions (the first three failed with the AIOOBE before the fix)
- a normal-size image run twice produces identical output (sanity that the main path is unchanged)

`./gradlew :scrimage-filters:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)