### PR TITLE
Remove unused public methods in BlockFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BlockFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BlockFilter.java
@@ -39,26 +39,6 @@ public class BlockFilter extends AbstractBufferedImageOp {
 		this.blockSize = blockSize;
 	}
 
-	/**
-	 * Set the pixel block size.
-	 * @param blockSize the number of pixels along each block edge
-     * min-value 1
-     * max-value 100+
-     * @see #getBlockSize
-	 */
-	public void setBlockSize(int blockSize) {
-		this.blockSize = blockSize;
-	}
-
-	/**
-	 * Get the pixel block size.
-	 * @return the number of pixels along each block edge
-     * @see #setBlockSize
-	 */
-	public int getBlockSize() {
-		return blockSize;
-	}
-
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {
         int width = src.getWidth();
         int height = src.getHeight();


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `BlockFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `BlockFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setBlockSize`
- `getBlockSize`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)