### PR TITLE
Reject empty frame array in GifSequenceWriter.bytes with a clear error

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
@@ -62,6 +62,10 @@ public class GifSequenceWriter extends AbstractGifWriter {
 
    public byte[] bytes(ImmutableImage[] images) throws IOException {
 
+      if (images == null || images.length == 0) {
+         throw new IllegalArgumentException("Cannot write a gif with no frames");
+      }
+
       ImageWriter writer = ImageIO.getImageWritersBySuffix("gif").next();
       try {
          ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/GifSequenceWriterTest.kt
@@ -6,6 +6,7 @@ import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.nio.AnimatedGifReader
 import com.sksamuel.scrimage.nio.GifSequenceWriter
 import com.sksamuel.scrimage.nio.ImageSource
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import org.apache.commons.io.IOUtils
@@ -39,6 +40,12 @@ class GifSequenceWriterTest : WordSpec({
          decoded.getFrame(0).height shouldBe 2
          decoded.getFrame(1).width shouldBe 2
          decoded.getFrame(1).height shouldBe 2
+      }
+      "reject an empty frame array with a clear error" {
+         // Previously dereferenced images[0] and threw a confusing ArrayIndexOutOfBoundsException.
+         shouldThrow<IllegalArgumentException> {
+            GifSequenceWriter().bytes(emptyArray())
+         }
       }
    }
 


### PR DESCRIPTION
## Problem

`GifSequenceWriter().bytes(new ImmutableImage[0])` — and the `output(...)` overloads that delegate to it — throw a confusing `ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0`.

## Cause

`bytes()` dereferences `images[0]` twice (to build the `ImageTypeSpecifier` and the output-buffer size hint) without first checking the array is non-empty.

## Fix

A gif must have at least one frame, so validate up front and throw `IllegalArgumentException("Cannot write a gif with no frames")` instead of an opaque AIOOBE. Also guards against a null array.

## Test

Added a regression test asserting an empty frame array throws `IllegalArgumentException`. Fails on master (AIOOBE), passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)