### PR TITLE
Remove unused public methods in ContourFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContourFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContourFilter.java
@@ -35,36 +35,8 @@ public class ContourFilter extends WholeImageFilter {
 		this.levels = levels;
 	}
 
-	public float getLevels() {
-		return levels;
-	}
-
-	/**
-     * Specifies the scale of the contours.
-     * @param scale the scale of the contours.
-     * min-value 0
-     * max-value 1
-     * @see #getScale
-     */
-	public void setScale( float scale ) {
-		this.scale = scale;
-	}
-
-	/**
-     * Returns the scale of the contours.
-     * @return the scale of the contours.
-     * @see #setScale
-     */
-	public float getScale() {
-		return scale;
-	}
-
 	public void setOffset( float offset ) {
 		this.offset = offset;
-	}
-
-	public float getOffset() {
-		return offset;
 	}
 
 	public void setContourColor( int contourColor ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `ContourFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ContourFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getLevels`
- `setScale`
- `getScale`
- `getOffset`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)