### PR TITLE
Honour tRNS palette transparency when decoding indexed PNGs

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngReader.java
@@ -46,15 +46,28 @@ public class PngReader implements ImageReader {
       int[] matrix = new int[(int) pixelCount];
 
       if (pngr.imgInfo.indexed) {
+         ar.com.hjg.pngj.chunks.PngChunkPLTE plte = pngr.getMetadata().getPLTE();
+         // The tRNS chunk carries per-palette-entry alpha for indexed PNGs.
+         // When present, palette2rgb unpacks 4 channels (RGBA) so the entry's
+         // alpha is honoured; previously it was passed null and every pixel was
+         // forced to alpha 255, silently dropping palette transparency.
+         ar.com.hjg.pngj.chunks.PngChunkTRNS trns = pngr.getMetadata().getTRNS();
          int[] pixels = null;
          for (int row = 0; row < h; row++) {
             ImageLineInt scanline = (ImageLineInt) pngr.readRow();
             if (bitDepth < 8)
                ImageLineHelper.scaleUp(scanline);
-            pixels = ImageLineHelper.palette2rgb(scanline, pngr.getMetadata().getPLTE(), null, pixels);
             int rowOffset = row * w;
-            for (int x = 0, k = 0; x < w; x++, k += 3) {
-               matrix[rowOffset + x] = PixelTools.argb(255, pixels[k], pixels[k + 1], pixels[k + 2]);
+            if (trns == null) {
+               pixels = ImageLineHelper.palette2rgb(scanline, plte, pixels); // 3 channels (RGB)
+               for (int x = 0, k = 0; x < w; x++, k += 3) {
+                  matrix[rowOffset + x] = PixelTools.argb(255, pixels[k], pixels[k + 1], pixels[k + 2]);
+               }
+            } else {
+               pixels = ImageLineHelper.palette2rgb(scanline, plte, trns, pixels); // 4 channels (RGBA)
+               for (int x = 0, k = 0; x < w; x++, k += 4) {
+                  matrix[rowOffset + x] = PixelTools.argb(pixels[k + 3], pixels[k], pixels[k + 1], pixels[k + 2]);
+               }
             }
          }
       } else {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderIndexedTransparencyTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngReaderIndexedTransparencyTest.kt
@@ -1,0 +1,65 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.nio.PngReader
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+import java.awt.image.IndexColorModel
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+/**
+ * Regression for PngReader dropping palette transparency (the tRNS chunk) when
+ * decoding indexed (colour type 3) PNGs. It used to pass null for the tRNS chunk
+ * and hard-code alpha 255, so an indexed PNG with one or more transparent palette
+ * entries decoded fully opaque.
+ */
+class PngReaderIndexedTransparencyTest : WordSpec({
+
+   // An indexed PNG with a 2-entry palette: index 0 = opaque red, index 1 = fully transparent.
+   // ImageIO emits a PLTE + tRNS chunk for an IndexColorModel that carries alpha.
+   fun indexedPngWithTransparency(): ByteArray {
+      val reds = byteArrayOf(255.toByte(), 0)
+      val greens = byteArrayOf(0, 0)
+      val blues = byteArrayOf(0, 0)
+      val alphas = byteArrayOf(255.toByte(), 0)
+      val icm = IndexColorModel(8, 2, reds, greens, blues, alphas)
+      val img = BufferedImage(2, 1, BufferedImage.TYPE_BYTE_INDEXED, icm)
+      img.raster.setSample(0, 0, 0, 0) // opaque red
+      img.raster.setSample(1, 0, 0, 1) // transparent
+      val baos = ByteArrayOutputStream()
+      ImageIO.write(img, "png", baos)
+      return baos.toByteArray()
+   }
+
+   fun containsChunk(bytes: ByteArray, type: String): Boolean {
+      val t = type.toByteArray(Charsets.US_ASCII)
+      outer@ for (i in 0..bytes.size - t.size) {
+         for (j in t.indices) if (bytes[i + j] != t[j]) continue@outer
+         return true
+      }
+      return false
+   }
+
+   "PngReader" should {
+      "honour tRNS palette transparency on indexed PNGs" {
+         val bytes = indexedPngWithTransparency()
+
+         // sanity check the fixture really is an indexed PNG carrying a tRNS chunk,
+         // so this test exercises PngReader's indexed branch. IHDR colour type is the
+         // byte at offset 25 (8 sig + 4 len + 4 "IHDR" + 4 width + 4 height + 1 bitdepth).
+         bytes[25].toInt() shouldBe 3 // colour type 3 == indexed
+         containsChunk(bytes, "tRNS") shouldBe true
+
+         val image = PngReader().read(bytes, null)
+
+         val opaque = image.pixel(0, 0)
+         opaque.alpha() shouldBe 255
+         opaque.red() shouldBe 255
+
+         image.pixel(1, 0).alpha() shouldBe 0
+      }
+   }
+})


### PR DESCRIPTION
## Problem

`PngReader`'s indexed (colour type 3) branch passed `null` for the tRNS chunk and hard-coded alpha 255:

```java
pixels = ImageLineHelper.palette2rgb(scanline, pngr.getMetadata().getPLTE(), null, pixels);
...
matrix[rowOffset + x] = PixelTools.argb(255, pixels[k], pixels[k + 1], pixels[k + 2]);
```

The tRNS chunk carries per-palette-entry alpha for indexed PNGs. With it dropped and alpha forced to 255, an indexed PNG with transparent palette entries decoded **fully opaque**, silently losing transparency. Indexed PNGs with a transparent entry are common (e.g. icons, sprites).

(The default load path tries `ImageIOReader` first, which handles tRNS; `PngReader` is the registered fallback for PNGs ImageIO rejects, and is also part of the public API — so the bug is reachable.)

## Fix

Fetch the tRNS chunk via `getMetadata().getTRNS()`. When present, `palette2rgb` unpacks 4 channels (RGBA) and the entry alpha is read from `pixels[k + 3]`; when absent, the existing 3-channel opaque path is kept.

## Test

`PngReaderIndexedTransparencyTest` mints an indexed PNG (2-entry palette: opaque red + fully transparent) via `ImageIO`, asserts the bytes really are colour type 3 with a `tRNS` chunk (so the indexed branch is exercised), then asserts `PngReader` decodes the transparent pixel with alpha 0 and the opaque pixel with alpha 255. Fails before the fix (alpha was 255).

🤖 Generated with [Claude Code](https://claude.com/claude-code)