### PR TITLE
Remove unused public methods in PosterizeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PosterizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PosterizeFilter.java
@@ -40,15 +40,6 @@ public class PosterizeFilter extends PointFilter {
 	}
 
 	/**
-     * Get the number of levels in the output image.
-     * @return the number of levels
-     * @see #setNumLevels
-     */
-	public int getNumLevels() {
-		return numLevels;
-	}
-
-	/**
      * Initialize the filter.
      */
     protected void initialize() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `PosterizeFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `PosterizeFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getNumLevels`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)