### PR TITLE
Add ZhangSkeleton: a correct Zhang-Suen thinning filter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ZhangSkeleton.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ZhangSkeleton.java
@@ -1,0 +1,142 @@
+/*
+   Copyright 2013 Stephen K Samuel
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package com.sksamuel.scrimage.filter;
+
+import com.sksamuel.scrimage.ImmutableImage;
+import thirdparty.jhlabs.image.PixelUtils;
+
+/**
+ * Reduces a shape to a one-pixel-wide skeleton using the Zhang-Suen thinning
+ * algorithm (T. Y. Zhang and C. Y. Suen, "A fast parallel algorithm for
+ * thinning digital patterns", CACM, March 1984, 236-239).
+ * <p>
+ * The image is first binarised: a pixel is treated as foreground when its
+ * brightness is below {@code threshold} (default 128), i.e. dark shapes on a
+ * lighter background. The foreground is then repeatedly thinned — boundary
+ * pixels are stripped in two complementary sub-iterations per pass until no
+ * more can be removed without breaking connectivity or eroding an endpoint.
+ * <p>
+ * The result is written as an opaque black skeleton on a white background.
+ * Pixels on the image edge are thinned correctly (out-of-image neighbours are
+ * treated as background), and every output pixel is written, so the filter is
+ * safe on images of any size, including 1xN, Nx1 and 1x1.
+ */
+public class ZhangSkeleton implements Filter {
+
+   private final int threshold;
+
+   /**
+    * Creates a skeleton filter with the default brightness threshold of 128.
+    */
+   public ZhangSkeleton() {
+      this(128);
+   }
+
+   /**
+    * @param threshold the brightness cut-off in [0, 255]; a pixel is foreground
+    *                  when its brightness is strictly below this value.
+    */
+   public ZhangSkeleton(int threshold) {
+      if (threshold < 0 || threshold > 255)
+         throw new IllegalArgumentException("threshold must be in [0, 255], got " + threshold);
+      this.threshold = threshold;
+   }
+
+   @Override
+   public void apply(ImmutableImage image) {
+      int w = image.width;
+      int h = image.height;
+      int[] argb = image.awt().getRGB(0, 0, w, h, null, 0, w);
+
+      // Binarise into 1 = foreground (dark), 0 = background.
+      byte[] fg = new byte[w * h];
+      for (int i = 0; i < argb.length; i++) {
+         fg[i] = (byte) (PixelUtils.brightness(argb[i]) < threshold ? 1 : 0);
+      }
+
+      thin(fg, w, h);
+
+      // Write back: skeleton -> opaque black, everything else -> opaque white.
+      for (int i = 0; i < argb.length; i++) {
+         argb[i] = fg[i] != 0 ? 0xff000000 : 0xffffffff;
+      }
+      image.awt().setRGB(0, 0, w, h, argb, 0, w);
+   }
+
+   private static void thin(byte[] fg, int w, int h) {
+      int[] toRemove = new int[w * h];
+      boolean changed;
+      do {
+         changed = false;
+         for (int step = 0; step < 2; step++) {
+            int n = 0;
+            for (int y = 0; y < h; y++) {
+               for (int x = 0; x < w; x++) {
+                  if (fg[y * w + x] == 0)
+                     continue;
+
+                  // 8 neighbours, clockwise from north; out-of-image == background.
+                  int p2 = at(fg, w, h, x, y - 1);
+                  int p3 = at(fg, w, h, x + 1, y - 1);
+                  int p4 = at(fg, w, h, x + 1, y);
+                  int p5 = at(fg, w, h, x + 1, y + 1);
+                  int p6 = at(fg, w, h, x, y + 1);
+                  int p7 = at(fg, w, h, x - 1, y + 1);
+                  int p8 = at(fg, w, h, x - 1, y);
+                  int p9 = at(fg, w, h, x - 1, y - 1);
+
+                  int b = p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+                  if (b < 2 || b > 6)
+                     continue;
+
+                  // A = number of 0 -> 1 transitions in the ordered ring.
+                  int a = 0;
+                  if (p2 == 0 && p3 == 1) a++;
+                  if (p3 == 0 && p4 == 1) a++;
+                  if (p4 == 0 && p5 == 1) a++;
+                  if (p5 == 0 && p6 == 1) a++;
+                  if (p6 == 0 && p7 == 1) a++;
+                  if (p7 == 0 && p8 == 1) a++;
+                  if (p8 == 0 && p9 == 1) a++;
+                  if (p9 == 0 && p2 == 1) a++;
+                  if (a != 1)
+                     continue;
+
+                  if (step == 0) {
+                     if (p2 * p4 * p6 != 0) continue; // at least one of N, E, S is background
+                     if (p4 * p6 * p8 != 0) continue; // at least one of E, S, W is background
+                  } else {
+                     if (p2 * p4 * p8 != 0) continue; // at least one of N, E, W is background
+                     if (p2 * p6 * p8 != 0) continue; // at least one of N, S, W is background
+                  }
+
+                  toRemove[n++] = y * w + x;
+               }
+            }
+            for (int k = 0; k < n; k++)
+               fg[toRemove[k]] = 0;
+            if (n > 0)
+               changed = true;
+         }
+      } while (changed);
+   }
+
+   private static int at(byte[] fg, int w, int h, int x, int y) {
+      if (x < 0 || x >= w || y < 0 || y >= h)
+         return 0;
+      return fg[y * w + x];
+   }
+}

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ZhangSkeletonTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ZhangSkeletonTest.kt
@@ -1,0 +1,106 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+class ZhangSkeletonTest : FunSpec({
+
+   // Builds an image from a row-per-string grid: 'X' = black, anything else = white.
+   fun img(rows: List<String>): ImmutableImage {
+      val h = rows.size
+      val w = rows[0].length
+      val bi = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+      for (y in 0 until h)
+         for (x in 0 until w)
+            bi.setRGB(x, y, if (rows[y][x] == 'X') 0xff000000.toInt() else 0xffffffff.toInt())
+      return ImmutableImage.wrapAwt(bi)
+   }
+
+   fun isBlack(image: ImmutableImage, x: Int, y: Int) = image.pixel(x, y).red() < 128
+
+   fun blackCount(image: ImmutableImage): Int {
+      var c = 0
+      for (y in 0 until image.height)
+         for (x in 0 until image.width)
+            if (isBlack(image, x, y)) c++
+      return c
+   }
+
+   test("a 1px line is a fixed point of thinning") {
+      val out = img(
+         listOf(
+            ".........",
+            "XXXXXXXXX",
+            "........."
+         )
+      ).filter(ZhangSkeleton())
+      for (x in 0 until 9) {
+         isBlack(out, x, 0) shouldBe false
+         isBlack(out, x, 1) shouldBe true
+         isBlack(out, x, 2) shouldBe false
+      }
+   }
+
+   test("a solid block is thinned but not erased") {
+      val out = img((0 until 5).map { "XXXXX" }).filter(ZhangSkeleton())
+      val c = blackCount(out)
+      c shouldBeGreaterThan 0
+      c shouldBeLessThan 25
+   }
+
+   test("a thick bar thins to a one-pixel-wide line") {
+      // a 3-row-thick horizontal bar should reduce to a single row per column
+      val out = img(
+         listOf(
+            ".........",
+            "XXXXXXXXX",
+            "XXXXXXXXX",
+            "XXXXXXXXX",
+            "........."
+         )
+      ).filter(ZhangSkeleton())
+      // at most one black pixel in any column
+      for (x in 0 until 9) {
+         val col = (0 until 5).count { y -> isBlack(out, x, y) }
+         col shouldBeLessThan 2
+      }
+      blackCount(out) shouldBeGreaterThan 0
+   }
+
+   test("an all-white image yields no skeleton") {
+      blackCount(img(listOf(".....", ".....", ".....")).filter(ZhangSkeleton())) shouldBe 0
+   }
+
+   test("a single dark pixel is preserved (endpoint), not wiped") {
+      val out = img(
+         listOf(".....", ".....", "..X..", ".....", ".....")
+      ).filter(ZhangSkeleton())
+      isBlack(out, 2, 2) shouldBe true
+      blackCount(out) shouldBe 1
+   }
+
+   // The old jhlabs SkeletonFilter never wrote the 1px border (it stayed
+   // transparent black) and wiped images <= 2px to fully transparent.
+   // ZhangSkeleton writes every pixel and is safe at any size.
+   test("tiny images do not crash, preserve dimensions, and are fully opaque") {
+      listOf(1 to 1, 1 to 5, 5 to 1, 2 to 2).forEach { (w, h) ->
+         val out = ImmutableImage.filled(w, h, Color.BLACK).filter(ZhangSkeleton())
+         out.width shouldBe w
+         out.height shouldBe h
+         for (y in 0 until h)
+            for (x in 0 until w)
+               out.pixel(x, y).alpha() shouldBe 255
+      }
+   }
+
+   test("rejects out-of-range threshold") {
+      shouldThrow<IllegalArgumentException> { ZhangSkeleton(-1) }
+      shouldThrow<IllegalArgumentException> { ZhangSkeleton(256) }
+   }
+})


### PR DESCRIPTION
## Motivation

The existing `SkeletonFilter` wraps the jhlabs table-based variant, which:
- never writes the 1-pixel image border (it stays transparent black), and
- wipes any image ≤ 2px in a dimension to fully transparent.

This adds `ZhangSkeleton`, a native, from-scratch implementation of the classic **Zhang-Suen** thinning algorithm (T. Y. Zhang & C. Y. Suen, *A fast parallel algorithm for thinning digital patterns*, CACM March 1984).

## Behaviour

- Binarises the image by brightness — a pixel is foreground when its brightness is below `threshold` (default 128, i.e. dark shapes on a lighter background; configurable via `new ZhangSkeleton(threshold)`).
- Repeatedly strips boundary pixels in the two complementary sub-iterations per pass until only the connected one-pixel-wide skeleton remains (preserving endpoints and connectivity).
- Out-of-image neighbours are treated as background and **every** output pixel is written, so edge pixels thin correctly and the filter is safe at any size — 1×N, N×1, 1×1.
- Output is an opaque black skeleton on a white background.

```java
ImmutableImage skeleton = image.filter(new ZhangSkeleton());
```

## Tests

`ZhangSkeletonTest` covers:
- a 1px line is a fixed point of thinning (deterministic);
- a 3-row-thick bar reduces to ≤ 1 black pixel per column;
- a solid block is thinned but not erased;
- an all-white image yields no skeleton;
- a single dark pixel is preserved (endpoint), not wiped;
- tiny images (1×1, 1×5, 5×1, 2×2) don't crash, preserve dimensions, and are fully opaque (the failure mode of the old filter);
- out-of-range threshold is rejected.

The existing `SkeletonFilter` is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)