### PR TITLE
Validate rays >= 1 in SparkleFilter to avoid ArithmeticException

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SparkleFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SparkleFilter.java
@@ -26,6 +26,12 @@ public class SparkleFilter extends BufferedOpFilter {
     private final int amount;
 
     public SparkleFilter(int x, int y, int rays, int radius, int amount) {
+        // jhlabs SparkleFilter indexes rayLengths[i % rays] for every pixel,
+        // so rays == 0 throws ArithmeticException (/ by zero) and rays < 0
+        // allocates a negative-length array. Reject up front, mirroring the
+        // input validation in the SmearFilter and OilFilter wrappers.
+        if (rays < 1)
+            throw new IllegalArgumentException("rays must be >= 1, got " + rays);
         this.x = x;
         this.y = y;
         this.rays = rays;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SparkleFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SparkleFilterValidationTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: SparkleFilter passed `rays` straight to jhlabs SparkleFilter,
+ * which indexes `rayLengths[i % rays]` for every pixel. rays == 0 threw
+ * ArithmeticException (/ by zero) on the first pixel, and rays < 0 allocated
+ * a negative-length array. The wrapper now validates rays >= 1.
+ */
+class SparkleFilterValidationTest : FunSpec({
+
+   test("SparkleFilter rejects rays == 0") {
+      shouldThrow<IllegalArgumentException> { SparkleFilter(0, 0, 0, 25, 50) }
+   }
+
+   test("SparkleFilter rejects negative rays") {
+      shouldThrow<IllegalArgumentException> { SparkleFilter(0, 0, -1, 25, 50) }
+   }
+
+   test("SparkleFilter accepts the documented defaults and applies") {
+      val image = ImmutableImage.filled(16, 16, Color(120, 120, 120))
+      val result = image.filter(SparkleFilter())
+      result.width shouldBe 16
+      result.height shouldBe 16
+   }
+})


### PR DESCRIPTION
## Problem

The `SparkleFilter` wrapper passed `rays` straight to jhlabs `SparkleFilter`, which computes `rayLengths[i % rays]` for every pixel:

```java
if (radius != 0) {                                   // radius defaults to 25
    float length = ImageMath.lerp(f, rayLengths[i % rays], rayLengths[(i+1) % rays]);
```

With `rays == 0` that is `0 % 0` → `ArithmeticException: / by zero` on the first pixel. `rays < 0` allocates a negative-length `rayLengths` array. The public constructor `SparkleFilter(int x, int y, int rays, int radius, int amount)` performed no validation.

## Fix

Reject `rays < 1` in the wrapper constructor, mirroring the input validation already present in the `SmearFilter` (`distance >= 1`) and `OilFilter` (`levels` range) wrappers. For `rays >= 1` the `% rays` wrap is well-defined.

## Test

`SparkleFilterValidationTest` asserts `rays == 0` and negative `rays` throw `IllegalArgumentException`, and that the documented defaults still apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)