### PR TITLE
Remove unused public methods in QuantizeFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/QuantizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/QuantizeFilter.java
@@ -59,14 +59,6 @@ public class QuantizeFilter extends WholeImageFilter {
 		this.dither = dither;
 	}
 
-	/**
-	 * Set whether to use a serpentine pattern for return or not. This can reduce 'avalanche' artifacts in the output.
-	 * @param serpentine true to use serpentine pattern
-	 */
-	public void setSerpentine(boolean serpentine) {
-		this.serpentine = serpentine;
-	}
-
 	public void quantize(int[] inPixels, int[] outPixels, int width, int height, int numColors, boolean dither, boolean serpentine) {
 		int count = width*height;
 		Quantizer quantizer = new OctTreeQuantizer();


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `QuantizeFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `QuantizeFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setSerpentine`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)