### PR TITLE
Remove unused public methods in DiffuseFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DiffuseFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DiffuseFilter.java
@@ -42,16 +42,6 @@ public class DiffuseFilter extends TransformFilter {
         this.scale = scale;
     }
 
-    /**
-     * Returns the scale of the texture.
-     *
-     * @return the scale of the texture.
-     * @see #setScale
-     */
-    public float getScale() {
-        return scale;
-    }
-
     protected void transformInverse(int x, int y, float[] out) {
         int angle = (int) (Math.random() * 255);
         float distance = (float) Math.random();


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `DiffuseFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `DiffuseFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getScale`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)