### PR TITLE
Remove unused public methods in Quat4f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Quat4f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Quat4f.java
@@ -82,14 +82,6 @@ public class Quat4f extends Tuple4f {
 	}
 */
 
-	public void normalize() {
-		float d = 1.0f/( x*x+y*y+z*z+w*w );
-		x *= d;
-		y *= d;
-		z *= d;
-		w *= d;
-	}
-
 /*
 	public void mul( Quat4f q ) {
 		Quat4f q3 = new Quat4f();


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Quat4f` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `Quat4f` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `normalize`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)