### PR TITLE
Remove unused public methods in TwirlFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TwirlFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TwirlFilter.java
@@ -45,93 +45,34 @@ public class TwirlFilter extends TransformFilter {
 	/**
 	 * Set the angle of twirl in radians. 0 means no distortion.
 	 * @param angle the angle of twirl. This is the angle by which pixels at the nearest edge of the image will move.
-     * @see #getAngle
 	 */
 	public void setAngle(float angle) {
 		this.angle = angle;
 	}
 
 	/**
-	 * Get the angle of twist.
-	 * @return the angle in radians.
-     * @see #setAngle
-	 */
-	public float getAngle() {
-		return angle;
-	}
-
-	/**
 	 * Set the centre of the effect in the X direction as a proportion of the image size.
 	 * @param centreX the center
-     * @see #getCentreX
 	 */
 	public void setCentreX( float centreX ) {
 		this.centreX = centreX;
 	}
 
 	/**
-	 * Get the centre of the effect in the X direction as a proportion of the image size.
-	 * @return the center
-     * @see #setCentreX
-	 */
-	public float getCentreX() {
-		return centreX;
-	}
-
-	/**
 	 * Set the centre of the effect in the Y direction as a proportion of the image size.
 	 * @param centreY the center
-     * @see #getCentreY
 	 */
 	public void setCentreY( float centreY ) {
 		this.centreY = centreY;
 	}
 
 	/**
-	 * Get the centre of the effect in the Y direction as a proportion of the image size.
-	 * @return the center
-     * @see #setCentreY
-	 */
-	public float getCentreY() {
-		return centreY;
-	}
-
-	/**
-	 * Set the centre of the effect as a proportion of the image size.
-	 * @param centre the center
-     * @see #getCentre
-	 */
-	public void setCentre( Point2D centre ) {
-		this.centreX = (float)centre.getX();
-		this.centreY = (float)centre.getY();
-	}
-
-	/**
-	 * Get the centre of the effect as a proportion of the image size.
-	 * @return the center
-     * @see #setCentre
-	 */
-	public Point2D getCentre() {
-		return new Point2D.Float( centreX, centreY );
-	}
-
-	/**
 	 * Set the radius of the effect.
 	 * @param radius the radius
      * min-value 0
-     * @see #getRadius
 	 */
 	public void setRadius(float radius) {
 		this.radius = radius;
-	}
-
-	/**
-	 * Get the radius of the effect.
-	 * @return the radius
-     * @see #setRadius
-	 */
-	public float getRadius() {
-		return radius;
 	}
 
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `TwirlFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `TwirlFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getAngle`
- `getCentreX`
- `getCentreY`
- `setCentre`
- `getCentre`
- `getRadius`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)