### PR TITLE
Fix ShearFilter ArrayIndexOutOfBoundsException by honouring the resize flag

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ShearFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ShearFilter.java
@@ -63,16 +63,26 @@ public class ShearFilter extends TransformFilter {
 	}
 	
 	protected void transformSpace(Rectangle r) {
-		float tangent = (float)Math.tan(xangle);
-		xoffset = -r.height * tangent;
-		if (tangent < 0.0)
-			tangent = -tangent;
-		r.width = (int)(r.height * tangent + r.width + 0.999999f);
-		tangent = (float)Math.tan(yangle);
-		yoffset = -r.width * tangent;
-		if (tangent < 0.0)
-			tangent = -tangent;
-		r.height = (int)(r.width * tangent + r.height + 0.999999f);
+		if (resize) {
+			float tangent = (float)Math.tan(xangle);
+			xoffset = -r.height * tangent;
+			if (tangent < 0.0)
+				tangent = -tangent;
+			r.width = (int)(r.height * tangent + r.width + 0.999999f);
+			tangent = (float)Math.tan(yangle);
+			yoffset = -r.width * tangent;
+			if (tangent < 0.0)
+				tangent = -tangent;
+			r.height = (int)(r.width * tangent + r.height + 0.999999f);
+		} else {
+			// When not resizing, keep the output the same size as the input and shear
+			// in place (no offset); the transform's edge action samples/clips whatever
+			// falls outside the source. Previously `resize` was ignored and the output
+			// rectangle was always enlarged, overflowing a same-sized destination buffer
+			// and throwing ArrayIndexOutOfBoundsException from setRGB.
+			xoffset = 0.0f;
+			yoffset = 0.0f;
+		}
 	}
 
 /*

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ShearFilterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ShearFilterTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class ShearFilterTest : FunSpec({
+
+   test("shearing produces a same-sized image without throwing") {
+      // The scrimage wrapper requests setResize(false) so the output keeps the
+      // input dimensions, but the resize flag was ignored: transformSpace always
+      // enlarged the output rectangle, which overflowed the same-sized destination
+      // buffer and threw ArrayIndexOutOfBoundsException from setRGB.
+      val src = ImmutableImage.filled(20, 20, Color.WHITE)
+      val out = src.filter(ShearFilter(0.5f, 0.0f))
+      out.width shouldBe 20
+      out.height shouldBe 20
+      // the top-left corner stays within the source, so it remains white
+      out.pixel(0, 0).toARGBInt() shouldBe Color.WHITE.rgb
+   }
+
+   test("shearing on both axes also stays in bounds") {
+      val out = ImmutableImage.filled(15, 25, Color.WHITE).filter(ShearFilter(0.3f, 0.2f))
+      out.width shouldBe 15
+      out.height shouldBe 25
+   }
+})


### PR DESCRIPTION
## Problem

`image.filter(new ShearFilter(xAngle, yAngle))` throws for any non-zero angle:

```java
ImmutableImage.filled(20, 20, Color.WHITE).filter(ShearFilter(0.5f, 0f));
// java.lang.ArrayIndexOutOfBoundsException: Coordinate out of bounds!
```

## Cause

`ShearFilter.transformSpace` always enlarges the output rectangle for a non-zero shear angle, **ignoring the `resize` field** (it has a setter but was read nowhere). The scrimage wrapper calls `op.setResize(false)`, and `BufferedOpFilter` runs the op in place (`op().filter(image.awt(), image.awt())`), so the destination is the same size as the source. The enlarged `transformedSpace.width` then overflows that buffer — `TransformFilter` writes `setRGB(dst, 0, y, transformedSpace.width, …)` with a width larger than the raster, throwing on the first row.

## Fix

Honour the flag in `transformSpace`:
- `resize == true` (default): unchanged — direct jhlabs use with a `null` dst still grows the canvas exactly as before.
- `resize == false`: keep the output the same size and shear in place (no offset), letting the transform's edge action clip the overflow.

## Test

`ShearFilterTest`: shearing a filled image on one or both axes returns a same-sized image (not a crash), with the in-bounds top-left corner preserved. Fails on master (AIOOBE), passes with the fix. Filters suite stays green (no Shear golden existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)