### PR TITLE
Add ConvolveFilter for arbitrary custom-kernel convolution (filterous-2 'convolute')

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ConvolveFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ConvolveFilter.java
@@ -1,0 +1,68 @@
+/*
+   Copyright 2013 Stephen K Samuel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package com.sksamuel.scrimage.filter;
+
+import java.awt.image.BufferedImageOp;
+import java.awt.image.Kernel;
+
+/**
+ * Applies an arbitrary convolution kernel to an image — the building block for
+ * sharpen, blur, edge-detection and emboss effects via a custom matrix. This is
+ * the equivalent of filterous-2's {@code convolute(matrix)}.
+ *
+ * <p>The kernel is applied exactly as given (it is <b>not</b> renormalised), and
+ * out-of-bounds neighbours at the image borders are clamped to the edge pixel.
+ * Matrices are row-major.
+ */
+public class ConvolveFilter extends BufferedOpFilter {
+
+    private final int kernelWidth;
+    private final int kernelHeight;
+    private final float[] matrix;
+
+    /**
+     * Creates a 3x3 convolution filter from a 9-element row-major matrix.
+     *
+     * @param matrix the nine kernel weights, row by row
+     */
+    public ConvolveFilter(float[] matrix) {
+        this(3, 3, matrix);
+    }
+
+    /**
+     * Creates a convolution filter from a {@code kernelWidth} x {@code kernelHeight}
+     * row-major matrix.
+     *
+     * @param kernelWidth  the number of columns in the kernel
+     * @param kernelHeight the number of rows in the kernel
+     * @param matrix       the kernel weights, row by row (length must be width * height)
+     */
+    public ConvolveFilter(int kernelWidth, int kernelHeight, float[] matrix) {
+        if (kernelWidth <= 0 || kernelHeight <= 0)
+            throw new IllegalArgumentException("kernel dimensions must be positive");
+        if (matrix == null || matrix.length != kernelWidth * kernelHeight)
+            throw new IllegalArgumentException(
+                "matrix length must be kernelWidth * kernelHeight (" + (kernelWidth * kernelHeight) + ")");
+        this.kernelWidth = kernelWidth;
+        this.kernelHeight = kernelHeight;
+        this.matrix = matrix.clone();
+    }
+
+    @Override
+    public BufferedImageOp op() {
+        return new thirdparty.jhlabs.image.ConvolveFilter(new Kernel(kernelWidth, kernelHeight, matrix));
+    }
+}

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ConvolveFilterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/filter/ConvolveFilterTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+class ConvolveFilterTest : FunSpec({
+
+   test("identity kernel leaves the image unchanged") {
+      val img = ImmutableImage.create(5, 5).map { p -> Color(p.x * 20 + 10, p.y * 20 + 10, 100) }
+      val identity = floatArrayOf(0f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 0f)
+      val out = img.filter(ConvolveFilter(identity))
+      out.pixels().toList() shouldBe img.pixels().toList()
+   }
+
+   test("sharpen kernel applies the matrix as given") {
+      // gray 100 everywhere except a brighter centre pixel
+      val img = ImmutableImage.create(5, 5).map { p ->
+         if (p.x == 2 && p.y == 2) Color(200, 200, 200) else Color(100, 100, 100)
+      }
+      val sharpen = floatArrayOf(0f, -1f, 0f, -1f, 5f, -1f, 0f, -1f, 0f)
+      val out = img.filter(ConvolveFilter(sharpen))
+      // centre: 5*200 - 4*100 = 600 -> clamped to 255
+      out.pixel(2, 2).red() shouldBe 255
+      // orthogonal neighbour of centre: 5*100 - (100+200+100+100) = 0
+      out.pixel(2, 1).red() shouldBe 0
+      // interior pixel with all-100 neighbourhood: 5*100 - 4*100 = 100 (unchanged)
+      out.pixel(1, 1).red() shouldBe 100
+   }
+})


### PR DESCRIPTION
## Context

Comparing the filters in [filterous-2](https://github.com/girliemac/filterous-2) against Scrimage: **Scrimage already implements every filterous-2 filter** — all 40 Instagram presets (Aden … Xpro2, Nashville, 1977, etc., in `filter.instagram`) and every basic adjustment (grayscale, sepia, invert, brightness, contrast, `rgbAdjust`→`RGBFilter`, `colorFilter`→`ColorizeFilter`, `saturation`/`hueSaturation`→`HSBFilter`).

The **one** filterous-2 filter with no public Scrimage equivalent was `convolute` — a general custom-kernel convolution. (The jhlabs `ConvolveFilter` existed but was internal-only.)

## This PR

Adds `com.sksamuel.scrimage.filter.ConvolveFilter`, exposing arbitrary-matrix convolution:

```java
// 3x3 sharpen
image.filter(new ConvolveFilter(new float[]{0,-1,0, -1,5,-1, 0,-1,0}));
// arbitrary kernel
image.filter(new ConvolveFilter(width, height, matrix));
```

- Kernel applied **as given** (not renormalised), matching filterous-2.
- Borders clamp to the edge pixel (CLAMP_EDGES); edge-action selection is intentionally not exposed.
- Matrix length validated against the kernel dimensions.

## Tests

Deterministic (`ConvolveFilterTest`):
- Identity kernel `[0,0,0, 0,1,0, 0,0,0]` leaves the image unchanged.
- Sharpen kernel on a known image yields the hand-computed values: centre `5*200 - 4*100 = 600 → 255`, an orthogonal neighbour `0`, an all-100 neighbourhood `100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)