### PR TITLE
Remove unused public methods in GammaFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GammaFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GammaFilter.java
@@ -71,15 +71,6 @@ public class GammaFilter extends TransferFilter {
 		setGamma(gamma, gamma, gamma);
 	}
 	
-    /**
-     * Get the gamma level.
-     * @return the gamma level for all RGB channels
-     * @see #setGamma
-     */
-	public float getGamma() {
-		return rGamma;
-	}
-	
     protected void initialize() {
 		rTable = makeTable(rGamma);
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `GammaFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `GammaFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getGamma`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)