### PR TITLE
Expose fadeEdges in CrystallizeFilter; prune remaining unused methods

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CrystallizeFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/CrystallizeFilter.java
@@ -23,8 +23,17 @@ public class CrystallizeFilter extends BufferedOpFilter {
     private final double edgeThickness;
     private final int edgeColor;
     private final double randomness;
+    private final boolean fadeEdges;
 
     public CrystallizeFilter(double scale, double edgeThickness, int edgeColor, double randomness) {
+        this(scale, edgeThickness, edgeColor, randomness, false);
+    }
+
+    /**
+     * @param fadeEdges when true, cell edges are faded between neighbouring cells rather than
+     *                  drawn in {@code edgeColor}.
+     */
+    public CrystallizeFilter(double scale, double edgeThickness, int edgeColor, double randomness, boolean fadeEdges) {
         if (!(scale > 0))
             throw new IllegalArgumentException("scale must be > 0, got " + scale);
         // The jhlabs implementation computes `f = (f2 - f1) / edgeThickness`
@@ -38,6 +47,7 @@ public class CrystallizeFilter extends BufferedOpFilter {
         this.edgeThickness = edgeThickness;
         this.edgeColor = edgeColor;
         this.randomness = randomness;
+        this.fadeEdges = fadeEdges;
     }
 
     public CrystallizeFilter() {
@@ -51,6 +61,7 @@ public class CrystallizeFilter extends BufferedOpFilter {
         op.setEdgeThickness((float) edgeThickness);
         op.setScale((float) scale);
         op.setRandomness((float) randomness);
+        op.setFadeEdges(fadeEdges);
         return op;
     }
 }

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CrystallizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CrystallizeFilter.java
@@ -34,24 +34,12 @@ public class CrystallizeFilter extends CellularFilter {
 		this.edgeThickness = edgeThickness;
 	}
 
-	public float getEdgeThickness() {
-		return edgeThickness;
-	}
-
 	public void setFadeEdges(boolean fadeEdges) {
 		this.fadeEdges = fadeEdges;
 	}
 
-	public boolean getFadeEdges() {
-		return fadeEdges;
-	}
-
 	public void setEdgeColor(int edgeColor) {
 		this.edgeColor = edgeColor;
-	}
-
-	public int getEdgeColor() {
-		return edgeColor;
 	}
 
 	public int getPixel(int x, int y, int[] inPixels, int width, int height) {

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CrystallizeFilterFadeEdgesTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/CrystallizeFilterFadeEdgesTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Verifies the fadeEdges constructor parameter is honoured and passed through to
+ * the jhlabs CrystallizeFilter (fadeEdges blends cell edges instead of drawing
+ * them in edgeColor, so the output differs).
+ */
+class CrystallizeFilterFadeEdgesTest : FunSpec({
+
+   val original = ImmutableImage.fromResource("/bird_small.png")
+
+   test("fadeEdges changes the output") {
+      val faded = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.0, true))
+      val notFaded = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.0, false))
+      faded shouldNotBe notFaded
+   }
+
+   test("the four-arg constructor defaults fadeEdges to false") {
+      val fourArg = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.0))
+      val explicitFalse = original.filter(CrystallizeFilter(16.0, 0.4, 0xff000000.toInt(), 0.0, false))
+      fourArg shouldBe explicitFalse
+   }
+})


### PR DESCRIPTION
Scrimage wraps the jhlabs `CrystallizeFilter`, but the wrapper never exposed the filter's `fadeEdges` option (which blends cell edges between neighbouring cells instead of drawing them in `edgeColor`).

## Changes

- Adds a new `CrystallizeFilter(scale, edgeThickness, edgeColor, randomness, fadeEdges)` constructor that passes the flag through to the jhlabs filter via `op.setFadeEdges(...)`. The existing four-arg constructor delegates with `fadeEdges = false` (the jhlabs default), so its behaviour and golden output are unchanged.
- Since the wrapper now calls `setFadeEdges`, that method is no longer dead and is **retained** (this PR originally removed it). The genuinely-unused jhlabs `CrystallizeFilter` getters are still removed: `getEdgeThickness`, `getFadeEdges`, `getEdgeColor`.

## Tests

`CrystallizeFilterFadeEdgesTest` asserts that `fadeEdges = true` produces different output than `false` (proving the flag reaches the jhlabs filter), and that the four-arg constructor equals the five-arg with `fadeEdges = false`. The existing `CrystallizeFilterTest` golden tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)