### PR TITLE
Clamp resizeToWidth/resizeToHeight derived dimension to at least 1

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1107,7 +1107,10 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image that is the result of resizing the canvas.
     */
    public ImmutableImage resizeToHeight(int targetHeight, Position position, Color background, int imageType) {
-      return resizeTo((int) (targetHeight / (double) height * width), targetHeight, position, background, imageType);
+      // Clamp the derived width to at least 1: for an extreme aspect ratio (e.g. a 1x1000
+      // image) the integer arithmetic floors to 0, which then fails creating a 0-width canvas.
+      int targetWidth = Math.max(1, (int) (targetHeight / (double) height * width));
+      return resizeTo(targetWidth, targetHeight, position, background, imageType);
    }
 
    /**
@@ -1140,7 +1143,10 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image that is the result of resizing the canvas.
     */
    public ImmutableImage resizeToWidth(int targetWidth, Position position, Color background, int imageType) {
-      return resizeTo(targetWidth, (int) (targetWidth / (double) width * height), position, background, imageType);
+      // Clamp the derived height to at least 1: for an extreme aspect ratio (e.g. a 1000x1
+      // image) the integer arithmetic floors to 0, which then fails creating a 0-height canvas.
+      int targetHeight = Math.max(1, (int) (targetWidth / (double) width * height));
+      return resizeTo(targetWidth, targetHeight, position, background, imageType);
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ResizeTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ResizeTest.kt
@@ -134,4 +134,18 @@ class ResizeTest : FunSpec({
       972 shouldBe scaled.width
       648 shouldBe scaled.height
    }
+
+   test("resizeToWidth clamps the derived height to at least 1 for an extreme aspect ratio") {
+      // A 1000x1 strip: the aspect-preserving height is 1000/1000 -> floors to 0, which used
+      // to throw "Width (10) and height (0) cannot be <= 0" creating a 0-height canvas.
+      val out = ImmutableImage.create(1000, 1).resizeToWidth(10)
+      out.width shouldBe 10
+      out.height shouldBe 1
+   }
+
+   test("resizeToHeight clamps the derived width to at least 1 for an extreme aspect ratio") {
+      val out = ImmutableImage.create(1, 1000).resizeToHeight(10)
+      out.width shouldBe 1
+      out.height shouldBe 10
+   }
 })


### PR DESCRIPTION
## Problem

`resizeToWidth` and `resizeToHeight` derive the other dimension from the aspect ratio with integer arithmetic that floors to 0 for an extreme aspect ratio:

```java
resizeToWidth:  resizeTo(targetWidth, (int)(targetWidth/(double)width*height), ...)
resizeToHeight: resizeTo((int)(targetHeight/(double)height*width), targetHeight, ...)
```

For a `1000x1` image, `resizeToWidth(10)` derives height `(int)(10/1000.0*1) = 0`; a `1x1000` image's `resizeToHeight(10)` derives width 0. Creating the 0-sized canvas then throws:

```
java.lang.IllegalArgumentException: Width (10) and height (0) cannot be <= 0
```

## Fix

These are canvas resizes (crop/pad, **not** resampling), so a 1px result is valid. Clamp the derived dimension to `Math.max(1, …)` — an extreme aspect ratio now yields the smallest valid canvas instead of crashing.

## Test

`ResizeTest`: `1000x1 .resizeToWidth(10)` → `10x1`, and `1x1000 .resizeToHeight(10)` → `1x10`. Both throw on master, pass with the fix.

## Note (not in this PR)

`fit`/`max`/`bound` and `scaleToWidth`/`scaleToHeight` have the same floor-to-zero in their aspect math, but those route through the resampler, which independently requires a ≥3×3 target — so clamping there only changes the error message, not the outcome. Left out deliberately to keep this fix demonstrable; the confusing fit/max error for extreme ratios could be a separate hardening change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)