### PR TITLE
Validate blockSize >= 1 in PixelateFilter to avoid an infinite loop

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/PixelateFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/PixelateFilter.java
@@ -22,6 +22,13 @@ public class PixelateFilter extends BufferedOpFilter {
     private final int blockSize;
 
     public PixelateFilter(int blockSize) {
+        // jhlabs BlockFilter steps the row/column loops by blockSize and
+        // allocates new int[blockSize * blockSize]. blockSize == 0 spins
+        // forever (y += 0) and later divides by zero; blockSize < 0 throws
+        // NegativeArraySizeException / runs degenerate loops. Reject up front,
+        // mirroring the input validation in the SmearFilter/OilFilter wrappers.
+        if (blockSize < 1)
+            throw new IllegalArgumentException("blockSize must be >= 1, got " + blockSize);
         this.blockSize = blockSize;
     }
 

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/PixelateFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/PixelateFilterValidationTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Regression: PixelateFilter forwarded blockSize to jhlabs BlockFilter, which
+ * steps its loops by blockSize and allocates int[blockSize*blockSize].
+ * blockSize == 0 spins forever (y += 0) and divides by zero; blockSize < 0
+ * throws NegativeArraySizeException. The wrapper now validates blockSize >= 1
+ * at construction (so an invalid value fails fast rather than hanging).
+ */
+class PixelateFilterValidationTest : FunSpec({
+
+   test("PixelateFilter rejects blockSize == 0") {
+      shouldThrow<IllegalArgumentException> { PixelateFilter(0) }
+   }
+
+   test("PixelateFilter rejects negative blockSize") {
+      shouldThrow<IllegalArgumentException> { PixelateFilter(-3) }
+   }
+
+   test("PixelateFilter accepts the documented default and applies") {
+      val image = ImmutableImage.filled(16, 16, Color(120, 120, 120))
+      val result = image.filter(PixelateFilter())
+      result.width shouldBe 16
+      result.height shouldBe 16
+   }
+})


### PR DESCRIPTION
## Problem

`PixelateFilter` forwarded `blockSize` to jhlabs `BlockFilter` unchecked:

```java
int[] pixels = new int[blockSize * blockSize];
for (int y = 0; y < height; y += blockSize) { ... }
```

- `blockSize == 0`: the loop never advances (`y += 0`) → **infinite loop** that hangs the caller (and the later `t = w*h` average divides by zero).
- `blockSize < 0`: `new int[blockSize*blockSize]`… actually positive, but the loops run degenerately and `getRGB` is called with negative extents.

The public constructor `PixelateFilter(int blockSize)` performed no validation.

## Fix

Reject `blockSize < 1` in the wrapper constructor, mirroring the input validation already present in the `SmearFilter` and `OilFilter` wrappers. An invalid value now fails fast at construction instead of hanging during application.

## Test

`PixelateFilterValidationTest` asserts `blockSize == 0` and negative `blockSize` throw `IllegalArgumentException` at construction (so the test never triggers the hang), and that the documented default still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)