### PR TITLE
Fix NoiseReduction ArrayIndexOutOfBoundsException on 1px-wide/tall images

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/marvin/image/restoration/NoiseReduction.java
+++ b/scrimage-filters/src/main/java/thirdparty/marvin/image/restoration/NoiseReduction.java
@@ -60,6 +60,20 @@ public class NoiseReduction extends MarvinAbstractImagePlugin {
         width = a_imageIn.getWidth();
         height = a_imageIn.getHeight();
 
+        // Total-variation denoising needs a neighbour along each axis: the
+        // derivative helpers (diff_x/diff_y/diff_xx/diff_yy/diff_xy) index
+        // [i+1] / [j+1], which throws ArrayIndexOutOfBoundsException on a
+        // 1px-wide or 1px-tall image. Such an image has no 2D neighbourhood to
+        // denoise, so copy it through unchanged.
+        if (width < 2 || height < 2) {
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    a_imageOut.setIntColor(x, y, a_imageIn.getIntColor(x, y));
+                }
+            }
+            return;
+        }
+
         mat1 = new double[width][height];
         mat2 = new double[width][height];
         mat4 = new double[width][height];

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/NoiseReductionFilterTinyImageTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/NoiseReductionFilterTinyImageTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: NoiseReduction crashed with ArrayIndexOutOfBoundsException on a
+ * 1px-wide or 1px-tall image. The total-variation derivative helpers
+ * (diff_x/diff_y/diff_xx/diff_yy/diff_xy) index [i+1] / [j+1], which is out of
+ * bounds when width or height is 1. Such an image has no 2D neighbourhood to
+ * denoise, so it is now copied through unchanged. The filter runs the helpers
+ * along both axes, so both orientations crashed.
+ */
+class NoiseReductionFilterTinyImageTest : FunSpec({
+
+   fun image(width: Int, height: Int): ImmutableImage =
+      ImmutableImage.filled(width, height, Color.ORANGE)
+
+   test("noise reduction of a 1x1 image completes and preserves dimensions") {
+      val result = image(1, 1).filter(NoiseReductionFilter())
+      result.width shouldBe 1
+      result.height shouldBe 1
+   }
+
+   test("noise reduction of a 1xN image completes and preserves dimensions") {
+      val result = image(1, 7).filter(NoiseReductionFilter())
+      result.width shouldBe 1
+      result.height shouldBe 7
+   }
+
+   test("noise reduction of an Nx1 image completes and preserves dimensions") {
+      val result = image(7, 1).filter(NoiseReductionFilter())
+      result.width shouldBe 7
+      result.height shouldBe 1
+   }
+
+   test("noise reduction of a 2x2 image completes and preserves dimensions") {
+      val result = image(2, 2).filter(NoiseReductionFilter())
+      result.width shouldBe 2
+      result.height shouldBe 2
+   }
+})


### PR DESCRIPTION
## Problem

`NoiseReduction`'s total-variation derivative helpers index the neighbouring cell with `[i+1]` / `[j+1]`:

```java
// diff_x, arrays are double[width][height]
if (j == 0) {
    mat1 = matx[i][j];
    mat2 = matx[i][j + 1];   // out of bounds when height == 1
}
```

On a 1px-tall image (`height == 1`) the `j == 0` branch reads `matx[i][1]` from a `[width][1]` array → `ArrayIndexOutOfBoundsException`. The mirror cases crash a 1px-wide image (`diff_y`/`diff_yy` read `maty[1][j]`), and `diff_xx`/`diff_xy` are affected the same way.

Reachable via the public API: `image.filter(new NoiseReductionFilter())` on any 1×N or N×1 image.

## Fix

A single-pixel-wide or -tall image has no 2D neighbourhood to denoise, so `process()` now copies it through unchanged when `width < 2 || height < 2`. Images 2×2 and larger keep the existing behaviour (verified: the existing golden-image regression test still passes, and a 2×2 image runs the full denoise path without crashing).

## Test

`NoiseReductionFilterTinyImageTest` runs the filter over 1×1, 1×7, 7×1 and 2×2 images and asserts each completes and preserves its dimensions. The 1px cases throw before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)