### PR TITLE
Remove unused public methods in DitherFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DitherFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DitherFilter.java
@@ -212,15 +212,6 @@ public class DitherFilter extends PointFilter {
 	}
 
 	/**
-	 * Set whether to use a color dither.
-	 * @param colorDither whether to use a color dither
-     * @see #getColorDither
-	 */
-	public void setColorDither(boolean colorDither) {
-		this.colorDither = colorDither;
-	}
-
-	/**
 	 * Get whether to use a color dither.
 	 * @return whether to use a color dither
      * @see #getColorDither


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `DitherFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `setColorDither`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)