### PR TITLE
Remove unused public methods in Vector3f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Vector3f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Vector3f.java
@@ -49,10 +49,6 @@ public class Vector3f extends Tuple3f {
 		this.z = t.z;
 	}
 
-	public float angle( Vector3f v ) {
-		return (float)Math.acos( dot(v) / (length()*v.length()) );
-	}
-
 	public float dot( Vector3f v ) {
 		return v.x * x + v.y * y + v.z * z;
 	}


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Vector3f` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `Vector3f` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `angle`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)