### PR TITLE
Remove unused public methods in MarvinImageMask (marvin/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinImageMask.java
+++ b/scrimage-filters/src/main/java/thirdparty/marvin/image/MarvinImageMask.java
@@ -57,19 +57,6 @@ public class MarvinImageMask {
     }
 
     /**
-     * Clear the mask for a new selection
-     */
-    public void clear() {
-        if (arrMask != null) {
-            for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
-                    arrMask[x][y] = false;
-                }
-            }
-        }
-    }
-
-    /**
      * @return Mask Array.
      */
     public boolean[][] getMaskArray() {


### PR DESCRIPTION
These non-private methods in the vendored `marvin/image` class `MarvinImageMask` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `MarvinImageMask` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `clear`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)