### PR TITLE
Expose angle/centre/radius in KaleidoscopeFilter; prune unused getters

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/KaleidoscopeFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/KaleidoscopeFilter.java
@@ -20,21 +20,45 @@ import java.awt.image.BufferedImageOp;
 public class KaleidoscopeFilter extends BufferedOpFilter {
 
     private final int sides;
+    private final float angle;
+    private final float centreX;
+    private final float centreY;
+    private final float radius;
 
     public KaleidoscopeFilter() {
         this(3);
     }
 
     public KaleidoscopeFilter(int sides) {
+        // jhlabs defaults: angle 0, centre (0.5, 0.5), radius 0.
+        this(sides, 0f, 0.5f, 0.5f, 0f);
+    }
+
+    /**
+     * @param sides   the number of reflected segments (must be &gt; 2)
+     * @param angle   the rotation angle of the kaleidoscope, in radians
+     * @param centreX the centre of the effect in X, as a proportion of the image width [0, 1]
+     * @param centreY the centre of the effect in Y, as a proportion of the image height [0, 1]
+     * @param radius  the radius of the effect in pixels (0 applies it across the whole image)
+     */
+    public KaleidoscopeFilter(int sides, float angle, float centreX, float centreY, float radius) {
         if (sides < 3)
             throw new IllegalArgumentException("'sides' must be greater than 2");
         this.sides = sides;
+        this.angle = angle;
+        this.centreX = centreX;
+        this.centreY = centreY;
+        this.radius = radius;
     }
 
     @Override
     public BufferedImageOp op() {
         thirdparty.jhlabs.image.KaleidoscopeFilter filter = new thirdparty.jhlabs.image.KaleidoscopeFilter();
         filter.setSides(sides);
+        filter.setAngle(angle);
+        filter.setCentreX(centreX);
+        filter.setCentreY(centreY);
+        filter.setRadius(radius);
         return filter;
     }
 }

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/KaleidoscopeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/KaleidoscopeFilter.java
@@ -45,125 +45,25 @@ public class KaleidoscopeFilter extends TransformFilter {
     * Set the number of sides of the kaleidoscope.
     *
     * @param sides the number of sides
-    * @see #getSides
     */
    public void setSides(int sides) {
       this.sides = sides;
    }
 
-   /**
-    * Get the number of sides of the kaleidoscope.
-    *
-    * @return the number of sides
-    * @see #setSides
-    */
-   public int getSides() {
-      return sides;
-   }
-
-   /**
-    * Set the angle of the kaleidoscope.
-    *
-    * @param angle the angle of the kaleidoscope.
-    * @see #getAngle
-    */
    public void setAngle(float angle) {
       this.angle = angle;
    }
 
-   /**
-    * Get the angle of the kaleidoscope.
-    *
-    * @return the angle of the kaleidoscope.
-    * @see #setAngle
-    */
-   public float getAngle() {
-      return angle;
-   }
-
-   public void setAngle2(float angle2) {
-      this.angle2 = angle2;
-   }
-
-   /**
-    * Set the centre of the effect in the X direction as a proportion of the image size.
-    *
-    * @param centreX the center
-    * @see #getCentreX
-    */
    public void setCentreX(float centreX) {
       this.centreX = centreX;
    }
 
-   /**
-    * Get the centre of the effect in the X direction as a proportion of the image size.
-    *
-    * @return the center
-    * @see #setCentreX
-    */
-   public float getCentreX() {
-      return centreX;
-   }
-
-   /**
-    * Set the centre of the effect in the Y direction as a proportion of the image size.
-    *
-    * @param centreY the center
-    * @see #getCentreY
-    */
    public void setCentreY(float centreY) {
       this.centreY = centreY;
    }
 
-   /**
-    * Get the centre of the effect in the Y direction as a proportion of the image size.
-    *
-    * @return the center
-    * @see #setCentreY
-    */
-   public float getCentreY() {
-      return centreY;
-   }
-
-   /**
-    * Set the centre of the effect as a proportion of the image size.
-    *
-    * @param centre the center
-    * @see #getCentre
-    */
-   public void setCentre(Point2D centre) {
-      this.centreX = (float) centre.getX();
-      this.centreY = (float) centre.getY();
-   }
-
-   /**
-    * Get the centre of the effect as a proportion of the image size.
-    *
-    * @return the center
-    * @see #setCentre
-    */
-   public Point2D getCentre() {
-      return new Point2D.Float(centreX, centreY);
-   }
-
-   /**
-    * Set the radius of the effect.
-    *
-    * @param radius the radius
-    * @see #getRadius
-    */
    public void setRadius(float radius) {
       this.radius = radius;
-   }
-
-   /**
-    * Get the radius of the effect.
-    *
-    * @return the radius
-    * @see #setRadius
-    */
-   public float getRadius() {
-      return radius;
    }
 
    public BufferedImage filter(BufferedImage src, BufferedImage dst) {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/KaleidoscopeFilterParamsTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/KaleidoscopeFilterParamsTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.awt.Color
+
+/**
+ * Verifies the angle/centre/radius constructor parameters are passed through to
+ * the jhlabs KaleidoscopeFilter (each changes the transform, so the output differs).
+ */
+class KaleidoscopeFilterParamsTest : FunSpec({
+
+   // a non-symmetric gradient so the kaleidoscope transform is observable
+   val src = ImmutableImage.create(64, 64).map { p -> Color((p.x() * 4) % 256, (p.y() * 4) % 256, 128) }
+
+   test("angle is passed through") {
+      val a = src.filter(KaleidoscopeFilter(3, 0f, 0.5f, 0.5f, 0f))
+      val b = src.filter(KaleidoscopeFilter(3, 1.2f, 0.5f, 0.5f, 0f))
+      a shouldNotBe b
+   }
+
+   test("centre is passed through") {
+      val a = src.filter(KaleidoscopeFilter(3, 0f, 0.5f, 0.5f, 0f))
+      val b = src.filter(KaleidoscopeFilter(3, 0f, 0.3f, 0.7f, 0f))
+      a shouldNotBe b
+   }
+
+   test("radius is passed through") {
+      val a = src.filter(KaleidoscopeFilter(3, 0f, 0.5f, 0.5f, 0f))
+      val b = src.filter(KaleidoscopeFilter(3, 0f, 0.5f, 0.5f, 15f))
+      a shouldNotBe b
+   }
+
+   test("the sides-only constructor still applies") {
+      src.filter(KaleidoscopeFilter(4)).width shouldBe 64
+   }
+})


### PR DESCRIPTION
The scrimage `KaleidoscopeFilter` wrapper only exposed `sides`, ignoring the jhlabs filter's angle, centre and radius.

## Changes
- New constructor `KaleidoscopeFilter(int sides, float angle, float centreX, float centreY, float radius)` that passes the values through (`setAngle`, `setCentreX`, `setCentreY`, `setRadius`). Existing constructors delegate with the jhlabs defaults (angle 0, centre 0.5/0.5, radius 0), so behaviour is unchanged.
- Those four setters are retained (the wrapper now uses them); the genuinely unused jhlabs getters and `setAngle2`/`setCentre(Point2D)` remain removed.

## Tests
`KaleidoscopeFilterParamsTest` asserts angle, centre and radius each change the output, and that the sides-only constructor still applies.

(Rebased onto current master; no new javadoc `@see` danglers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)