### PR TITLE
Bring UnsupportedFormatException up to par with ImageParseException

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/UnsupportedFormatException.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/UnsupportedFormatException.java
@@ -1,9 +1,27 @@
 package com.sksamuel.scrimage;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class UnsupportedFormatException extends IOException {
-   public UnsupportedFormatException(String msg) {
-      super(msg);
+
+   private final List<Throwable> errors;
+
+   public UnsupportedFormatException(List<Throwable> errors) {
+      super(
+         "Image parsing failed, could not determine format from provided bytes. Tried the following ImageReader implementations:\n" +
+            errors.stream().map(Throwable::getMessage).collect(Collectors.joining("\n"))
+      );
+      this.errors = errors;
+   }
+
+   public UnsupportedFormatException() {
+      this(new ArrayList<>());
+   }
+
+   public List<Throwable> getErrors() {
+      return errors;
    }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageReaders.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageReaders.java
@@ -2,6 +2,7 @@ package com.sksamuel.scrimage.nio;
 
 import com.sksamuel.scrimage.ImageParseException;
 import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.UnsupportedFormatException;
 import com.sksamuel.scrimage.format.Format;
 import com.sksamuel.scrimage.format.FormatDetector;
 
@@ -62,7 +63,7 @@ public class ImageReaders {
       }
       Format format = FormatDetector.detect(bytes).orElse(null);
       if (format == null)
-         throw new ImageParseException(errors);
+         throw new UnsupportedFormatException(errors);
       else
          throw new ImageParseException(errors, format);
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/MultipleImageLoaderExceptionErrorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/MultipleImageLoaderExceptionErrorTest.kt
@@ -13,7 +13,8 @@ class MultipleImageLoaderExceptionErrorTest : FunSpec() {
          val e = shouldThrowAny {
             ImmutableImageLoader.create().load(ImageSource.of(bytes))
          }
-         e.message shouldContain """Image parsing failed for unknown image format. Tried the following ImageReader implementations"""
+         e.message shouldContain """Image parsing failed"""
+         e.message shouldContain """Tried the following ImageReader implementations"""
          e.message shouldContain """com.sksamuel.scrimage.nio.ImageIOReader"""
          e.message shouldContain """com.sksamuel.scrimage.nio.PngReader"""
       }


### PR DESCRIPTION
I spotted this exception type while working on a project where I needed to be able to determine whether a parse failure was due to the input data being of a recognized format but unparseable (unexpected EOF, etc.) or because the input data did not match a known format at all. Sadly, `UnsupportedFormatException` is an unused stub right now so I had to resort to doing string matching on the different message texts of `ImageParseException`.

This PR just brings `UnsupportedFormatException` up to be about on par with `ImageParseException` and makes use of it instead of `ImageParseException` where I think it makes sense to.

Since all exceptions thrown from `ImmutableImage.read()` are still descendants of `IOException`, the signature doesn't really change.