### PR TITLE
Expose raysOnly in RaysFilter; prune remaining unused methods

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/RaysFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/RaysFilter.java
@@ -26,9 +26,19 @@ public class RaysFilter extends BufferedOpFilter {
     private final float distance;
     private final float zoom;
     private final float rotation;
+    private final boolean raysOnly;
 
     public RaysFilter(float opacity, float threshold, float strength,
                       float angle, float distance, float zoom, float rotation) {
+        this(opacity, threshold, strength, angle, distance, zoom, rotation, false);
+    }
+
+    /**
+     * @param raysOnly when true, only the rays are rendered (over a black background) rather
+     *                 than composited over the source image.
+     */
+    public RaysFilter(float opacity, float threshold, float strength,
+                      float angle, float distance, float zoom, float rotation, boolean raysOnly) {
         this.opacity = opacity;
         this.threshold = threshold;
         this.strength = strength;
@@ -36,6 +46,7 @@ public class RaysFilter extends BufferedOpFilter {
         this.distance = distance;
         this.zoom = zoom;
         this.rotation = rotation;
+        this.raysOnly = raysOnly;
     }
 
     public RaysFilter(float opacity, float threshold, float strength) {
@@ -63,6 +74,7 @@ public class RaysFilter extends BufferedOpFilter {
         op.setDistance(distance);
         op.setZoom(zoom);
         op.setRotation(rotation);
+        op.setRaysOnly(raysOnly);
         return op;
     }
 }

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RaysFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RaysFilter.java
@@ -44,30 +44,12 @@ public class RaysFilter extends MotionBlurOp {
 	}
 
 	/**
-     * Get the opacity of the rays.
-     * @return the opacity.
-     * @see #setOpacity
-     */
-	public float getOpacity() {
-		return opacity;
-	}
-
-	/**
      * Set the threshold value.
      * @param threshold the threshold value
      * @see #getThreshold
      */
 	public void setThreshold( float threshold ) {
 		this.threshold = threshold;
-	}
-	
-	/**
-     * Get the threshold value.
-     * @return the threshold value
-     * @see #setThreshold
-     */
-	public float getThreshold() {
-		return threshold;
 	}
 	
 	/**
@@ -78,52 +60,11 @@ public class RaysFilter extends MotionBlurOp {
 	public void setStrength( float strength ) {
 		this.strength = strength;
 	}
-	
-	/**
-     * Get the strength of the rays.
-     * @return the strength.
-     * @see #setStrength
-     */
-	public float getStrength() {
-		return strength;
-	}
-	
-	/**
-     * Set whether to render only the rays.
-     * @param raysOnly true to render rays only.
-     * @see #getRaysOnly
-     */
+
 	public void setRaysOnly(boolean raysOnly) {
 		this.raysOnly = raysOnly;
 	}
 
-	/**
-     * Get whether to render only the rays.
-     * @return true to render rays only.
-     * @see #setRaysOnly
-     */
-	public boolean getRaysOnly() {
-		return raysOnly;
-	}
-
-    /**
-     * Set the colormap to be used for the filter.
-     * @param colormap the colormap
-     * @see #getColormap
-     */
-	public void setColormap(Colormap colormap) {
-		this.colormap = colormap;
-	}
-	
-    /**
-     * Get the colormap to be used for the filter.
-     * @return the colormap
-     * @see #setColormap
-     */
-	public Colormap getColormap() {
-		return colormap;
-	}
-	
     public BufferedImage filter( BufferedImage src, BufferedImage dst ) {
         int width = src.getWidth();
         int height = src.getHeight();

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/RaysFilterRaysOnlyTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/RaysFilterRaysOnlyTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Covers the raysOnly constructor parameter, which is passed through to
+ * thirdparty.jhlabs.image.RaysFilter.setRaysOnly.
+ *
+ * Note: raysOnly has no observable effect under the current BufferedOpFilter
+ * invocation, which calls op().filter(img, img) with the same image as src and
+ * dst. In jhlabs RaysFilter the flag only controls whether the source is drawn
+ * onto dst before the rays are added; since dst IS the source here, that draw is
+ * a no-op either way. These tests therefore only verify the flag is accepted and
+ * the filter applies cleanly.
+ */
+class RaysFilterRaysOnlyTest : FunSpec({
+
+   val src = ImmutableImage.create(100, 100).map { p ->
+      val dx = p.x() - 50; val dy = p.y() - 50
+      if (dx * dx + dy * dy < 10 * 10) Color(255, 255, 255) else Color.BLACK
+   }
+
+   test("raysOnly = true is accepted and the filter applies") {
+      val out = src.filter(RaysFilter(1.0f, 0f, 0.5f, 0f, 0f, 0.35f, 0f, true))
+      out.width shouldBe 100
+      out.height shouldBe 100
+   }
+
+   test("the seven-arg constructor defaults raysOnly to false") {
+      val sevenArg = src.filter(RaysFilter(1.0f, 0f, 0.5f, 0f, 0f, 0.35f, 0f))
+      val explicitFalse = src.filter(RaysFilter(1.0f, 0f, 0.5f, 0f, 0f, 0.35f, 0f, false))
+      sevenArg shouldBe explicitFalse
+   }
+})


### PR DESCRIPTION
Scrimage wraps the jhlabs `RaysFilter`, but the wrapper never exposed the `raysOnly` option.

## Changes

- Adds a new `RaysFilter(opacity, threshold, strength, angle, distance, zoom, rotation, raysOnly)` constructor that passes the flag through via `op.setRaysOnly(...)`. The existing seven-arg constructor delegates with `raysOnly = false` (the jhlabs default).
- Since the wrapper now calls `setRaysOnly`, that method is **retained** (this PR originally removed it). The genuinely-unused jhlabs `RaysFilter` methods are still removed: `getOpacity`, `getThreshold`, `getStrength`, `getRaysOnly`, `setColormap`, `getColormap`.

## ⚠️ Note on effect

`raysOnly` currently has **no observable effect** under scrimage's filter invocation: `BufferedOpFilter.apply` calls `op().filter(img, img)` with the same image as src and dst. In jhlabs `RaysFilter` the flag only gates whether the source is drawn onto `dst` before the rays are added — and since `dst` *is* the source here, that draw is a no-op either way. The flag is wired through for API completeness; making it functional would require changing how `BufferedOpFilter` supplies the destination image (happy to do that separately if wanted).

## Tests

`RaysFilterRaysOnlyTest` verifies the flag is accepted and the filter applies, and that the seven-arg constructor equals the eight-arg with `raysOnly = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)