### PR TITLE
Remove unused public methods in Point3f (jhlabs/vecmath)

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Point3f.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/vecmath/Point3f.java
@@ -60,11 +60,4 @@ public class Point3f extends Tuple3f {
 		return dx*dx+dy*dy+dz*dz;
 	}
 
-	public float distance( Point3f p ) {
-		float dx = x-p.x;
-		float dy = y-p.y;
-		float dz = z-p.z;
-		return (float)Math.sqrt( dx*dx+dy*dy+dz*dz );
-	}
-
 }


### PR DESCRIPTION
These non-private methods in the vendored `jhlabs/vecmath` class `Point3f` have **no caller anywhere in the repository**.

Verified by JVM **bytecode analysis**: across every compiled class in all modules (including Kotlin/Scala tests, examples and benchmarks), no `invoke` instruction references these methods on `Point3f` or any type related to it by inheritance. They are not overrides or interface implementations (those are excluded). The `thirdparty/*` code is internal to scrimage, so these are not part of a supported API.

Removed:
- `distance`

`:scrimage-filters:compileJava` compiles cleanly, and the full `scrimage-core`/`scrimage-filters`/`scrimage-tests` suites pass with the complete set of these removals applied together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)