### PR TITLE
Remove unused public methods in ContrastFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContrastFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContrastFilter.java
@@ -43,15 +43,6 @@ public class ContrastFilter extends TransferFilter {
 	}
 
     /**
-     * Get the filter brightness.
-     * @return the brightness in the range 0 to 1
-     * @see #setBrightness
-     */
-	public float getBrightness() {
-		return brightness;
-	}
-
-    /**
      * Set the filter contrast.
      * @param contrast the contrast in the range 0 to 1
      * min-value 0
@@ -61,15 +52,6 @@ public class ContrastFilter extends TransferFilter {
 	public void setContrast(float contrast) {
 		this.contrast = contrast;
 		initialized = false;
-	}
-
-    /**
-     * Get the filter contrast.
-     * @return the contrast in the range 0 to 1
-     * @see #setContrast
-     */
-	public float getContrast() {
-		return contrast;
 	}
 
 	public String toString() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ContrastFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ContrastFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getBrightness`
- `getContrast`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)