### PR TITLE
Remove unused public methods in TransformFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransformFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransformFilter.java
@@ -86,37 +86,9 @@ public abstract class TransformFilter extends AbstractBufferedImageOp {
     /**
      * Set the action to perform for pixels off the edge of the image.
      * @param edgeAction one of ZERO, CLAMP or WRAP
-     * @see #getEdgeAction
      */
 	public void setEdgeAction(int edgeAction) {
 		this.edgeAction = edgeAction;
-	}
-
-    /**
-     * Get the action to perform for pixels off the edge of the image.
-     * @return one of ZERO, CLAMP or WRAP
-     * @see #setEdgeAction
-     */
-	public int getEdgeAction() {
-		return edgeAction;
-	}
-	
-    /**
-     * Set the type of interpolation to perform.
-     * @param interpolation one of NEAREST_NEIGHBOUR or BILINEAR
-     * @see #getInterpolation
-     */
-	public void setInterpolation(int interpolation) {
-		this.interpolation = interpolation;
-	}
-
-    /**
-     * Get the type of interpolation to perform.
-     * @return one of NEAREST_NEIGHBOUR or BILINEAR
-     * @see #setInterpolation
-     */
-	public int getInterpolation() {
-		return interpolation;
 	}
 	
     /**


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `TransformFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `TransformFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getEdgeAction`
- `setInterpolation`
- `getInterpolation`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)