### PR TITLE
Harden ZERO_EDGES handling in the static convolution helpers

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ConvolveFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ConvolveFilter.java
@@ -335,11 +335,15 @@ public class ConvolveFilter extends AbstractBufferedImageOp {
 								ix = 0;
 							else if ( edgeAction == WRAP_EDGES )
 								ix = (x+width) % width;
+							else
+								continue; // ZERO_EDGES: out-of-bounds contributes nothing
 						} else if ( ix >= width) {
 							if ( edgeAction == CLAMP_EDGES )
 								ix = width-1;
 							else if ( edgeAction == WRAP_EDGES )
 								ix = (x+width) % width;
+							else
+								continue; // ZERO_EDGES: out-of-bounds contributes nothing
 						}
 						int rgb = inPixels[ioffset+ix];
 						a += f * ((rgb >> 24) & 0xff);
@@ -386,14 +390,14 @@ public class ConvolveFilter extends AbstractBufferedImageOp {
 						else if ( edgeAction == WRAP_EDGES )
 							ioffset = ((y+height) % height)*width;
 						else
-							ioffset = iy*width;
+							continue; // ZERO_EDGES: out-of-bounds contributes nothing
 					} else if ( iy >= height) {
 						if ( edgeAction == CLAMP_EDGES )
 							ioffset = (height-1)*width;
 						else if ( edgeAction == WRAP_EDGES )
 							ioffset = ((y+height) % height)*width;
 						else
-							ioffset = iy*width;
+							continue; // ZERO_EDGES: out-of-bounds contributes nothing
 					} else
 						ioffset = iy*width;
 

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GaussianFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GaussianFilter.java
@@ -128,11 +128,15 @@ public class GaussianFilter extends ConvolveFilter {
                                 ix = 0;
                             else if (edgeAction == WRAP_EDGES)
                                 ix = (x + width) % width;
+                            else
+                                continue; // ZERO_EDGES: out-of-bounds contributes nothing
                         } else if (ix >= width) {
                             if (edgeAction == CLAMP_EDGES)
                                 ix = width - 1;
                             else if (edgeAction == WRAP_EDGES)
                                 ix = (x + width) % width;
+                            else
+                                continue; // ZERO_EDGES: out-of-bounds contributes nothing
                         }
                         int rgb = inPixels[ioffset + ix];
                         int pa = (rgb >> 24) & 0xff;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ConvolveZeroEdgesTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ConvolveZeroEdgesTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.scrimage.filter
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import thirdparty.jhlabs.image.ConvolveFilter
+import thirdparty.jhlabs.image.GaussianFilter
+import java.awt.image.Kernel
+
+/**
+ * The static convolution helpers handled CLAMP_EDGES and WRAP_EDGES at the image
+ * borders but, for ZERO_EDGES, left the sample index out of range and indexed the
+ * pixel array anyway, throwing ArrayIndexOutOfBoundsException. (convolveHV already
+ * skipped out-of-bounds samples correctly.) ZERO_EDGES means out-of-bounds
+ * neighbours contribute nothing, so the border samples should simply be skipped.
+ */
+class ConvolveZeroEdgesTest : FunSpec({
+
+   val gray = 0xff808080.toInt()
+   val red = { rgb: Int -> (rgb shr 16) and 0xff }
+
+   // a horizontal gaussian kernel (width=5, height=1) and its vertical form (width=1, height=5)
+   val hKernel = GaussianFilter.makeKernel(2f)
+   val vKernel = Kernel(1, hKernel.width, hKernel.getKernelData(null))
+
+   test("convolveAndTranspose does not overrun the array with ZERO_EDGES") {
+      val width = 5; val height = 1
+      val inPix = IntArray(width * height) { gray }
+      val out = IntArray(width * height)
+      GaussianFilter.convolveAndTranspose(hKernel, inPix, out, width, height, true, false, false, ConvolveFilter.ZERO_EDGES)
+      // out is transposed to height x width; for height==1 index is just x
+      red(out[2]) shouldBe 128            // centre unaffected
+      red(out[0]) shouldBeLessThan 128    // edge pulled toward the zero background
+   }
+
+   test("convolveH does not overrun the array with ZERO_EDGES") {
+      val width = 5; val height = 1
+      val inPix = IntArray(width * height) { gray }
+      val out = IntArray(width * height)
+      ConvolveFilter.convolveH(hKernel, inPix, out, width, height, true, ConvolveFilter.ZERO_EDGES)
+      red(out[2]) shouldBe 128
+      red(out[0]) shouldBeLessThan 128
+   }
+
+   test("convolveV does not overrun the array with ZERO_EDGES") {
+      val width = 1; val height = 5
+      val inPix = IntArray(width * height) { gray }
+      val out = IntArray(width * height)
+      ConvolveFilter.convolveV(vKernel, inPix, out, width, height, true, ConvolveFilter.ZERO_EDGES)
+      red(out[2]) shouldBe 128
+      red(out[0]) shouldBeLessThan 128
+   }
+})


### PR DESCRIPTION
## Problem

`GaussianFilter.convolveAndTranspose` and `ConvolveFilter.convolveH` / `convolveV` handle `CLAMP_EDGES` and `WRAP_EDGES` at the image borders, but for `ZERO_EDGES` they fall through without adjusting the out-of-range sample index and then index the pixel array anyway:

```
java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 5
```

`convolveHV` already handles `ZERO_EDGES` correctly (it skips out-of-bounds samples), so the three siblings were simply inconsistent with it.

These are `public static` methods, so the crash is reachable for direct API callers even though the in-tree filters currently only pass `CLAMP`/`WRAP`.

## Fix

`ZERO_EDGES` means an out-of-bounds neighbour contributes nothing — so `continue` past it, matching `convolveHV`. The `CLAMP_EDGES` and `WRAP_EDGES` paths are unchanged (verified: full filters + core suites stay green, no golden image changes).

## Test

`ConvolveZeroEdgesTest` calls each of the three methods directly with `ZERO_EDGES` on a solid image: the centre pixel is unaffected and the border is pulled toward the zero background. All three throw `ArrayIndexOutOfBoundsException` on master and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)