### PR TITLE
Remove unused public methods in LensBlurFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
@@ -41,16 +41,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
     }
 
     /**
-     * Get the radius of the kernel.
-     *
-     * @return the radius
-     * @see #setRadius
-     */
-    public float getRadius() {
-        return radius;
-    }
-
-    /**
      * Set the number of sides of the aperture.
      *
      * @param sides the number of sides
@@ -58,16 +48,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      */
     public void setSides(int sides) {
         this.sides = sides;
-    }
-
-    /**
-     * Get the number of sides of the aperture.
-     *
-     * @return the number of sides
-     * @see #setSides
-     */
-    public int getSides() {
-        return sides;
     }
 
     /**
@@ -81,16 +61,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
     }
 
     /**
-     * Get the bloom factor.
-     *
-     * @return the bloom factor
-     * @see #setBloom
-     */
-    public float getBloom() {
-        return bloom;
-    }
-
-    /**
      * Set the bloom threshold.
      *
      * @param bloomThreshold the bloom threshold
@@ -98,16 +68,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      */
     public void setBloomThreshold(float bloomThreshold) {
         this.bloomThreshold = bloomThreshold;
-    }
-
-    /**
-     * Get the bloom threshold.
-     *
-     * @return the bloom threshold
-     * @see #setBloomThreshold
-     */
-    public float getBloomThreshold() {
-        return bloomThreshold;
     }
 
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `LensBlurFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `LensBlurFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getRadius`
- `getSides`
- `getBloom`
- `getBloomThreshold`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)