### PR TITLE
Remove unused public methods in LightFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LightFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LightFilter.java
@@ -115,14 +115,6 @@ public class LightFilter extends WholeImageFilter {
       return bumpFunction;
    }
 
-   public void setBumpHeight(float bumpHeight) {
-      this.bumpHeight = bumpHeight;
-   }
-
-   public float getBumpHeight() {
-      return bumpHeight;
-   }
-
    public void setBumpSoftness(float bumpSoftness) {
       this.bumpSoftness = bumpSoftness;
    }
@@ -177,14 +169,6 @@ public class LightFilter extends WholeImageFilter {
 
    public int getBumpSource() {
       return bumpSource;
-   }
-
-   public void setDiffuseColor(int diffuseColor) {
-      material.diffuseColor = diffuseColor;
-   }
-
-   public int getDiffuseColor() {
-      return material.diffuseColor;
    }
 
    public void addLight(Light light) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `LightFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `LightFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setBumpHeight`
- `getBumpHeight`
- `setDiffuseColor`
- `getDiffuseColor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)