### PR TITLE
Remove unused public methods in GaussianFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GaussianFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GaussianFilter.java
@@ -59,21 +59,10 @@ public class GaussianFilter extends ConvolveFilter {
      * @param radius the radius of the blur in pixels.
      * min-value 0
      * max-value 100+
-     * @see #getRadius
      */
     public void setRadius(float radius) {
         this.radius = radius;
         kernel = makeKernel(radius);
-    }
-
-    /**
-     * Get the radius of the kernel.
-     *
-     * @return the radius
-     * @see #setRadius
-     */
-    public float getRadius() {
-        return radius;
     }
 
     public BufferedImage filter(BufferedImage src, BufferedImage dst) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `GaussianFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `GaussianFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getRadius`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)