### PR TITLE
Remove unused public methods in NoiseFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/NoiseFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/NoiseFilter.java
@@ -47,73 +47,17 @@ public class NoiseFilter extends PointFilter {
 	 * @param amount the amount
      * min-value 0
      * max-value 1
-     * @see #getAmount
 	 */
 	public void setAmount(int amount) {
 		this.amount = amount;
 	}
 
 	/**
-	 * Get the amount of noise.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public int getAmount() {
-		return amount;
-	}
-
-	/**
-	 * Set the distribution of the noise.
-	 * @param distribution the distribution
-     * @see #getDistribution
-	 */
-	public void setDistribution( int distribution ) {
-		this.distribution = distribution;
-	}
-
-	/**
-	 * Get the distribution of the noise.
-	 * @return the distribution
-     * @see #setDistribution
-	 */
-	public int getDistribution() {
-		return distribution;
-	}
-
-	/**
-	 * Set whether to use monochrome noise.
-	 * @param monochrome true for monochrome noise
-     * @see #getMonochrome
-	 */
-	public void setMonochrome(boolean monochrome) {
-		this.monochrome = monochrome;
-	}
-
-	/**
-	 * Get whether to use monochrome noise.
-	 * @return true for monochrome noise
-     * @see #setMonochrome
-	 */
-	public boolean getMonochrome() {
-		return monochrome;
-	}
-
-	/**
 	 * Set the density of the noise.
 	 * @param density the density
-     * @see #getDensity
 	 */
 	public void setDensity( float density ) {
 		this.density = density;
-	}
-
-	/**
-	 * Get the density of the noise.
-	 * @return the density
-     * @see #setDensity
-	 */
-	public float getDensity() {
-		return density;
 	}
 
 	private int random(int x) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `NoiseFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `NoiseFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getAmount`
- `setDistribution`
- `getDistribution`
- `setMonochrome`
- `getMonochrome`
- `getDensity`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)