### PR TITLE
Remove unused public methods in KaleidoscopeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/KaleidoscopeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/KaleidoscopeFilter.java
@@ -86,16 +86,6 @@ public class KaleidoscopeFilter extends TransformFilter {
    }
 
    /**
-    * Get the secondary angle of the kaleidoscope.
-    *
-    * @return the angle
-    * @see #setAngle2
-    */
-   public float getAngle2() {
-      return angle2;
-   }
-
-   /**
     * Set the centre of the effect in the X direction as a proportion of the image size.
     *
     * @param centreX the center


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `KaleidoscopeFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getAngle2`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)