### PR TITLE
Clamp scaleToWidth/scaleToHeight derived dimension to at least 1

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1362,7 +1362,10 @@ public class ImmutableImage extends MutableImage {
    }
 
    public ImmutableImage scaleToWidth(int targetWidth, ScaleMethod scaleMethod, boolean keepAspectRatio) {
-      int targetHeight = keepAspectRatio ? (int) (targetWidth / (double) width * height) : height;
+      // Clamp the derived height to at least 1: for an extreme aspect ratio (e.g. a 1000x1
+      // image scaled to width 1) the integer arithmetic floors to 0, which then fails
+      // creating a 0-height image. Mirrors the clamp in resizeToWidth.
+      int targetHeight = keepAspectRatio ? Math.max(1, (int) (targetWidth / (double) width * height)) : height;
       return scaleTo(targetWidth, targetHeight, scaleMethod);
    }
 
@@ -1404,7 +1407,10 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image that is the result of scaling this image
     */
    public ImmutableImage scaleToHeight(int targetHeight, ScaleMethod scaleMethod, boolean keepAspectRatio) {
-      int targetWidth = keepAspectRatio ? (int) (targetHeight / (double) height * width) : width;
+      // Clamp the derived width to at least 1: for an extreme aspect ratio (e.g. a 1x1000
+      // image scaled to height 1) the integer arithmetic floors to 0, which then fails
+      // creating a 0-width image. Mirrors the clamp in resizeToHeight.
+      int targetWidth = keepAspectRatio ? Math.max(1, (int) (targetHeight / (double) height * width)) : width;
       return scaleTo(targetWidth, targetHeight, scaleMethod);
    }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ScaleToExtremeAspectTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ops/ScaleToExtremeAspectTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.scrimage.core.ops
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression for scaleToWidth / scaleToHeight deriving a 0 dimension on an extreme
+ * aspect ratio. The derived dimension is computed with integer truncation, so e.g.
+ * scaleToWidth(1) on a 1000x1 image floored the height to 0 and then threw creating
+ * a 0-height image. The derived dimension is now clamped to at least 1, mirroring the
+ * existing clamp in resizeToWidth / resizeToHeight.
+ *
+ * FastScale is used because the bicubic/bilinear resamplers impose their own minimum
+ * target size (3x3); FastScale (nearest neighbour) has no such floor, so it isolates
+ * the derived-dimension clamp.
+ */
+class ScaleToExtremeAspectTest : FunSpec({
+
+   test("scaleToWidth clamps the derived height to at least 1") {
+      val image = ImmutableImage.create(1000, 1)
+      val scaled = image.scaleToWidth(1, ScaleMethod.FastScale)
+      scaled.width shouldBe 1
+      scaled.height shouldBe 1
+   }
+
+   test("scaleToHeight clamps the derived width to at least 1") {
+      val image = ImmutableImage.create(1, 1000)
+      val scaled = image.scaleToHeight(1, ScaleMethod.FastScale)
+      scaled.width shouldBe 1
+      scaled.height shouldBe 1
+   }
+})


### PR DESCRIPTION
## Problem

`scaleToWidth` / `scaleToHeight` derive the other dimension with integer truncation:

```java
int targetHeight = keepAspectRatio ? (int) (targetWidth / (double) width * height) : height;
```

For an extreme aspect ratio this floors to 0 — e.g. `scaleToWidth(1)` on a 1000×1 image yields `targetHeight = (int)(1/1000.0 * 1) = 0`. The subsequent `scaleTo(1, 0, ...)` then throws creating a 0-dimension image.

This is the same defect that was fixed for `resizeToWidth` / `resizeToHeight` in #710; the two `scaleTo*` siblings were missed.

## Fix

Clamp the derived dimension to at least 1, mirroring the existing `Math.max(1, …)` clamp in `resizeToWidth` / `resizeToHeight`.

## Test

`ScaleToExtremeAspectTest` scales a 1000×1 image to width 1 (and a 1×1000 image to height 1) and asserts the result is 1×1. Uses `ScaleMethod.FastScale` to isolate the derived-dimension clamp — the bicubic/bilinear resamplers impose their own minimum target size (3×3), whereas FastScale (nearest neighbour) does not. Throws before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)