### PR TITLE
Remove unused public methods in ImageFunction2D (jhlabs/math)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/math/ImageFunction2D.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/math/ImageFunction2D.java
@@ -104,14 +104,6 @@ public class ImageFunction2D implements Function2D {
 		}
 		return alpha ? ((pixels[iy*width+ix] >> 24) & 0xff) / 255.0f : PixelUtils.brightness(pixels[iy*width+ix]) / 255.0f;
 	}
-	
-	public void setEdgeAction(int edgeAction) {
-		this.edgeAction = edgeAction;
-	}
-
-	public int getEdgeAction() {
-		return edgeAction;
-	}
 
 	public int getWidth() {
 		return width;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/math` class `ImageFunction2D` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `ImageFunction2D` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `setEdgeAction`
- `getEdgeAction`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)