### PR TITLE
Remove unused public methods in RGBAdjustFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RGBAdjustFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RGBAdjustFilter.java
@@ -51,18 +51,6 @@ public class RGBAdjustFilter extends PointFilter {
 		this.bFactor = 1+bFactor;
 	}
 	
-	public float getBFactor() {
-		return bFactor-1;
-	}
-
-	public int[] getLUT() {
-		int[] lut = new int[256];
-		for ( int i = 0; i < 256; i++ ) {
-			lut[i] = filterRGB( 0, 0, (i << 24) | (i << 16) | (i << 8) | i );
-		}
-		return lut;
-	}
-	
 	public int filterRGB(int x, int y, int rgb) {
 		int a = rgb & 0xff000000;
 		int r = (rgb >> 16) & 0xff;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `RGBAdjustFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `RGBAdjustFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getBFactor`
- `getLUT`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)