### PR TITLE
Remove unused public methods in ConvolveFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ConvolveFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ConvolveFilter.java
@@ -95,75 +95,11 @@ public class ConvolveFilter extends AbstractBufferedImageOp {
 	}
 
     /**
-     * Set the convolution kernel.
-     * @param kernel the kernel
-     * @see #getKernel
-     */
-	public void setKernel(Kernel kernel) {
-		this.kernel = kernel;
-	}
-
-    /**
-     * Get the convolution kernel.
-     * @return the kernel
-     * @see #setKernel
-     */
-	public Kernel getKernel() {
-		return kernel;
-	}
-
-    /**
      * Set the action to perfomr for pixels off the image edges.
      * @param edgeAction the action
-     * @see #getEdgeAction
      */
 	public void setEdgeAction(int edgeAction) {
 		this.edgeAction = edgeAction;
-	}
-
-    /**
-     * Get the action to perfomr for pixels off the image edges.
-     * @return the action
-     * @see #setEdgeAction
-     */
-	public int getEdgeAction() {
-		return edgeAction;
-	}
-
-    /**
-     * Set whether to convolve the alpha channel.
-     * @param useAlpha true to convolve the alpha
-     * @see #getUseAlpha
-     */
-	public void setUseAlpha( boolean useAlpha ) {
-		this.alpha = useAlpha;
-	}
-
-    /**
-     * Get whether to convolve the alpha channel.
-     * @return true to convolve the alpha
-     * @see #setUseAlpha
-     */
-	public boolean getUseAlpha() {
-		return alpha;
-	}
-
-    /**
-     * Set whether to premultiply the alpha channel.
-     * @param premultiplyAlpha true to premultiply the alpha
-     * @see #getPremultiplyAlpha
-     */
-	public void setPremultiplyAlpha( boolean premultiplyAlpha ) {
-		this.premultiplyAlpha = premultiplyAlpha;
-	}
-
-    /**
-     * Get whether to premultiply the alpha channel.
-     * @return true to premultiply the alpha
-     * @see #setPremultiplyAlpha
-     */
-	public boolean getPremultiplyAlpha() {
-		return premultiplyAlpha;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ConvolveFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ConvolveFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setKernel`
- `getKernel`
- `getEdgeAction`
- `setUseAlpha`
- `getUseAlpha`
- `setPremultiplyAlpha`
- `getPremultiplyAlpha`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)