### PR TITLE
Expose softness in DissolveFilter; prune unused getters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/DissolveFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/DissolveFilter.java
@@ -20,18 +20,29 @@ import java.awt.image.BufferedImageOp;
 public class DissolveFilter extends BufferedOpFilter {
 
    private final float density;
+   private final float softness;
 
    /**
     * @param density the density in the range 0 to 1.
     */
    public DissolveFilter(float density) {
+      this(density, 0f);
+   }
+
+   /**
+    * @param density  the density in the range 0 to 1.
+    * @param softness the softness of the dissolve in the range 0 to 1 (jhlabs default 0).
+    */
+   public DissolveFilter(float density, float softness) {
       this.density = density;
+      this.softness = softness;
    }
 
    @Override
    public BufferedImageOp op() {
       thirdparty.jhlabs.image.DissolveFilter op = new thirdparty.jhlabs.image.DissolveFilter();
       op.setDensity(density);
+      op.setSoftness(softness);
       return op;
    }
 

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DissolveFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DissolveFilter.java
@@ -37,39 +37,13 @@ public class DissolveFilter extends PointFilter {
 	 * @param density the density
      * min-value 0
      * max-value 1
-     * @see #getDensity
 	 */
 	public void setDensity( float density ) {
 		this.density = density;
 	}
 
-	/**
-	 * Get the density of the image.
-	 * @return the density
-     * @see #setDensity
-	 */
-	public float getDensity() {
-		return density;
-	}
-
-	/**
-	 * Set the softness of the dissolve in the range 0..1.
-	 * @param softness the softness
-     * min-value 0
-     * max-value 1
-     * @see #getSoftness
-	 */
 	public void setSoftness( float softness ) {
 		this.softness = softness;
-	}
-
-	/**
-	 * Get the softness of the dissolve.
-	 * @return the softness
-     * @see #setSoftness
-	 */
-	public float getSoftness() {
-		return softness;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/DissolveFilterSoftnessTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/DissolveFilterSoftnessTest.kt
@@ -1,0 +1,26 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Covers the softness constructor parameter, passed through to the jhlabs
+ * DissolveFilter (setSoftness). The dissolve is randomised, so this only checks
+ * the parameter is accepted and the filter applies cleanly.
+ */
+class DissolveFilterSoftnessTest : FunSpec({
+
+   val src = ImmutableImage.filled(40, 40, Color(120, 120, 120))
+
+   test("softness is accepted and the filter applies") {
+      val out = src.filter(DissolveFilter(0.5f, 0.7f))
+      out.width shouldBe 40
+      out.height shouldBe 40
+   }
+
+   test("the density-only constructor still applies") {
+      src.filter(DissolveFilter(0.5f)).width shouldBe 40
+   }
+})


### PR DESCRIPTION
Adds a `DissolveFilter(float density, float softness)` constructor passing `softness` to the jhlabs filter (`setSoftness`). The density-only constructor delegates with softness 0 (jhlabs default).

`setSoftness` is retained (the wrapper now uses it); the unused `getDensity`/`getSoftness` getters remain removed. `DissolveFilterSoftnessTest` covers it (the dissolve is randomised, so the test verifies the param is accepted and applies cleanly). Rebased onto current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)