### PR TITLE
Remove unused public methods in MarvinColorModelConverter (marvin/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinColorModelConverter.java
+++ b/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinColorModelConverter.java
@@ -10,30 +10,6 @@ package thirdparty.marvin.image;
 public class MarvinColorModelConverter {
 
     /**
-     * Converts an image in RGB mode to BINARY mode
-     *
-     * @param img       image
-     * @param threshold grays cale threshold
-     * @return new MarvinImage instance in BINARY mode
-     */
-    public static MarvinImage rgbToBinary(MarvinImage img, int threshold) {
-        MarvinImage resultImage = new MarvinImage(img.getWidth(), img.getHeight(), MarvinImage.COLOR_MODEL_BINARY);
-
-        for (int y = 0; y < img.getHeight(); y++) {
-            for (int x = 0; x < img.getWidth(); x++) {
-                int gray = (int) ((img.getIntComponent0(x, y) * 0.3) + (img.getIntComponent1(x, y) * 0.59) + (img.getIntComponent2(x, y) * 0.11));
-
-                if (gray <= threshold) {
-                    resultImage.setBinaryColor(x, y, true);
-                } else {
-                    resultImage.setBinaryColor(x, y, false);
-                }
-            }
-        }
-        return resultImage;
-    }
-
-    /**
      * Converts an image in BINARY mode to RGB mode
      *
      * @param img image


### PR DESCRIPTION
These non-private methods in the vendored `marvin/image` class `MarvinColorModelConverter` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `rgbToBinary`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)