### PR TITLE
Remove unused private members in retained vendored classes

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/composite/RGBCompositeContext.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/composite/RGBCompositeContext.java
@@ -8,13 +8,9 @@ import java.awt.image.WritableRaster;
 public abstract class RGBCompositeContext implements CompositeContext {
 
     private float alpha;
-    private ColorModel srcColorModel;
-    private ColorModel dstColorModel;
 
     public RGBCompositeContext(float alpha, ColorModel srcColorModel, ColorModel dstColorModel) {
         this.alpha = alpha;
-        this.srcColorModel = srcColorModel;
-        this.dstColorModel = dstColorModel;
     }
 
     public void dispose() {

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
@@ -27,7 +27,6 @@ import java.util.Random;
 public class CausticsFilter extends WholeImageFilter {
 
 	private float scale = 32;
-	private float angle = 0.0f;
 	private int brightness = 10;
 	private float amount = 1.0f;
 	private float turbulence = 1.0f;
@@ -286,41 +285,6 @@ public class CausticsFilter extends WholeImageFilter {
 			}
 		}
 		return pixels;
-	}
-
-	private static int add(int rgb, float brightness) {
-		int r = (rgb >> 16) & 0xff;
-		int g = (rgb >> 8) & 0xff;
-		int b = rgb & 0xff;
-		r += brightness;
-		g += brightness;
-		b += brightness;
-		if (r > 255)
-			r = 255;
-		if (g > 255)
-			g = 255;
-		if (b > 255)
-			b = 255;
-		return 0xff000000 | (r << 16) | (g << 8) | b;
-	}
-
-	private static int add(int rgb, float brightness, int c) {
-		int r = (rgb >> 16) & 0xff;
-		int g = (rgb >> 8) & 0xff;
-		int b = rgb & 0xff;
-		if (c == 2)
-			r += brightness;
-		else if (c == 1)
-			g += brightness;
-		else
-			b += brightness;
-		if (r > 255)
-			r = 255;
-		if (g > 255)
-			g = 255;
-		if (b > 255)
-			b = 255;
-		return 0xff000000 | (r << 16) | (g << 8) | b;
 	}
 
 	private float turbulence2(float x, float y, float time, float octaves) {

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
@@ -25,7 +25,6 @@ import java.awt.geom.Point2D;
  */
 public class FlareFilter extends PointFilter {
 
-    private int rays = 50;
     private float radius;
     private float baseAmount = 1.0f;
     private float ringAmount = 0.2f;
@@ -39,7 +38,6 @@ public class FlareFilter extends PointFilter {
     private float gauss = 0.006f;
     private float mix = 0.50f;
     private float falloff = 6.0f;
-    private float sigma;
 
     private float icentreX, icentreY;
 
@@ -105,7 +103,6 @@ public class FlareFilter extends PointFilter {
      */
     public void setRadius(float radius) {
         this.radius = radius;
-        sigma = radius / 3;
     }
 
     /**

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/Gradient.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/Gradient.java
@@ -453,10 +453,6 @@ public class Gradient extends ArrayColormap implements Cloneable {
 		}
 	}
 
-	private void rebuild() {
-		sortKnots();
-		rebuildGradient();
-	}
 	
     /**
      * Randomize the gradient.

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/MotionBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/MotionBlurFilter.java
@@ -25,7 +25,6 @@ import java.awt.geom.*;
 public class MotionBlurFilter extends AbstractBufferedImageOp {
 
 	private float angle = 0.0f;
-	private float falloff = 1.0f;
 	private float distance = 1.0f;
 	private float zoom = 0.0f;
 	private float rotation = 0.0f;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
@@ -117,9 +117,6 @@ public class SmearFilter extends WholeImageFilter {
 		seed = new Date().getTime();
 	}
 
-	private float random(float low, float high) {
-		return low+(high-low) * randomGenerator.nextFloat();
-	}
 
 	protected int[] filterPixels( int width, int height, int[] inPixels, Rectangle transformedSpace ) {
 		int[] outPixels = new int[width * height];

--- a/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinAbstractImagePlugin.java
+++ b/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinAbstractImagePlugin.java
@@ -2,8 +2,6 @@ package thirdparty.marvin.image;
 
 public abstract class MarvinAbstractImagePlugin extends MarvinAbstractPlugin implements MarvinImagePlugin {
 
-  private boolean valid;
-
   public void process(MarvinImage imgIn,
                       MarvinImage imgOut,
                       MarvinImageMask mask) {


### PR DESCRIPTION
A follow-up dead-code pass over the **retained** `thirdparty/` classes. The earlier private-member audit covered only the project's own `com/sksamuel` code (which was clean); this checks the vendored classes that remain after the unused-class removals.

Each of these private members is never read/called anywhere in its declaring file. A `private` member is only reachable from its own top-level file, so this is verifiable locally and safe:

| File | Member |
|------|--------|
| `jhlabs/image/Gradient` | `private void rebuild()` — nothing calls it (only `rebuildGradient()` is used) |
| `jhlabs/image/SmearFilter` | `private float random(float, float)` |
| `jhlabs/image/CausticsFilter` | field `angle` (never read); **both** `private static add(...)` overloads (`filterPixels` inlines the brightness addition and never calls them) |
| `jhlabs/image/FlareFilter` | fields `rays` (never read) and `sigma` (write-only — its assignment in `setRadius` is dropped too) |
| `jhlabs/image/MotionBlurFilter` | field `falloff` (never read) |
| `jhlabs/composite/RGBCompositeContext` | fields `srcColorModel`, `dstColorModel` (assigned in the constructor, never read; constructor parameters are retained since callers pass them) |
| `marvin/image/MarvinAbstractImagePlugin` | field `valid` (shadowed and unused; the superclass `MarvinAbstractPlugin` has its own used `valid`) |

`scrimage-filters` and `scrimage-tests` compile and their test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)