### PR TITLE
Remove unused public methods in FlareFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/FlareFilter.java
@@ -59,32 +59,16 @@ public class FlareFilter extends PointFilter {
         this.ringWidth = ringWidth;
     }
 
-    public float getRingWidth() {
-        return ringWidth;
-    }
-
     public void setBaseAmount(float baseAmount) {
         this.baseAmount = baseAmount;
-    }
-
-    public float getBaseAmount() {
-        return baseAmount;
     }
 
     public void setRingAmount(float ringAmount) {
         this.ringAmount = ringAmount;
     }
 
-    public float getRingAmount() {
-        return ringAmount;
-    }
-
     public void setRayAmount(float rayAmount) {
         this.rayAmount = rayAmount;
-    }
-
-    public float getRayAmount() {
-        return rayAmount;
     }
 
     public void setCentre(Point2D centre) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `FlareFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getRingWidth`
- `getBaseAmount`
- `getRingAmount`
- `getRayAmount`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)