### PR TITLE
Remove unused public methods in PointillizeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PointillizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PointillizeFilter.java
@@ -32,24 +32,12 @@ public class PointillizeFilter extends CellularFilter {
         this.edgeThickness = edgeThickness;
     }
 
-    public float getEdgeThickness() {
-        return edgeThickness;
-    }
-
     public void setFadeEdges(boolean fadeEdges) {
         this.fadeEdges = fadeEdges;
     }
 
-    public boolean getFadeEdges() {
-        return fadeEdges;
-    }
-
     public void setEdgeColor(int edgeColor) {
         this.edgeColor = edgeColor;
-    }
-
-    public int getEdgeColor() {
-        return edgeColor;
     }
 
     public void setFuzziness(float fuzziness) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `PointillizeFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `PointillizeFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getEdgeThickness`
- `getFadeEdges`
- `getEdgeColor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)