### PR TITLE
Remove unused public methods in ChromeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ChromeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ChromeFilter.java
@@ -37,15 +37,6 @@ public class ChromeFilter extends LightFilter {
 	}
 
 	/**
-	 * Get the amount of chrome.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public float getAmount() {
-		return amount;
-	}
-
-	/**
 	 * Set the exppsure of the effect.
 	 * @param exposure the exposure
      * min-value 0
@@ -54,15 +45,6 @@ public class ChromeFilter extends LightFilter {
 	 */
 	public void setExposure(float exposure) {
 		this.exposure = exposure;
-	}
-
-	/**
-	 * Get the exppsure of the effect.
-	 * @return the exposure
-     * @see #setExposure
-	 */
-	public float getExposure() {
-		return exposure;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ChromeFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ChromeFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getAmount`
- `getExposure`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)