### PR TITLE
Remove unused public methods in Tuple4f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Tuple4f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Tuple4f.java
@@ -129,14 +129,6 @@ public class Tuple4f {
 		w = -t.w;
 	}
 
-	public void interpolate( Tuple4f t, float alpha ) {
-		float a = 1-alpha;
-		x = a*x + alpha*t.x;
-		y = a*y + alpha*t.y;
-		z = a*z + alpha*t.z;
-		w = a*w + alpha*t.w;
-	}
-
 	public void scale( float s ) {
 		x *= s;
 		y *= s;


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Tuple4f` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `Tuple4f` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `interpolate`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)