### PR TITLE
Dispose Graphics2D in try/finally in ImageUtils.convert

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/mortennobel/ImageUtils.java
+++ b/scrimage-core/src/main/java/thirdparty/mortennobel/ImageUtils.java
@@ -195,8 +195,11 @@ public class ImageUtils {
    public static BufferedImage convert(BufferedImage src, int bufImgType) {
       BufferedImage img = new BufferedImage(src.getWidth(), src.getHeight(), bufImgType);
       Graphics2D g2d = img.createGraphics();
-      g2d.drawImage(src, 0, 0, null);
-      g2d.dispose();
+      try {
+         g2d.drawImage(src, 0, 0, null);
+      } finally {
+         g2d.dispose();
+      }
       return img;
    }
 }


### PR DESCRIPTION
## Problem

`thirdparty.mortennobel.ImageUtils.convert` disposes its `Graphics2D` only as a trailing statement:

```java
Graphics2D g2d = img.createGraphics();
g2d.drawImage(src, 0, 0, null);  // if this throws, dispose() is skipped
g2d.dispose();
```

If `drawImage` throws, the `Graphics2D` leaks.

## Why it matters

`convert` is on the **live resize path** — `ResampleOp` calls it whenever a `TYPE_BYTE_BINARY`, `TYPE_BYTE_INDEXED`, or `TYPE_CUSTOM` image is resampled (e.g. scaling a palette GIF or a 1-bit image). This is the same dispose-in-`finally` pattern already applied across the codebase in #656, #657, and #411.

## Fix

Wrap the draw in `try/finally` so the `Graphics2D` is always released. No behavioural change on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)