### PR TITLE
Remove unused public methods in HSBAdjustFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/HSBAdjustFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/HSBAdjustFilter.java
@@ -38,16 +38,8 @@ public class HSBAdjustFilter extends PointFilter {
 		this.hFactor = hFactor;
 	}
 	
-	public float getHFactor() {
-		return hFactor;
-	}
-	
 	public void setSFactor( float sFactor ) {
 		this.sFactor = sFactor;
-	}
-	
-	public float getSFactor() {
-		return sFactor;
 	}
 	
 	public void setBFactor( float bFactor ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `HSBAdjustFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getHFactor`
- `getSFactor`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)