### PR TITLE
Remove unused public methods in ThresholdFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ThresholdFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ThresholdFilter.java
@@ -52,30 +52,12 @@ public class ThresholdFilter extends PointFilter {
 	}
 	
 	/**
-     * Get the lower threshold value.
-     * @return the threshold value
-     * @see #setLowerThreshold
-     */
-	public int getLowerThreshold() {
-		return lowerThreshold;
-	}
-	
-	/**
      * Set the upper threshold value.
      * @param upperThreshold the threshold value
      * @see #getUpperThreshold
      */
 	public void setUpperThreshold(int upperThreshold) {
 		this.upperThreshold = upperThreshold;
-	}
-
-	/**
-     * Get the upper threshold value.
-     * @return the threshold value
-     * @see #setUpperThreshold
-     */
-	public int getUpperThreshold() {
-		return upperThreshold;
 	}
 
 	/**
@@ -88,30 +70,12 @@ public class ThresholdFilter extends PointFilter {
 	}
 
 	/**
-     * Get the color to be used for pixels above the upper threshold.
-     * @return the color
-     * @see #setWhite
-     */
-	public int getWhite() {
-		return white;
-	}
-
-	/**
      * Set the color to be used for pixels below the lower threshold.
      * @param black the color
      * @see #getBlack
      */
 	public void setBlack(int black) {
 		this.black = black;
-	}
-
-	/**
-     * Set the color to be used for pixels below the lower threshold.
-     * @return the color
-     * @see #setBlack
-     */
-	public int getBlack() {
-		return black;
 	}
 
 	public int filterRGB(int x, int y, int rgb) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ThresholdFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ThresholdFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getLowerThreshold`
- `getUpperThreshold`
- `getWhite`
- `getBlack`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)