### PR TITLE
Remove unused public methods in LinearColormap (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LinearColormap.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LinearColormap.java
@@ -42,22 +42,6 @@ public class LinearColormap implements Colormap {
 	}
 
 	/**
-	 * Get the first color.
-	 * @return the color corresponding to value 0 in the colormap
-	 */
-	public int getColor1() {
-		return color1;
-	}
-
-	/**
-	 * Get the second color.
-	 * @return the color corresponding to value 1 in the colormap
-	 */
-	public int getColor2() {
-		return color2;
-	}
-
-	/**
 	 * Convert a value in the range 0..1 to an RGB color.
 	 * @param v a value in the range 0..1
 	 * @return an RGB color


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `LinearColormap` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `LinearColormap` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getColor1`
- `getColor2`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)