### PR TITLE
Remove unused public methods in SmearFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/SmearFilter.java
@@ -55,16 +55,8 @@ public class SmearFilter extends WholeImageFilter {
 		this.distance = distance;
 	}
 
-	public int getDistance() {
-		return distance;
-	}
-
 	public void setDensity(float density) {
 		this.density = density;
-	}
-
-	public float getDensity() {
-		return density;
 	}
 
 	public void setScatter(float scatter) {
@@ -82,13 +74,6 @@ public class SmearFilter extends WholeImageFilter {
 		this.angle = angle;
 	}
 
-	/**
-     * Returns the angle of the texture.
-     */
-	public float getAngle() {
-		return angle;
-	}
-
 	public void setMix(float mix) {
 		this.mix = mix;
 	}
@@ -103,18 +88,6 @@ public class SmearFilter extends WholeImageFilter {
 
 	public int getFadeout() {
 		return fadeout;
-	}
-
-	public void setBackground(boolean background) {
-		this.background = background;
-	}
-
-	public boolean getBackground() {
-		return background;
-	}
-
-	public void randomize() {
-		seed = new Date().getTime();
 	}
 
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `SmearFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `SmearFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getDistance`
- `getDensity`
- `getAngle`
- `setBackground`
- `getBackground`
- `randomize`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)