### PR TITLE
Fix NullPointerException in GifSequenceReader on a GIF with no colour table

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/internal/GifSequenceReader.java
@@ -738,14 +738,20 @@ public class GifSequenceReader {
          if (bgIndex == transIndex)
             bgColor = 0;
       }
-      int save = 0;
-      if (transparency) {
-         save = act[transIndex];
-         act[transIndex] = 0; // set transparent color if specified
-      }
-
       if (act == null) {
          status = STATUS_FORMAT_ERROR; // no color table defined
+         return; // bail before dereferencing act below (a malformed GIF with
+                 // no global/local colour table and the transparency flag set
+                 // would otherwise NPE here rather than report a format error)
+      }
+
+      // transIndex is read as an unsigned byte (0-255) but the active colour
+      // table may hold fewer entries, so guard the index before indexing it.
+      boolean applyTransparency = transparency && transIndex < act.length;
+      int save = 0;
+      if (applyTransparency) {
+         save = act[transIndex];
+         act[transIndex] = 0; // set transparent color if specified
       }
 
       if (err()) return;
@@ -765,7 +771,7 @@ public class GifSequenceReader {
 
       frames.add(new GifFrame(image, delay, dispose)); // add image to frame list
 
-      if (transparency) {
+      if (applyTransparency) {
          act[transIndex] = save;
       }
       resetFrame();

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderNullColorTableTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/internal/GifSequenceReaderNullColorTableTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.scrimage.core.nio.internal
+
+import com.sksamuel.scrimage.nio.internal.GifSequenceReader
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.ByteArrayInputStream
+
+/**
+ * Regression for GifSequenceReader.readImage NPEing on a malformed GIF that has
+ * no global colour table (GCTFlag = 0), no local colour table (LCTFlag = 0) and
+ * the transparency flag set in a graphics control extension. The active colour
+ * table `act` is then null, but the transparency block dereferenced
+ * `act[transIndex]` before the null check ran, throwing a raw
+ * NullPointerException out of read(...) instead of returning STATUS_FORMAT_ERROR.
+ */
+class GifSequenceReaderNullColorTableTest : FunSpec({
+
+   // GIF89a, 1x1, no global colour table, a GCE with the transparency bit set,
+   // then an image descriptor with no local colour table.
+   val malformed = byteArrayOf(
+      'G'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(),
+      '8'.code.toByte(), '9'.code.toByte(), 'a'.code.toByte(), // signature
+      0x01, 0x00,             // logical screen width = 1
+      0x01, 0x00,             // logical screen height = 1
+      0x00,                   // packed: GCTFlag = 0 (no global colour table)
+      0x00,                   // background colour index
+      0x00,                   // pixel aspect ratio
+      0x21, 0xF9.toByte(), 0x04, // graphic control extension introducer + label + block size
+      0x01,                   // packed: transparency flag = 1
+      0x00, 0x00,             // delay
+      0x00,                   // transparent colour index
+      0x00,                   // block terminator
+      0x2C,                   // image separator
+      0x00, 0x00, 0x00, 0x00, // image left, top
+      0x01, 0x00, 0x01, 0x00, // image width = 1, height = 1
+      0x00,                   // packed: LCTFlag = 0 (no local colour table)
+      0x3B                    // trailer
+   )
+
+   test("readImage reports STATUS_FORMAT_ERROR instead of NPEing when no colour table is defined") {
+      val reader = GifSequenceReader()
+      val status: Int = reader.read(ByteArrayInputStream(malformed))
+      status shouldBe GifSequenceReader.STATUS_FORMAT_ERROR
+   }
+})


### PR DESCRIPTION
## Problem

`GifSequenceReader.readImage` dereferenced `act[transIndex]` in the transparency block **before** the `if (act == null)` check that immediately follows it:

```java
int save = 0;
if (transparency) {
   save = act[transIndex];      // NPE when act == null
   act[transIndex] = 0;
}
if (act == null) {              // too late
   status = STATUS_FORMAT_ERROR;
}
```

`act` is the active colour table (`lct` if a local table is present, otherwise the global `gct`). A malformed GIF that declares **no global colour table** (GCTFlag = 0), supplies **no local colour table** (LCTFlag = 0) and sets the **transparency flag** in a graphics control extension leaves `act == null`, so `save = act[transIndex]` throws a raw `NullPointerException`.

Unlike the other format errors in this reader (which set `status` and are handled gracefully), this NPE propagated out of `readImage` → `readContents` → `read(...)`. As a result `AnimatedGifReader.read` threw `NullPointerException` instead of the intended `IOException("Error loading animated GIF")`, so callers catching `IOException` never caught it.

## Fix

- Move the `act == null` check above the transparency block and return early, so `act` is never dereferenced while null (status is set to `STATUS_FORMAT_ERROR`, which `read` reports normally).
- Guard the transparent-colour index against the table length. `transIndex` is read as an unsigned byte (0–255) but the active table may hold fewer entries, so the index is also a latent `ArrayIndexOutOfBoundsException`. The set and the later restore are guarded symmetrically.

## Test

Adds `GifSequenceReaderNullColorTableTest`, which feeds a hand-built malformed GIF (no GCT, no LCT, transparency flag set) and asserts `read` returns `STATUS_FORMAT_ERROR` instead of throwing. Fails with an NPE before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)