### PR TITLE
Remove unused public methods in SparkleFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SparkleFilter.java
@@ -75,10 +75,6 @@ public class SparkleFilter extends PointFilter {
 		this.rays = rays;
 	}
 
-	public int getRays() {
-		return rays;
-	}
-
 	/**
 	 * Set the radius of the effect.
 	 * @param radius the radius


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `SparkleFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getRays`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)