### PR TITLE
Remove unused public methods in NoiseInstance (jhlabs/math)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/math/NoiseInstance.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/math/NoiseInstance.java
@@ -49,22 +49,6 @@ public class NoiseInstance implements Function1D, Function2D, Function3D {
      * @param octaves number of octaves of turbulence
      * @return turbulence value at (x,y)
      */
-    public float turbulence2(float x, float y, float octaves) {
-        float t = 0.0f;
-
-        for (float f = 1.0f; f <= octaves; f *= 2)
-            t += Math.abs(noise2(f * x, f * y)) / f;
-        return t;
-    }
-
-    /**
-     * Compute turbulence using Perlin noise.
-     *
-     * @param x       the x value
-     * @param y       the y value
-     * @param octaves number of octaves of turbulence
-     * @return turbulence value at (x,y)
-     */
     public float turbulence3(float x, float y, float z, float octaves) {
         float t = 0.0f;
 


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/math` class `NoiseInstance` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `NoiseInstance` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `turbulence2`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)