### PR TITLE
Remove unused public methods in BinaryFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BinaryFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BinaryFilter.java
@@ -65,21 +65,5 @@ public abstract class BinaryFilter extends WholeImageFilter {
 		return colormap;
 	}
 
-	public void setNewColor(int newColor) {
-		this.newColor = newColor;
-	}
-
-	public int getNewColor() {
-		return newColor;
-	}
-
-	public void setBlackFunction(BinaryFunction blackFunction) {
-		this.blackFunction = blackFunction;
-	}
-
-	public BinaryFunction getBlackFunction() {
-		return blackFunction;
-	}
-
 }
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `BinaryFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `setNewColor`
- `getNewColor`
- `setBlackFunction`
- `getBlackFunction`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)