### PR TITLE
Remove unused public methods in CellularFilter (jhlabs/image)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CellularFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CellularFilter.java
@@ -81,43 +81,14 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 	/**
      * Specifies the scale of the texture.
      * @param scale the scale of the texture.
-     * @see #getScale
      */
 	public void setScale(float scale) {
 		this.scale = scale;
 	}
 
 	/**
-     * Returns the scale of the texture.
-     * @return the scale of the texture.
-     * @see #setScale
-     */
-	public float getScale() {
-		return scale;
-	}
-
-	/**
-     * Specifies the stretch factor of the texture.
-     * @param stretch the stretch factor of the texture.
-     * @see #getStretch
-     */
-	public void setStretch(float stretch) {
-		this.stretch = stretch;
-	}
-
-	/**
-     * Returns the stretch factor of the texture.
-     * @return the stretch factor of the texture.
-     * @see #setStretch
-     */
-	public float getStretch() {
-		return stretch;
-	}
-
-	/**
      * Specifies the angle of the texture.
      * @param angle the angle of the texture.
-     * @see #getAngle
      */
 	public void setAngle(float angle) {
 		this.angle = angle;
@@ -129,83 +100,12 @@ public class CellularFilter extends WholeImageFilter implements Function2D, Clon
 		m11 = cos;
 	}
 
-	/**
-     * Returns the angle of the texture.
-     * @return the angle of the texture.
-     * @see #setAngle
-     */
-	public float getAngle() {
-		return angle;
-	}
-
-    /**
-     * Set the colormap to be used for the filter.
-     * @param colormap the colormap
-     * @see #getColormap
-     */
-	public void setColormap(Colormap colormap) {
-		this.colormap = colormap;
-	}
-
-    /**
-     * Get the colormap to be used for the filter.
-     * @return the colormap
-     * @see #setColormap
-     */
-	public Colormap getColormap() {
-		return colormap;
-	}
-
 	public void setRandomness(float randomness) {
 		this.randomness = randomness;
 	}
 
-	public float getRandomness() {
-		return randomness;
-	}
-
 	public void setGridType(int gridType) {
 		this.gridType = gridType;
-	}
-
-	/**
-     * Specifies the turbulence of the texture.
-     * @param turbulence the turbulence of the texture.
-     * min-value 0
-     * max-value 1
-     * @see #getTurbulence
-     */
-	public void setTurbulence(float turbulence) {
-		this.turbulence = turbulence;
-	}
-
-	/**
-     * Returns the turbulence of the effect.
-     * @return the turbulence of the effect.
-     * @see #setTurbulence
-     */
-	public float getTurbulence() {
-		return turbulence;
-	}
-
-	/**
-	 * Set the amount of effect.
-	 * @param amount the amount
-     * min-value 0
-     * max-value 1
-     * @see #getAmount
-	 */
-	public void setAmount(float amount) {
-		this.amount = amount;
-	}
-
-	/**
-	 * Get the amount of texture.
-	 * @return the amount
-     * @see #setAmount
-	 */
-	public float getAmount() {
-		return amount;
 	}
 
 	public class Point {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/image` class `CellularFilter` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `CellularFilter` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `getScale`
- `setStretch`
- `getStretch`
- `getAngle`
- `setColormap`
- `getColormap`
- `getRandomness`
- `setTurbulence`
- `getTurbulence`
- `setAmount`
- `getAmount`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)