### PR TITLE
Fix integer overflow in MMCQ.VBox.avg() on large images

### DIFF
--- a/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
+++ b/scrimage-core/src/main/java/thirdparty/colorthief/MMCQ.java
@@ -134,9 +134,15 @@ public class MMCQ {
          if (_avg == null || force) {
             int ntot = 0;
 
-            int rsum = 0;
-            int gsum = 0;
-            int bsum = 0;
+            // long accumulators: each cell contributes up to hval * 31.5 * MULT
+            // (MULT == 8), so for a VBox holding more than ~8.5M sampled pixels
+            // the running sum exceeds Integer.MAX_VALUE and an int would wrap to
+            // a garbage (possibly negative) channel value. The root VBoxes hold
+            // nearly all pixels, so a large enough image (reachable via the public
+            // ImmutableImage.quantize / ColorThief.getColorMap) triggers this.
+            long rsum = 0;
+            long gsum = 0;
+            long bsum = 0;
 
             int hval, i, j, k, histoindex;
 
@@ -154,8 +160,8 @@ public class MMCQ {
             }
 
             if (ntot > 0) {
-               _avg = new int[] {clampChannel(rsum / ntot), clampChannel(gsum / ntot),
-                  clampChannel(bsum / ntot)};
+               _avg = new int[] {clampChannel((int) (rsum / ntot)), clampChannel((int) (gsum / ntot)),
+                  clampChannel((int) (bsum / ntot))};
             } else {
                _avg = new int[] {clampChannel(MULT * (r1 + r2 + 1) / 2),
                   clampChannel(MULT * (g1 + g2 + 1) / 2), clampChannel(MULT * (b1 + b2 + 1) / 2)};

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/MMCQOverflowTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/MMCQOverflowTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.scrimage.core
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import thirdparty.colorthief.MMCQ
+
+/**
+ * Regression for integer overflow in MMCQ.VBox.avg(). The red/green/blue sums
+ * were accumulated in int, but each histogram cell contributes up to
+ * hval * 31.5 * MULT (MULT == 8). For a VBox holding more than ~8.5M sampled
+ * pixels the running sum exceeds Integer.MAX_VALUE, so the int accumulator
+ * saturates and the returned channel average is wrong. This is reachable via
+ * the public ImmutableImage.quantize / ColorThief.getColorMap on large images
+ * (the root VBoxes hold nearly every sampled pixel).
+ */
+class MMCQOverflowTest : FunSpec({
+
+   // colour index layout used by MMCQ.getColorIndex: (r << 2*SIGBITS) + (g << SIGBITS) + b, SIGBITS = 5.
+   fun colorIndex(r: Int, g: Int, b: Int) = (r shl 10) + (g shl 5) + b
+
+   test("VBox.avg does not overflow for a box holding more than ~8.5M pixels") {
+      // a single populated cell at the top of the red range (r index 31) with 50M pixels.
+      val histo = IntArray(1 shl 15)
+      val r = 31
+      val g = 1
+      val b = 1
+      histo[colorIndex(r, g, b)] = 50_000_000
+
+      val avg = MMCQ.VBox(r, r, g, g, b, b, histo).avg(false)
+
+      // expected red = (31 + 0.5) * 8 = 252. With int overflow the sum saturated to
+      // Integer.MAX_VALUE and the average collapsed to ~42.
+      avg[0] shouldBe 252
+      avg[1] shouldBe 12 // (1 + 0.5) * 8
+      avg[2] shouldBe 12
+   }
+})


### PR DESCRIPTION
## Problem

`MMCQ.VBox.avg()` accumulated the red/green/blue channel sums in `int`:

```java
int rsum = 0, gsum = 0, bsum = 0;
...
rsum += (hval * (i + 0.5) * MULT);   // up to hval * 31.5 * 8 ≈ 252 per pixel
```

Each histogram cell contributes up to `hval * (i + 0.5) * MULT` where the index `i` reaches 31 and `MULT == 8`, i.e. up to ~252 per sampled pixel. Once a VBox holds more than `2^31 / 252 ≈ 8.5M` sampled pixels the running sum exceeds `Integer.MAX_VALUE`. The double-to-int narrowing in the compound assignment then **saturates** the accumulator at `Integer.MAX_VALUE`, so `rsum / ntot` produces a wrong (much smaller) channel value.

The root VBoxes hold nearly every sampled pixel, so this is reachable on large images through the public API:
- `ImmutableImage.quantize(n)` → `ColorThief.getColorMap(awt, n)` (default quality 10): images over ~85MP.
- `ColorThief.getColorMap(img, n, 1, ignoreWhite)` (quality 1): images over ~8.5MP.

The result is a wrong dominant colour / palette (and `BackgroundGradient` / `DominantGradient` reach this via `quantize`).

## Fix

Widen `rsum` / `gsum` / `bsum` to `long` and cast back to `int` for the average. Output is unchanged for images small enough not to overflow.

## Test

`MMCQOverflowTest` constructs a `VBox` with a single populated histogram cell (red index 31) holding 50M pixels and asserts the average red is 252 (`(31 + 0.5) * 8`). Before the fix the saturated int sum collapsed it to ~42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)