### PR TITLE
Clamp MMCQ.avg() channels to [0,255] so quantize() doesn't crash on solid-colour images

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
+++ b/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
@@ -50,6 +50,20 @@ public class MMCQ {
    }
 
    /**
+    * Clamp a computed average to a valid 8-bit colour channel. The centre of the topmost
+    * quantization bucket, and the midpoint formula used for empty buckets produced by a
+    * median cut, can evaluate to 256 (or slightly above), which is outside the [0, 255]
+    * range a colour channel can hold. Returning such a value crashes callers that validate
+    * the range (e.g. RGBColor.fromRGB).
+    */
+   private static int clampChannel(int value) {
+      if (value < 0) {
+         return 0;
+      }
+      return Math.min(value, 255);
+   }
+
+   /**
     * 3D color space box.
     */
    public static class VBox {
@@ -140,10 +154,11 @@ public class MMCQ {
             }
 
             if (ntot > 0) {
-               _avg = new int[] {~~(rsum / ntot), ~~(gsum / ntot), ~~(bsum / ntot)};
+               _avg = new int[] {clampChannel(rsum / ntot), clampChannel(gsum / ntot),
+                  clampChannel(bsum / ntot)};
             } else {
-               _avg = new int[] {~~(MULT * (r1 + r2 + 1) / 2), ~~(MULT * (g1 + g2 + 1) / 2),
-                  ~~(MULT * (b1 + b2 + 1) / 2)};
+               _avg = new int[] {clampChannel(MULT * (r1 + r2 + 1) / 2),
+                  clampChannel(MULT * (g1 + g2 + 1) / 2), clampChannel(MULT * (b1 + b2 + 1) / 2)};
             }
          }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/QuantizeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/QuantizeTest.kt
@@ -3,11 +3,23 @@ package com.sksamuel.scrimage.core
 import com.sksamuel.scrimage.ImmutableImage
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.awt.Color
 
 class QuantizeTest : FunSpec() {
    init {
 
       val image = ImmutableImage.loader().fromResource("/com/sksamuel/scrimage/bird.jpg")
+
+      test("quantize of a solid colour image returns in-range channels") {
+         // A single dominant colour leaves the upper half of the median cut empty; that empty
+         // box's averaged centre evaluated to 256, outside [0, 255], crashing RGBColor.fromRGB.
+         val palette = ImmutableImage.filled(20, 20, Color.RED).quantize(2)
+         palette.forEach { c ->
+            (c.red in 0..255) shouldBe true
+            (c.green in 0..255) shouldBe true
+            (c.blue in 0..255) shouldBe true
+         }
+      }
 
       test("quantize 16") {
 


### PR DESCRIPTION
## Problem

`ImmutableImage.quantize(n)` throws on a solid or strongly-dominant colour image:

```java
ImmutableImage.filled(20, 20, Color.RED).quantize(2);
// java.lang.IllegalArgumentException: RGBColor red component must be in [0, 255] but was 256
```

## Cause

A single dominant colour leaves the upper half of the median cut empty. `MMCQ.VBox.avg()` computes the centre of an empty box as `MULT * (r1 + r2 + 1) / 2`, which for a box at the top of the colour space evaluates to **256** — outside the `[0, 255]` range a colour channel can hold. (Reproduced: `quantize(2)` of solid red returns palette entries `252,4,4` and `256,4,4`.) ColorThief returns the int unchanged, and `ImmutableImage.quantize()` hands it to `RGBColor.fromRGB`, which validates the range and throws.

## Fix

Clamp the per-channel averages to `[0, 255]` at the source in `MMCQ.avg()` — both the populated branch (`rsum/ntot`) and the empty-box midpoint branch. This also covers `map()`/`nearest()`, which share `avg()`. In-range values are untouched, so existing palette output is unchanged (the existing `QuantizeTest` golden hex assertions still pass).

## Test

Added a regression test in `QuantizeTest` asserting every channel of a solid-colour image's palette is in `[0, 255]`. Fails on master (throws), passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)