### PR TITLE
Remove unused public methods in OilFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OilFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OilFilter.java
@@ -40,16 +40,6 @@ public class OilFilter extends WholeImageFilter {
     }
 
     /**
-     * Get the range of the effect in pixels.
-     *
-     * @return the range
-     * @see #setRange
-     */
-    public int getRange() {
-        return range;
-    }
-
-    /**
      * Set the number of levels for the effect.
      *
      * @param levels the number of levels
@@ -57,16 +47,6 @@ public class OilFilter extends WholeImageFilter {
      */
     public void setLevels(int levels) {
         this.levels = levels;
-    }
-
-    /**
-     * Get the number of levels for the effect.
-     *
-     * @return the number of levels
-     * @see #setLevels
-     */
-    public int getLevels() {
-        return levels;
     }
 
     protected int[] filterPixels(int width, int height, int[] inPixels, Rectangle transformedSpace) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `OilFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `OilFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getRange`
- `getLevels`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)