### PR TITLE
Remove unused public methods in TransferFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransferFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TransferFilter.java
@@ -59,16 +59,6 @@ public abstract class TransferFilter extends PointFilter {
 	protected float transferFunction( float v ) {
 		return 0;
 	}
-
-	public int[] getLUT() {
-		if (!initialized)
-			initialize();
-		int[] lut = new int[256];
-		for ( int i = 0; i < 256; i++ ) {
-			lut[i] = filterRGB( 0, 0, (i << 24) | (i << 16) | (i << 8) | i );
-		}
-		return lut;
-	}
 	
 }
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `TransferFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `TransferFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getLUT`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)