### PR TITLE
Remove unused public methods in RippleFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RippleFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RippleFilter.java
@@ -71,16 +71,6 @@ public class RippleFilter extends TransformFilter {
     }
 
     /**
-     * Get the amplitude of ripple in the X direction.
-     *
-     * @return the amplitude (in pixels).
-     * @see #setXAmplitude
-     */
-    public float getXAmplitude() {
-        return xAmplitude;
-    }
-
-    /**
      * Set the wavelength of ripple in the X direction.
      *
      * @param xWavelength the wavelength (in pixels).
@@ -88,16 +78,6 @@ public class RippleFilter extends TransformFilter {
      */
     public void setXWavelength(float xWavelength) {
         this.xWavelength = xWavelength;
-    }
-
-    /**
-     * Get the wavelength of ripple in the X direction.
-     *
-     * @return the wavelength (in pixels).
-     * @see #setXWavelength
-     */
-    public float getXWavelength() {
-        return xWavelength;
     }
 
     /**
@@ -111,16 +91,6 @@ public class RippleFilter extends TransformFilter {
     }
 
     /**
-     * Get the amplitude of ripple in the Y direction.
-     *
-     * @return the amplitude (in pixels).
-     * @see #setYAmplitude
-     */
-    public float getYAmplitude() {
-        return yAmplitude;
-    }
-
-    /**
      * Set the wavelength of ripple in the Y direction.
      *
      * @param yWavelength the wavelength (in pixels).
@@ -128,16 +98,6 @@ public class RippleFilter extends TransformFilter {
      */
     public void setYWavelength(float yWavelength) {
         this.yWavelength = yWavelength;
-    }
-
-    /**
-     * Get the wavelength of ripple in the Y direction.
-     *
-     * @return the wavelength (in pixels).
-     * @see #setYWavelength
-     */
-    public float getYWavelength() {
-        return yWavelength;
     }
 
 
@@ -149,16 +109,6 @@ public class RippleFilter extends TransformFilter {
      */
     public void setWaveType(int waveType) {
         this.waveType = waveType;
-    }
-
-    /**
-     * Get the wave type.
-     *
-     * @return the type.
-     * @see #setWaveType
-     */
-    public int getWaveType() {
-        return waveType;
     }
 
     protected void transformSpace(Rectangle r) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `RippleFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `RippleFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getXAmplitude`
- `getXWavelength`
- `getYAmplitude`
- `getYWavelength`
- `getWaveType`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)