### PR TITLE
Fix LaplaceFilter NullPointerException on single-row images

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LaplaceFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LaplaceFilter.java
@@ -47,8 +47,14 @@ public class LaplaceFilter extends AbstractBufferedImageOp {
         int[] pixels = new int[width];
         row1 = getRGB( src, 0, 0, width, 1, row1 );
         row2 = getRGB( src, 0, 0, width, 1, row2 );
+        // Seed row3 from the first row so it is never null. For height >= 2 it is
+        // overwritten by the y+1 read on the first iteration (so output is unchanged);
+        // for a single-row image there is no row below, and clamping the bottom
+        // neighbour to the current row avoids a NullPointerException at row3[x].
+        row3 = getRGB( src, 0, 0, width, 1, row3 );
         brightness( row1 );
         brightness( row2 );
+        brightness( row3 );
         for ( int y = 0; y < height; y++ ) {
             if ( y < height-1) {
                 row3 = getRGB( src, 0, y+1, width, 1, row3 );
@@ -79,6 +85,8 @@ public class LaplaceFilter extends AbstractBufferedImageOp {
 
         row1 = getRGB( dst, 0, 0, width, 1, row1 );
         row2 = getRGB( dst, 0, 0, width, 1, row2 );
+        // Seed row3 for the same single-row reason as the first pass.
+        row3 = getRGB( dst, 0, 0, width, 1, row3 );
         for ( int y = 0; y < height; y++ ) {
             if ( y < height-1) {
                 row3 = getRGB( dst, 0, y+1, width, 1, row3 );

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/LaplaceFilterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/LaplaceFilterTest.kt
@@ -1,0 +1,26 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class LaplaceFilterTest : FunSpec({
+
+   test("applies to a single-row image without throwing") {
+      // height == 1 means there is no row below, so the internal `row3` neighbour
+      // buffer was never initialised; the inner x-loop (which runs for width >= 3)
+      // then dereferenced a null row3 -> NullPointerException.
+      for (width in listOf(3, 4, 10)) {
+         val out = ImmutableImage.filled(width, 1, Color.WHITE).filter(LaplaceFilter())
+         out.width shouldBe width
+         out.height shouldBe 1
+      }
+   }
+
+   test("applies to a single-column image without throwing") {
+      val out = ImmutableImage.filled(1, 10, Color.WHITE).filter(LaplaceFilter())
+      out.width shouldBe 1
+      out.height shouldBe 10
+   }
+})


### PR DESCRIPTION
## Problem

`image.filter(new LaplaceFilter())` throws on any image with `height == 1` and `width >= 3`:

```java
ImmutableImage.filled(3, 1, Color.WHITE).filter(LaplaceFilter());
// java.lang.NullPointerException: Cannot load from int array because "row3" is null
```

## Cause

The filter uses three sliding-window row buffers (`row1`, `row2`, `row3`) but only reads a value into `row3` inside the `if (y < height-1)` guard. For a single-row image that guard is never true, so `row3` stays `null`, while the inner `for (x = 1; x < width-1; x++)` loop still runs for `width >= 3` and dereferences `row3[x]`.

Analogous to the VariableBlurFilter single-pixel fix (#703).

## Fix

Seed `row3` from the first row in both passes. For `height >= 2` it is overwritten by the `y+1` read on the first iteration, so existing output is unchanged; for a single-row image the bottom neighbour clamps to the current row (sensible edge behaviour) and the crash is gone.

## Test

`LaplaceFilterTest`: single-row (`3x1`, `4x1`, `10x1`) and single-column images filter without throwing and preserve dimensions. Fails on master (NPE), passes with the fix. Full filters + core suites stay green (no golden change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)