### PR TITLE
Remove unused public methods in UnsharpFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/UnsharpFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/UnsharpFilter.java
@@ -41,15 +41,6 @@ public class UnsharpFilter extends GaussianFilter {
 	}
 
 	/**
-     * Get the threshold value.
-     * @return the threshold value
-     * @see #setThreshold
-     */
-	public int getThreshold() {
-		return threshold;
-	}
-
-	/**
 	 * Set the amount of sharpening.
 	 * @param amount the amount
      * min-value 0
@@ -58,15 +49,6 @@ public class UnsharpFilter extends GaussianFilter {
 	 */
 	public void setAmount( float amount ) {
 		this.amount = amount;
-	}
-
-	/**
-	 * Get the amount of sharpening.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public float getAmount() {
-		return amount;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `UnsharpFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `UnsharpFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getThreshold`
- `getAmount`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)