### PR TITLE
Remove unused public methods in MarvinImageMask (marvin/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinImageMask.java
+++ b/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinImageMask.java
@@ -57,26 +57,6 @@ public class MarvinImageMask {
     }
 
     /**
-     * Add a point to the mask.
-     *
-     * @param x
-     * @param y
-     */
-    public void addPoint(int x, int y) {
-        arrMask[x][y] = true;
-    }
-
-    /**
-     * Remove point from the mask.
-     *
-     * @param x
-     * @param y
-     */
-    public void removePoint(int x, int y) {
-        arrMask[x][y] = false;
-    }
-
-    /**
      * Clear the mask for a new selection
      */
     public void clear() {


### PR DESCRIPTION
These non-private methods in the vendored `marvin/image` class `MarvinImageMask` are never called anywhere in the repository — each method name occurs exactly **once** across all source (only at its declaration), so it cannot be a call site or an override. The `thirdparty/*` code is internal to scrimage, so these are not part of any supported API.

Removed:
- `addPoint`
- `removePoint`

`:scrimage-filters:compileJava` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)