### PR TITLE
Remove unused public methods in HSBAdjustFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/HSBAdjustFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/HSBAdjustFilter.java
@@ -54,10 +54,6 @@ public class HSBAdjustFilter extends PointFilter {
 		this.bFactor = bFactor;
 	}
 	
-	public float getBFactor() {
-		return bFactor;
-	}
-	
 	public int filterRGB(int x, int y, int rgb) {
 		int a = rgb & 0xff000000;
 		int r = (rgb >> 16) & 0xff;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `HSBAdjustFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `HSBAdjustFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getBFactor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)