### PR TITLE
Remove unused public methods in RGBAdjustFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RGBAdjustFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RGBAdjustFilter.java
@@ -35,16 +35,8 @@ public class RGBAdjustFilter extends PointFilter {
 		this.rFactor = 1+rFactor;
 	}
 	
-	public float getRFactor() {
-		return rFactor-1;
-	}
-	
 	public void setGFactor( float gFactor ) {
 		this.gFactor = 1+gFactor;
-	}
-	
-	public float getGFactor() {
-		return gFactor-1;
 	}
 	
 	public void setBFactor( float bFactor ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `RGBAdjustFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getRFactor`
- `getGFactor`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)