### PR TITLE
Remove unused public methods in CausticsFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
@@ -51,57 +51,12 @@ public class CausticsFilter extends WholeImageFilter {
     }
 
 	/**
-	 * Specifies the scale of the texture.
-	 * @param scale the scale of the texture.
-     * @see #getScale
-     */
-	public void setScale(float scale) {
-		this.scale = scale;
-	}
-
-	/**
-     * Returns the scale of the texture.
-     * @return the scale of the texture.
-     * @see #setScale
-     */
-	public float getScale() {
-		return scale;
-	}
-
-	/**
-     * Set the brightness.
-     * @param brightness the brightness.
-     * @see #getBrightness
-     */
-	public void setBrightness(int brightness) {
-		this.brightness = brightness;
-	}
-
-	/**
-     * Get the brightness.
-     * @return the brightness.
-     * @see #setBrightness
-     */
-	public int getBrightness() {
-		return brightness;
-	}
-
-	/**
      * Specifies the turbulence of the texture.
      * @param turbulence the turbulence of the texture.
      * @see #getTurbulence
      */
 	public void setTurbulence(float turbulence) {
 		this.turbulence = turbulence;
-	}
-
-	/**
-     * Returns the turbulence of the effect.
-     * @return the turbulence of the effect.
-     * @see #setTurbulence
-     */
-	public float getTurbulence() {
-		return turbulence;
 	}
 
 	/**
@@ -114,48 +69,12 @@ public class CausticsFilter extends WholeImageFilter {
 	}
 
 	/**
-	 * Get the amount of effect.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public float getAmount() {
-		return amount;
-	}
-
-	/**
-	 * Set the dispersion.
-	 * @param dispersion the dispersion
-     * @see #getDispersion
-	 */
-	public void setDispersion(float dispersion) {
-		this.dispersion = dispersion;
-	}
-
-	/**
-	 * Get the dispersion.
-	 * @return the dispersion
-     * @see #setDispersion
-	 */
-	public float getDispersion() {
-		return dispersion;
-	}
-
-	/**
 	 * Set the time. Use this to animate the effect.
 	 * @param time the time
      * @see #getTime
 	 */
 	public void setTime(float time) {
 		this.time = time;
-	}
-
-	/**
-	 * Set the time.
-	 * @return the time
-     * @see #setTime
-	 */
-	public float getTime() {
-		return time;
 	}
 
 	/**
@@ -168,30 +87,12 @@ public class CausticsFilter extends WholeImageFilter {
 	}
 
 	/**
-	 * Get the number of samples per pixel.
-	 * @return the number of samples
-     * @see #setSamples
-	 */
-	public int getSamples() {
-		return samples;
-	}
-
-	/**
 	 * Set the background color.
 	 * @param c the color
      * @see #getBgColor
 	 */
 	public void setBgColor(int c) {
 		bgColor = c;
-	}
-
-	/**
-	 * Get the background color.
-	 * @return the color
-     * @see #setBgColor
-	 */
-	public int getBgColor() {
-		return bgColor;
 	}
 
 	protected int[] filterPixels( int width, int height, int[] inPixels, Rectangle transformedSpace ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `CausticsFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `CausticsFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setScale`
- `getScale`
- `setBrightness`
- `getBrightness`
- `getTurbulence`
- `getAmount`
- `setDispersion`
- `getDispersion`
- `getTime`
- `getSamples`
- `getBgColor`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)