### PR TITLE
Remove unused public methods in Quat4f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Quat4f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Quat4f.java
@@ -64,22 +64,6 @@ public class Quat4f extends Tuple4f {
 	}
 
 /*
-	public void EulerToQuaternion(float roll, float pitch, float yaw)
-	{
-		float cr, cp, cy, sr, sp, sy, cpcy, spsy;
-		cr = cos(roll/2);
-		cp = cos(pitch/2);
-		cy = cos(yaw/2);
-		sr = sin(roll/2);
-		sp = sin(pitch/2);
-		sy = sin(yaw/2);
-		cpcy = cp * cy;
-		spsy = sp * sy;
-		w = cr * cpcy + sr * spsy;
-		x = sr * cpcy - cr * spsy;
-		y = cr * sp * cy + sr * cp * sy;
-		z = cr * cp * sy - sr * sp * cy;
-	}
 */
 
 	public void normalize() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Quat4f` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `EulerToQuaternion`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)