### PR TITLE
Fix LensBlurFilter crash/corruption on non-square tiles

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
@@ -246,13 +246,21 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
                 fft.transform2D(ar[0], ar[1], cols, rows, false);
                 fft.transform2D(gb[0], gb[1], cols, rows, false);
 
-                // Convert back to RGB pixels, with quadrant remapping
-                int row_flip = w >> 1;
-                int col_flip = h >> 1;
+                // Convert back to RGB pixels, with quadrant remapping (fftshift).
+                // The tile is rows (h) high by cols (w) wide and need not be square
+                // once tileWidth/tileHeight are clamped to the image size, so the
+                // row index must flip by half the rows and iterate over h, while the
+                // column index flips by half the cols. The previous code used w for
+                // both (and iterated y < w), which indexed past the w*h buffers and
+                // threw ArrayIndexOutOfBoundsException on wider-than-tall images (and
+                // silently corrupted taller-than-wide ones). For a square tile (the
+                // common large-image case) this is identical to the old behaviour.
+                int row_flip = h >> 1;
+                int col_flip = w >> 1;
                 int index = 0;
 
                 //FIXME-don't bother converting pixels off image edges
-                for (int y = 0; y < w; y++) {
+                for (int y = 0; y < h; y++) {
                     int ym = y ^ row_flip;
                     int yi = ym * cols;
                     for (int x = 0; x < w; x++) {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensBlurFilterNonSquareTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/LensBlurFilterNonSquareTest.kt
@@ -1,0 +1,50 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeInRange
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: LensBlurFilter's FFT quadrant-remap loop assumed a square tile.
+ * Once tileWidth/tileHeight are clamped to the image size, an image with a
+ * small dimension produces a non-square tile (w != h). The remap iterated
+ * `y < w` and flipped both axes by `w`, which indexed past the w*h buffers:
+ * a wider-than-tall image threw ArrayIndexOutOfBoundsException, and a
+ * taller-than-wide one silently corrupted the output (stale/dark bands).
+ *
+ * Blurring a uniform image must return (approximately) the same uniform
+ * colour, so the centre pixel is a good probe for both the crash and the
+ * corruption. Large images (both dims clamp to 128) keep a square tile and
+ * are unaffected.
+ */
+class LensBlurFilterNonSquareTest : FunSpec({
+
+   val gray = 100
+
+   fun uniform(width: Int, height: Int): ImmutableImage =
+      ImmutableImage.filled(width, height, Color(gray, gray, gray))
+
+   fun assertBlurredUniform(width: Int, height: Int) {
+      val result = uniform(width, height).filter(LensBlurFilter())
+      result.width shouldBe width
+      result.height shouldBe height
+      val centre = result.pixel(width / 2, height / 2)
+      centre.red() shouldBeInRange (gray - 12)..(gray + 12)
+      centre.green() shouldBeInRange (gray - 12)..(gray + 12)
+      centre.blue() shouldBeInRange (gray - 12)..(gray + 12)
+   }
+
+   test("lens blur of a wider-than-tall small image does not crash and stays uniform") {
+      assertBlurredUniform(60, 20)
+   }
+
+   test("lens blur of a taller-than-wide small image does not corrupt and stays uniform") {
+      assertBlurredUniform(20, 60)
+   }
+
+   test("lens blur of a small square image stays uniform") {
+      assertBlurredUniform(40, 40)
+   }
+})


### PR DESCRIPTION
## Problem

`LensBlurFilter`'s FFT quadrant-remap loop assumed a square tile:

```java
int row_flip = w >> 1;
int col_flip = h >> 1;
for (int y = 0; y < w; y++) {          // iterates w rows...
    int ym = y ^ row_flip;
    int yi = ym * cols;
    for (int x = 0; x < w; x++) {
        int xm = yi + (x ^ col_flip);
        int a = (int) ar[0][xm];       // index past the w*h buffer
```

`tileWidth` / `tileHeight` are clamped to the image size (`min(128, dim + 2*radius)`), so an image with a small dimension produces a tile where `cols` (`w`) and `rows` (`h`) round to **different** powers of two. The remap iterated `y < w` and flipped both axes by `w >> 1`, indexing past the `w*h` FFT buffers (`ar`, `gb`).

Confirmed by running the filter with default parameters:
- **wider-than-tall** (e.g. 60×20): `ArrayIndexOutOfBoundsException` — the filter crashes outright.
- **taller-than-wide** (e.g. 20×60): silent output corruption — stale/dark bands at the tile seam.

Large images are unaffected because both dimensions clamp to 128, giving a square tile (which is why the existing `bird` golden test passes).

## Fix

Iterate the row index over `h` and flip it by `h >> 1`; flip the column index by `w >> 1`. For a square tile this is identical to the old behaviour, so existing output (and the golden test) is unchanged.

## Test

`LensBlurFilterNonSquareTest` blurs a uniform-grey image at 60×20, 20×60 and 40×40 and asserts the centre pixel stays approximately the input colour (blur of a constant is constant) — which catches both the crash and the corruption. The 60×20 case throws before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)