### PR TITLE
Remove unused public methods in Tuple3f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Tuple3f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Tuple3f.java
@@ -56,21 +56,6 @@ public class Tuple3f {
 		z = Math.abs(t.z);
 	}
 
-	public void clamp( float min, float max ) {
-		if ( x < min )
-			x = min;
-		else if ( x > max )
-			x = max;
-		if ( y < min )
-			y = min;
-		else if ( y > max )
-			y = max;
-		if ( z < min )
-			z = min;
-		else if ( z > max )
-			z = max;
-	}
-
 	public void set( float x, float y, float z ) {
 		this.x = x;
 		this.y = y;
@@ -111,13 +96,6 @@ public class Tuple3f {
 		x = -t.x;
 		y = -t.y;
 		z = -t.z;
-	}
-
-	public void interpolate( Tuple3f t, float alpha ) {
-		float a = 1-alpha;
-		x = a*x + alpha*t.x;
-		y = a*y + alpha*t.y;
-		z = a*z + alpha*t.z;
 	}
 
 	public void scale( float s ) {


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Tuple3f` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `Tuple3f` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `clamp`
- `interpolate`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)