### PR TITLE
Expose offset in ContourFilter; prune remaining unused methods

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ContourFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/ContourFilter.java
@@ -20,9 +20,18 @@ import java.awt.image.BufferedImageOp;
 public class ContourFilter extends BufferedOpFilter {
 
     private final int levels;
+    private final float offset;
 
     public ContourFilter(int levels) {
+        this(levels, 0f);
+    }
+
+    /**
+     * @param offset the contour offset (jhlabs default 0)
+     */
+    public ContourFilter(int levels, float offset) {
         this.levels = levels;
+        this.offset = offset;
     }
 
     public ContourFilter() {
@@ -33,6 +42,7 @@ public class ContourFilter extends BufferedOpFilter {
     public BufferedImageOp op() {
         thirdparty.jhlabs.image.ContourFilter op = new thirdparty.jhlabs.image.ContourFilter();
         op.setLevels(levels);
+        op.setOffset(offset);
         return op;
     }
 }

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContourFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContourFilter.java
@@ -67,14 +67,6 @@ public class ContourFilter extends WholeImageFilter {
 		return offset;
 	}
 
-	public void setContourColor( int contourColor ) {
-		this.contourColor = contourColor;
-	}
-
-	public int getContourColor() {
-		return contourColor;
-	}
-
 	protected int[] filterPixels( int width, int height, int[] inPixels, Rectangle transformedSpace ) {
 		int index = 0;
 		short[][] r = new short[3][width];

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ContourFilterOffsetTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/ContourFilterOffsetTest.kt
@@ -1,0 +1,26 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.Color
+
+/**
+ * Verifies the offset constructor parameter is passed through to the jhlabs
+ * ContourFilter (setOffset), changing the rendered contours.
+ */
+class ContourFilterOffsetTest : FunSpec({
+
+   val src = ImmutableImage.create(64, 64).map { p -> Color((p.x() * 4) % 256, (p.y() * 4) % 256, 100) }
+
+   test("offset is passed through") {
+      val a = src.filter(ContourFilter(3, 0f))
+      val b = src.filter(ContourFilter(3, 0.5f))
+      a shouldNotBe b
+   }
+
+   test("the levels-only constructor still applies") {
+      src.filter(ContourFilter(4)).width shouldBe 64
+   }
+})


### PR DESCRIPTION
Adds a `ContourFilter(int levels, float offset)` constructor that passes `offset` through to the jhlabs filter (`setOffset`). The existing `ContourFilter(int levels)` constructor delegates with offset 0 (the jhlabs default), so behaviour is unchanged.

`setOffset` is retained (the wrapper now uses it); the unused `setContourColor`/`getContourColor` are removed.

`ContourFilterOffsetTest` asserts offset changes the output and the levels-only constructor still applies. Rebased onto current master; no new javadoc `@see` danglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)