### PR TITLE
Remove unused public methods in GainFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GainFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GainFilter.java
@@ -43,15 +43,6 @@ public class GainFilter extends TransferFilter {
 	}
 
     /**
-     * Get the gain.
-     * @return the gain
-     * @see #setGain
-     */
-	public float getGain() {
-		return gain;
-	}
-
-    /**
      * Set the bias.
      * @param bias the bias
      * min-value: 0
@@ -61,15 +52,6 @@ public class GainFilter extends TransferFilter {
 	public void setBias(float bias) {
 		this.bias = bias;
 		initialized = false;
-	}
-
-    /**
-     * Get the bias.
-     * @return the bias
-     * @see #setBias
-     */
-	public float getBias() {
-		return bias;
 	}
 
 	public String toString() {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `GainFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `GainFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getGain`
- `getBias`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)