### PR TITLE
Remove unused public methods in ColorHalftoneFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ColorHalftoneFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ColorHalftoneFilter.java
@@ -36,73 +36,9 @@ public class ColorHalftoneFilter extends AbstractBufferedImageOp {
 	 * @param dotRadius the number of pixels along each block edge
      * min-value 1
      * max-value 100+
-     * @see #getdotRadius
 	 */
 	public void setdotRadius( float dotRadius ) {
 		this.dotRadius = dotRadius;
-	}
-
-	/**
-	 * Get the pixel block size.
-	 * @return the number of pixels along each block edge
-     * @see #setdotRadius
-	 */
-	public float getdotRadius() {
-		return dotRadius;
-	}
-
-	/**
-	 * Get the cyan screen angle.
-	 * @return the cyan screen angle (in radians)
-     * @see #setCyanScreenAngle
-	 */
-	public float getCyanScreenAngle() {
-		return cyanScreenAngle;
-	}
-
-	/**
-	 * Set the cyan screen angle.
-	 * @param cyanScreenAngle the cyan screen angle (in radians)
-     * @see #getCyanScreenAngle
-	 */
-	public void setCyanScreenAngle( float cyanScreenAngle ) {
-		this.cyanScreenAngle = cyanScreenAngle;
-	}
-
-	/**
-	 * Get the magenta screen angle.
-	 * @return the magenta screen angle (in radians)
-     * @see #setMagentaScreenAngle
-	 */
-	public float getMagentaScreenAngle() {
-		return magentaScreenAngle;
-	}
-
-	/**
-	 * Set the magenta screen angle.
-	 * @param magentaScreenAngle the magenta screen angle (in radians)
-     * @see #getMagentaScreenAngle
-	 */
-	public void setMagentaScreenAngle( float magentaScreenAngle ) {
-		this.magentaScreenAngle = magentaScreenAngle;
-	}
-
-	/**
-	 * Get the yellow screen angle.
-	 * @return the yellow screen angle (in radians)
-     * @see #setYellowScreenAngle
-	 */
-	public float getYellowScreenAngle() {
-		return yellowScreenAngle;
-	}
-
-	/**
-	 * Set the yellow screen angle.
-	 * @param yellowScreenAngle the yellow screen angle (in radians)
-     * @see #getYellowScreenAngle
-	 */
-	public void setYellowScreenAngle( float yellowScreenAngle ) {
-		this.yellowScreenAngle = yellowScreenAngle;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ColorHalftoneFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ColorHalftoneFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getdotRadius`
- `getCyanScreenAngle`
- `setCyanScreenAngle`
- `getMagentaScreenAngle`
- `setMagentaScreenAngle`
- `getYellowScreenAngle`
- `setYellowScreenAngle`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)