### PR TITLE
Remove unused public methods in VariableBlurFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/VariableBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/VariableBlurFilter.java
@@ -32,24 +32,6 @@ public class VariableBlurFilter extends AbstractBufferedImageOp {
 	private BufferedImage blurMask;
 	private boolean premultiplyAlpha = true;
 
-    /**
-     * Set whether to premultiply the alpha channel.
-     * @param premultiplyAlpha true to premultiply the alpha
-     * @see #getPremultiplyAlpha
-     */
-	public void setPremultiplyAlpha( boolean premultiplyAlpha ) {
-		this.premultiplyAlpha = premultiplyAlpha;
-	}
-
-    /**
-     * Get whether to premultiply the alpha channel.
-     * @return true to premultiply the alpha
-     * @see #setPremultiplyAlpha
-     */
-	public boolean getPremultiplyAlpha() {
-		return premultiplyAlpha;
-	}
-
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {
 		int width = src.getWidth();
         int height = src.getHeight();
@@ -198,97 +180,20 @@ public class VariableBlurFilter extends AbstractBufferedImageOp {
 	}
 
 	/**
-	 * Set the horizontal size of the blur.
-	 * @param hRadius the radius of the blur in the horizontal direction
-     * min-value 0
-     * @see #getHRadius
-	 */
-	public void setHRadius(int hRadius) {
-		this.hRadius = hRadius;
-	}
-
-	/**
-	 * Get the horizontal size of the blur.
-	 * @return the radius of the blur in the horizontal direction
-     * @see #setHRadius
-	 */
-	public int getHRadius() {
-		return hRadius;
-	}
-
-	/**
-	 * Set the vertical size of the blur.
-	 * @param vRadius the radius of the blur in the vertical direction
-     * min-value 0
-     * @see #getVRadius
-	 */
-	public void setVRadius(int vRadius) {
-		this.vRadius = vRadius;
-	}
-
-	/**
-	 * Get the vertical size of the blur.
-	 * @return the radius of the blur in the vertical direction
-     * @see #setVRadius
-	 */
-	public int getVRadius() {
-		return vRadius;
-	}
-
-	/**
 	 * Set the radius of the effect.
 	 * @param radius the radius
      * min-value 0
-     * @see #getRadius
 	 */
 	public void setRadius(int radius) {
 		this.hRadius = this.vRadius = radius;
 	}
 
 	/**
-	 * Get the radius of the effect.
-	 * @return the radius
-     * @see #setRadius
-	 */
-	public int getRadius() {
-		return hRadius;
-	}
-
-	/**
-	 * Set the number of iterations the blur is performed.
-	 * @param iterations the number of iterations
-     * min-value 0
-     * @see #getIterations
-	 */
-	public void setIterations(int iterations) {
-		this.iterations = iterations;
-	}
-
-	/**
-	 * Get the number of iterations the blur is performed.
-	 * @return the number of iterations
-     * @see #setIterations
-	 */
-	public int getIterations() {
-		return iterations;
-	}
-
-	/**
 	 * Set the mask used to give the amount of blur at each point.
 	 * @param blurMask the mask
-     * @see #getBlurMask
 	 */
 	public void setBlurMask(BufferedImage blurMask) {
 		this.blurMask = blurMask;
-	}
-
-	/**
-	 * Get the mask used to give the amount of blur at each point.
-	 * @return the mask
-     * @see #setBlurMask
-	 */
-	public BufferedImage getBlurMask() {
-		return blurMask;
 	}
 
 	public String toString() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `VariableBlurFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `VariableBlurFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setPremultiplyAlpha`
- `getPremultiplyAlpha`
- `setHRadius`
- `getHRadius`
- `setVRadius`
- `getVRadius`
- `getRadius`
- `setIterations`
- `getIterations`
- `getBlurMask`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)