### PR TITLE
Remove unused public methods in OpacityFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OpacityFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OpacityFilter.java
@@ -49,15 +49,6 @@ public class OpacityFilter extends PointFilter {
 		opacity24 = opacity << 24;
 	}
 	
-	/**
-	 * Get the opacity setting.
-	 * @return the opacity
-     * @see #setOpacity
-	 */
-	public int getOpacity() {
-		return opacity;
-	}
-	
 	public int filterRGB(int x, int y, int rgb) {
 		if ((rgb & 0xff000000) != 0)
 			return (rgb & 0xffffff) | opacity24;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `OpacityFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `OpacityFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getOpacity`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)