### PR TITLE
Remove unused public methods in EmbossFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EmbossFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EmbossFilter.java
@@ -55,14 +55,6 @@ public class EmbossFilter extends WholeImageFilter {
 	public float getBumpHeight() {
 		return width45 / 3;
 	}
-
-	public void setEmboss(boolean emboss) {
-		this.emboss = emboss;
-	}
-	
-	public boolean getEmboss() {
-		return emboss;
-	}
 	
 	protected int[] filterPixels( int width, int height, int[] inPixels, Rectangle transformedSpace ) {
 		int index = 0;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `EmbossFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `setEmboss`
- `getEmboss`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)