### PR TITLE
Remove unused public methods in BinaryFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BinaryFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/BinaryFilter.java
@@ -32,37 +32,9 @@ public abstract class BinaryFilter extends WholeImageFilter {
 	 * Set the number of iterations the effect is performed.
 	 * @param iterations the number of iterations
      * min-value 0
-     * @see #getIterations
 	 */
 	public void setIterations(int iterations) {
 		this.iterations = iterations;
-	}
-
-	/**
-	 * Get the number of iterations the effect is performed.
-	 * @return the number of iterations
-     * @see #setIterations
-	 */
-	public int getIterations() {
-		return iterations;
-	}
-
-    /**
-     * Set the colormap to be used for the filter.
-     * @param colormap the colormap
-     * @see #getColormap
-     */
-	public void setColormap(Colormap colormap) {
-		this.colormap = colormap;
-	}
-
-    /**
-     * Get the colormap to be used for the filter.
-     * @return the colormap
-     * @see #setColormap
-     */
-	public Colormap getColormap() {
-		return colormap;
 	}
 
 	public void setNewColor(int newColor) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `BinaryFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `BinaryFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getIterations`
- `setColormap`
- `getColormap`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)