### PR TITLE
Replace disabled-by-default asserts in HSVColor with explicit validation

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
@@ -7,7 +7,7 @@ import com.sksamuel.scrimage.pixels.PixelTools;
  * <p>
  * The hue component should be between 0.0 and 360.0
  * The saturation component should be between 0.0 and 1.0
- * The lightness component should be between 0.0 and 1.0
+ * The value component should be between 0.0 and 1.0
  * The alpha component should be between 0.0 and 1.0
  */
 public class HSVColor implements Color {
@@ -18,15 +18,24 @@ public class HSVColor implements Color {
    public final float alpha;
 
    public HSVColor(float hue, float saturation, float value, float alpha) {
-      assert (0 <= hue && hue <= 360f);
-      assert (0 <= saturation && saturation <= 1f);
-      assert (0 <= value && value <= 1f);
-      assert (0 <= alpha && alpha <= 1f);
+      // Validate explicitly rather than with `assert`, which is disabled by
+      // default in production JVMs (so out-of-range values would slip through
+      // and produce wrong colours in toRGB()).
+      requireInRange("hue", hue, 360f);
+      requireInRange("saturation", saturation, 1f);
+      requireInRange("value", value, 1f);
+      requireInRange("alpha", alpha, 1f);
 
       this.hue = hue;
       this.saturation = saturation;
       this.value = value;
       this.alpha = alpha;
+   }
+
+   private static void requireInRange(String component, float value, float max) {
+      if (value < 0 || value > max)
+         throw new IllegalArgumentException(
+            "HSVColor " + component + " component must be in [0, " + max + "] but was " + value);
    }
 
    public HSVColor toHSV() {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSVColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSVColorTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.scrimage.core.color
 
 import com.sksamuel.scrimage.color.HSVColor
 import com.sksamuel.scrimage.color.RGBColor
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -11,6 +12,23 @@ class HSVColorTest : StringSpec() {
       "HSV to RGB" {
          HSVColor(232F, 0.535F, 0.498F, 1.0f).toRGB() shouldBe RGBColor(59, 68, 127, 255)
          HSVColor(0f, 0F, 1F, 1f).toRGB() shouldBe RGBColor(255, 255, 255, 255)
+      }
+
+      "valid components are accepted (hue in [0, 360], others in [0, 1])" {
+         val color = HSVColor(360f, 0.5f, 1.0f, 0.25f)
+         color.hue shouldBe 360f
+         color.saturation shouldBe 0.5f
+         color.value shouldBe 1.0f
+         color.alpha shouldBe 0.25f
+      }
+
+      "out-of-range components are rejected with IllegalArgumentException" {
+         shouldThrow<IllegalArgumentException> { HSVColor(-1f, 0f, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(361f, 0f, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, -0.1f, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, 1.1f, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, 1.1f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, 0f, 1.1f) }
       }
    }
 }


### PR DESCRIPTION
## Problem

`HSVColor` validated its components with `assert`:

```java
assert (0 <= hue && hue <= 360f);
assert (0 <= saturation && saturation <= 1f);
assert (0 <= value && value <= 1f);
assert (0 <= alpha && alpha <= 1f);
```

`assert` is disabled by default in production JVMs (it requires `-ea`), so out-of-range components silently slip through and produce a wrong colour in `toRGB()` instead of failing fast. `RGBColor`, `HSLColor`, `CMYKColor` and `Grayscale` were all converted from `assert` to runtime `IllegalArgumentException` checks (e.g. #665 for `CMYKColor`); `HSVColor` was missed.

The class Javadoc also described the third component as *"lightness"*, but the field is `value` — HSV's V is value/brightness, not lightness (that's HSL).

## Fix

- Convert the asserts to explicit `IllegalArgumentException` range checks (hue in [0, 360], saturation/value/alpha in [0, 1]), mirroring `CMYKColor`.
- Correct the Javadoc to say "value".

The only in-library construction site, `RGBColor.toHSV()`, always produces in-range values, so no valid conversion is affected.

## Test

`HSVColorTest` gains a case asserting valid components are accepted and a case asserting each out-of-range component throws `IllegalArgumentException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)