### PR TITLE
Remove unused public methods in Point3f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Point3f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Point3f.java
@@ -49,15 +49,4 @@ public class Point3f extends Tuple3f {
 		this.z = t.z;
 	}
 
-	public float distanceL1( Point3f p ) {
-		return Math.abs(x-p.x) + Math.abs(y-p.y) + Math.abs(z-p.z);
-	}
-
-	public float distanceSquared( Point3f p ) {
-		float dx = x-p.x;
-		float dy = y-p.y;
-		float dz = z-p.z;
-		return dx*dx+dy*dy+dz*dz;
-	}
-
 }


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Point3f` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `distanceL1`
- `distanceSquared`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)