### PR TITLE
Guard DominantGradient against images with fewer than two dominant colours

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/DominantGradientFilter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/filter/DominantGradientFilter.java
@@ -20,8 +20,16 @@ public class DominantGradientFilter implements Filter {
    @Override
    public void apply(ImmutableImage image) throws IOException {
       RGBColor[] dominant = image.quantize(2);
+      // A blank (e.g. all-white) image quantizes to no colours, and a single-colour
+      // image to one; in either case there is no second stop, so leave a colourless
+      // image untouched and fall back to a solid fill of the only dominant colour.
+      if (dominant.length == 0) {
+         return;
+      }
+      RGBColor top = dominant[0];
+      RGBColor bottom = dominant.length > 1 ? dominant[1] : dominant[0];
       ImmutableImage gradient = ImmutableImage.create(image.width, image.height)
-         .fill(LinearGradient.vertical(dominant[0].awt(), dominant[1].awt()));
+         .fill(LinearGradient.vertical(top.awt(), bottom.awt()));
       int w = image.width;
       int h = image.height;
       int[] pixels = gradient.awt().getRGB(0, 0, w, h, null, 0, w);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/DominantGradient.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/transform/DominantGradient.java
@@ -23,12 +23,21 @@ public class DominantGradient implements Transform {
       // get the dominant colours
       RGBColor[] dominant = input.quantize(2);
 
+      // A blank (e.g. all-white) image quantizes to no colours, and a single-colour
+      // image to one; in either case there is no second stop, so return a colourless
+      // image untouched and fall back to a solid fill of the only dominant colour.
+      if (dominant.length == 0) {
+         return input;
+      }
+      RGBColor top = dominant[0];
+      RGBColor bottom = dominant.length > 1 ? dominant[1] : dominant[0];
+
       // create the linear gradient image (top-to-bottom). The previous code
       // called LinearGradient.horizontal(...) which, due to a swapped name
       // bug fixed in the same commit as this file, actually produced a
       // vertical gradient — switching to vertical() preserves the visual
       // output that the existing fixture images depend on.
       return ImmutableImage.create(input.width, input.height)
-         .fill(LinearGradient.vertical(dominant[0].awt(), dominant[1].awt()));
+         .fill(LinearGradient.vertical(top.awt(), bottom.awt()));
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/DominantGradientFilterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/DominantGradientFilterTest.kt
@@ -4,10 +4,19 @@ import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.transform.DominantGradient
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.awt.Color
 
 class DominantGradientFilterTest : FunSpec({
 
    val image = ImmutableImage.fromResource("/com/sksamuel/scrimage/bird.jpg").scaleToWidth(200)
+
+   test("leaves a blank image with no dominant colours unchanged") {
+      // A blank image quantizes to an empty palette; indexing dominant[0]/[1] used to
+      // throw ArrayIndexOutOfBoundsException.
+      val white = ImmutableImage.filled(20, 20, Color.WHITE)
+      val out = white.filter(DominantGradientFilter())
+      out shouldBe white
+   }
 
    test("preserves the image dimensions") {
       val out = image.filter(DominantGradientFilter())


### PR DESCRIPTION
## Problem

`DominantGradient` and `DominantGradientFilter` index `dominant[0]` and `dominant[1]` unconditionally, assuming `quantize(2)` always returns two colours:

```java
RGBColor[] dominant = image.quantize(2);
... LinearGradient.vertical(dominant[0].awt(), dominant[1].awt());
```

A blank image (e.g. all white) quantizes to an empty palette, and a single-colour image to one entry, so both throw `ArrayIndexOutOfBoundsException` on degenerate input.

## Fix

Leave a colourless image unchanged, and fall back to a solid fill of the only dominant colour when just one is found.

## Test

`DominantGradientFilterTest`: an all-white image is left unchanged instead of crashing. Verified to fail with `ArrayIndexOutOfBoundsException` on the base branch and pass with the guard.

## Stacking

> **Based on #705** (`fix/quantize-npe-all-white`). That PR makes `quantize()` return an empty palette for an all-white image instead of NPEing; without it this path would NPE upstream before reaching the indexing. Please merge #705 first — this PR will retarget to `master` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)