### PR TITLE
Remove unused public methods in GlowFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlowFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlowFilter.java
@@ -41,15 +41,6 @@ public class GlowFilter extends GaussianFilter {
 		this.amount = amount;
 	}
 
-	/**
-	 * Get the amount of glow.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public float getAmount() {
-		return amount;
-	}
-
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {
         int width = src.getWidth();
         int height = src.getHeight();


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `GlowFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `GlowFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getAmount`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)