### PR TITLE
Remove unused public methods in ArrayColormap (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ArrayColormap.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ArrayColormap.java
@@ -53,31 +53,10 @@ public class ArrayColormap implements Colormap, Cloneable {
    }
 
    /**
-    * Set the array of colors for the colormap.
-    *
-    * @param map the colors
-    * @see #getMap
-    */
-   public void setMap(int[] map) {
-      this.map = map;
-   }
-
-   /**
-    * Get the array of colors for the colormap.
-    *
-    * @return the colors
-    * @see #setMap
-    */
-   public int[] getMap() {
-      return map;
-   }
-
-   /**
     * Convert a value in the range 0..1 to an RGB color.
     *
     * @param v a value in the range 0..1
     * @return an RGB color
-    * @see #setColor
     */
    public int getColor(float v) {
 /*
@@ -121,17 +100,6 @@ public class ArrayColormap implements Colormap, Cloneable {
    public void setColorRange(int firstIndex, int lastIndex, int color) {
       for (int i = firstIndex; i <= lastIndex; i++)
          map[i] = color;
-   }
-
-   /**
-    * Set one element of the colormap to a given color.
-    *
-    * @param index the position of the color
-    * @param color the color
-    * @see #getColor
-    */
-   public void setColor(int index, int color) {
-      map[index] = color;
    }
 
 }


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ArrayColormap` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ArrayColormap` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setMap`
- `getMap`
- `setColor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)