### PR TITLE
Remove unused public methods in PointillizeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PointillizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PointillizeFilter.java
@@ -56,10 +56,6 @@ public class PointillizeFilter extends CellularFilter {
         this.fuzziness = fuzziness;
     }
 
-    public float getFuzziness() {
-        return fuzziness;
-    }
-
     public int getPixel(int x, int y, int[] inPixels, int width, int height) {
         float nx = m00 * x + m01 * y;
         float ny = m10 * x + m11 * y;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `PointillizeFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getFuzziness`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)