### PR TITLE
Remove unused public methods in EdgeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EdgeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EdgeFilter.java
@@ -72,16 +72,8 @@ public class EdgeFilter extends WholeImageFilter {
 	public EdgeFilter() {
 	}
 
-	public void setVEdgeMatrix(float[] vEdgeMatrix) {
-		this.vEdgeMatrix = vEdgeMatrix;
-	}
-
 	public float[] getVEdgeMatrix() {
 		return vEdgeMatrix;
-	}
-
-	public void setHEdgeMatrix(float[] hEdgeMatrix) {
-		this.hEdgeMatrix = hEdgeMatrix;
 	}
 
 	public float[] getHEdgeMatrix() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `EdgeFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `setVEdgeMatrix`
- `setHEdgeMatrix`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)