### PR TITLE
Remove unused public methods in EmbossFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EmbossFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/EmbossFilter.java
@@ -32,30 +32,6 @@ public class EmbossFilter extends WholeImageFilter {
 	public EmbossFilter() {
 	}
 
-	public void setAzimuth(float azimuth) {
-		this.azimuth = azimuth;
-	}
-	
-	public float getAzimuth() {
-		return azimuth;
-	}
-	
-	public void setElevation(float elevation) {
-		this.elevation = elevation;
-	}
-	
-	public float getElevation() {
-		return elevation;
-	}
-	
-	public void setBumpHeight(float bumpHeight) {
-		this.width45 = 3 * bumpHeight;
-	}
-
-	public float getBumpHeight() {
-		return width45 / 3;
-	}
-
 	public void setEmboss(boolean emboss) {
 		this.emboss = emboss;
 	}


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `EmbossFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `EmbossFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setAzimuth`
- `getAzimuth`
- `setElevation`
- `getElevation`
- `setBumpHeight`
- `getBumpHeight`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)