### PR TITLE
Correct AwtImage.average() Javadoc: it is a SrcOver blend, not a mean

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -697,9 +697,14 @@ public class AwtImage {
    }
 
    /**
-    * Returns the average colour of all pixels in this image
+    * Reduces all pixels in this image to a single colour by folding them with
+    * {@link com.sksamuel.scrimage.color.Color#average(com.sksamuel.scrimage.color.Color)},
+    * i.e. a left-to-right SrcOver alpha blend in row-major order — not an arithmetic
+    * mean of the channels. As a consequence, a fully opaque image collapses to the
+    * colour of its first (top-left) pixel, since SrcOver of two opaque colours yields
+    * the source.
     *
-    * @return the average colour of the image
+    * @return the SrcOver-blend reduction of every pixel in the image
     */
    public RGBColor average() {
       int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);


### PR DESCRIPTION
## Problem

`AwtImage.average()` is documented as:

> Returns the average colour of all pixels in this image

But the implementation performs a left-to-right SrcOver alpha-blend reduction (via `Color.average(Color)`), which is **not** an arithmetic mean. This behaviour is deliberate and pinned by tests (see #405, *"Drop per-step RGBColor allocation in AwtImage.average()"*, whose message notes *"this is a sequential SrcOver-blend reduce, not an arithmetic mean — an all-opaque image collapses to its first pixel"*).

The misleading Javadoc invites callers to expect a channel mean (e.g. black + white → grey), whereas a fully opaque image returns the colour of its top-left pixel.

## Fix

Documentation only — no behaviour change. The Javadoc now describes the SrcOver-blend reduction and the opaque-image consequence, so callers aren't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)