### PR TITLE
Remove unused public methods in TritoneFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
@@ -75,27 +75,11 @@ public class TritoneFilter extends PointFilter {
 	}
 
     /**
-     * Get the mid color.
-     * @return the mid color
-     */
-	public int getMidColor() {
-		return midColor;
-	}
-
-    /**
      * Set the high color.
      * @param highColor the high color
      */
 	public void setHighColor( int highColor ) {
 		this.highColor = highColor;
-	}
-
-    /**
-     * Get the high color.
-     * @return the high color
-     */
-	public int getHighColor() {
-		return highColor;
 	}
 
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `TritoneFilter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `getMidColor`
- `getHighColor`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)