### PR TITLE
Remove unused public methods in LinearColormap (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LinearColormap.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LinearColormap.java
@@ -42,27 +42,11 @@ public class LinearColormap implements Colormap {
 	}
 
 	/**
-	 * Set the first color.
-	 * @param color1 the color corresponding to value 0 in the colormap
-	 */
-	public void setColor1(int color1) {
-		this.color1 = color1;
-	}
-
-	/**
 	 * Get the first color.
 	 * @return the color corresponding to value 0 in the colormap
 	 */
 	public int getColor1() {
 		return color1;
-	}
-
-	/**
-	 * Set the second color.
-	 * @param color2 the color corresponding to value 1 in the colormap
-	 */
-	public void setColor2(int color2) {
-		this.color2 = color2;
 	}
 
 	/**


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `LinearColormap` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `setColor1`
- `setColor2`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)