### PR TITLE
Expose fadeout in SmearFilter; prune unused getters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SmearFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/SmearFilter.java
@@ -25,8 +25,16 @@ public class SmearFilter extends BufferedOpFilter {
     private final float scatter;
     private final int distance;
     private final float mix;
+    private final int fadeout;
 
     public SmearFilter(SmearType smearType, float angle, float density, float scatter, int distance, float mix) {
+        this(smearType, angle, density, scatter, distance, mix, 0);
+    }
+
+    /**
+     * @param fadeout fades the smeared shapes out towards their edges (jhlabs default 0).
+     */
+    public SmearFilter(SmearType smearType, float angle, float density, float scatter, int distance, float mix, int fadeout) {
         if (smearType == null)
             throw new IllegalArgumentException("smearType must not be null");
         // The jhlabs implementation does `nextInt() % distance` in the
@@ -45,6 +53,7 @@ public class SmearFilter extends BufferedOpFilter {
         this.scatter = scatter;
         this.distance = distance;
         this.mix = mix;
+        this.fadeout = fadeout;
     }
 
     public SmearFilter(SmearType smearType) {
@@ -59,6 +68,7 @@ public class SmearFilter extends BufferedOpFilter {
         op.setScatter(scatter);
         op.setDistance(distance);
         op.setMix(mix);
+        op.setFadeout(fadeout);
         switch (smearType) {
             case Circles:
                 op.setShape(thirdparty.jhlabs.image.SmearFilter.CIRCLES);

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
@@ -47,10 +47,6 @@ public class SmearFilter extends WholeImageFilter {
 		this.shape = shape;
 	}
 
-	public int getShape() {
-		return shape;
-	}
-
 	public void setDistance(int distance) {
 		this.distance = distance;
 	}
@@ -61,10 +57,6 @@ public class SmearFilter extends WholeImageFilter {
 
 	public void setScatter(float scatter) {
 		this.scatter = scatter;
-	}
-
-	public float getScatter() {
-		return scatter;
 	}
 
 	/**
@@ -78,16 +70,8 @@ public class SmearFilter extends WholeImageFilter {
 		this.mix = mix;
 	}
 
-	public float getMix() {
-		return mix;
-	}
-
 	public void setFadeout(int fadeout) {
 		this.fadeout = fadeout;
-	}
-
-	public int getFadeout() {
-		return fadeout;
 	}
 
 

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SmearFilterFadeoutTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/SmearFilterFadeoutTest.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Covers the fadeout constructor parameter, passed through to the jhlabs
+ * SmearFilter (setFadeout).
+ *
+ * Note: the jhlabs SmearFilter stores fadeout but never reads it in its
+ * shape-drawing algorithm, so it currently has no observable effect. The value
+ * is wired through for API completeness; this test only verifies it is accepted
+ * and the filter applies cleanly.
+ */
+class SmearFilterFadeoutTest : FunSpec({
+
+   val src = ImmutableImage.filled(40, 40, Color(120, 120, 120))
+
+   test("fadeout is accepted and the filter applies") {
+      val out = src.filter(SmearFilter(SmearType.Lines, 0f, 0.3f, 0f, 3, 0.4f, 10))
+      out.width shouldBe 40
+      out.height shouldBe 40
+   }
+
+   test("the six-arg constructor still applies") {
+      src.filter(SmearFilter(SmearType.Lines, 0f, 0.3f, 0f, 3, 0.4f)).width shouldBe 40
+   }
+})


### PR DESCRIPTION
Adds a 7-arg `SmearFilter(..., int fadeout)` constructor that passes `fadeout` to the jhlabs filter (`setFadeout`). The 6-arg constructor delegates with fadeout 0 (the jhlabs default).

`setFadeout` is retained (the wrapper now uses it); the unused `getShape`/`getScatter`/`getMix`/`getFadeout` getters remain removed.

## ⚠️ Note on effect
The jhlabs `SmearFilter` stores `fadeout` but **never reads it** in its shape-drawing algorithm, so the value currently has **no observable effect** — it's wired through for API completeness. (Implementing actual fade-out would require changes to the vendored jhlabs algorithm; happy to do that separately if wanted.)

`SmearFilterFadeoutTest` verifies the parameter is accepted and the filter applies. Rebased onto current master; no javadoc `@see` danglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)