### PR TITLE
Remove unused public methods in TritoneFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
@@ -58,15 +58,6 @@ public class TritoneFilter extends PointFilter {
 	}
 
     /**
-     * Get the shadow color.
-     * @return the shadow color
-     * @see #setShadowColor
-     */
-	public int getShadowColor() {
-		return shadowColor;
-	}
-
-    /**
      * Set the mid color.
      * @param midColor the mid color
      */


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `TritoneFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `TritoneFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getShadowColor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)