### PR TITLE
Fix master CI: remove @see tags pointing to removed methods

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/CausticsFilter.java
@@ -52,7 +52,6 @@ public class CausticsFilter extends WholeImageFilter {
 	/**
      * Specifies the turbulence of the texture.
      * @param turbulence the turbulence of the texture.
-     * @see #getTurbulence
      */
 	public void setTurbulence(float turbulence) {
 		this.turbulence = turbulence;
@@ -61,7 +60,6 @@ public class CausticsFilter extends WholeImageFilter {
 	/**
 	 * Set the amount of effect.
 	 * @param amount the amount
-     * @see #getAmount
 	 */
 	public void setAmount(float amount) {
 		this.amount = amount;
@@ -70,7 +68,6 @@ public class CausticsFilter extends WholeImageFilter {
 	/**
 	 * Set the time. Use this to animate the effect.
 	 * @param time the time
-     * @see #getTime
 	 */
 	public void setTime(float time) {
 		this.time = time;
@@ -79,7 +76,6 @@ public class CausticsFilter extends WholeImageFilter {
 	/**
 	 * Set the number of samples per pixel. More samples means better quality, but slower rendering.
 	 * @param samples the number of samples
-     * @see #getSamples
 	 */
 	public void setSamples(int samples) {
 		this.samples = samples;
@@ -88,7 +84,6 @@ public class CausticsFilter extends WholeImageFilter {
 	/**
 	 * Set the background color.
 	 * @param c the color
-     * @see #getBgColor
 	 */
 	public void setBgColor(int c) {
 		bgColor = c;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ChromeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ChromeFilter.java
@@ -30,7 +30,6 @@ public class ChromeFilter extends LightFilter {
 	 * @param amount the amount
      * min-value 0
      * max-value 1
-     * @see #getAmount
 	 */
 	public void setAmount(float amount) {
 		this.amount = amount;
@@ -41,7 +40,6 @@ public class ChromeFilter extends LightFilter {
 	 * @param exposure the exposure
      * min-value 0
      * max-value 1
-     * @see #getExposure
 	 */
 	public void setExposure(float exposure) {
 		this.exposure = exposure;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContrastFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ContrastFilter.java
@@ -35,7 +35,6 @@ public class ContrastFilter extends TransferFilter {
      * @param brightness the brightness in the range 0 to 1
      * min-value 0
      * max-value 0
-     * @see #getBrightness
      */
 	public void setBrightness(float brightness) {
 		this.brightness = brightness;
@@ -47,7 +46,6 @@ public class ContrastFilter extends TransferFilter {
      * @param contrast the contrast in the range 0 to 1
      * min-value 0
      * max-value 0
-     * @see #getContrast
      */
 	public void setContrast(float contrast) {
 		this.contrast = contrast;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DiffuseFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/DiffuseFilter.java
@@ -36,7 +36,6 @@ public class DiffuseFilter extends TransformFilter {
      * @param scale the scale of the texture.
      * min-value 1
      * max-value 100+
-     * @see #getScale
      */
     public void setScale(float scale) {
         this.scale = scale;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GainFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GainFilter.java
@@ -35,7 +35,6 @@ public class GainFilter extends TransferFilter {
      * @param gain the gain
      * min-value: 0
      * max-value: 1
-     * @see #getGain
      */
 	public void setGain(float gain) {
 		this.gain = gain;
@@ -47,7 +46,6 @@ public class GainFilter extends TransferFilter {
      * @param bias the bias
      * min-value: 0
      * max-value: 1
-     * @see #getBias
      */
 	public void setBias(float bias) {
 		this.bias = bias;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GammaFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GammaFilter.java
@@ -53,7 +53,6 @@ public class GammaFilter extends TransferFilter {
      * @param rGamma the gamma level for the red channel
      * @param gGamma the gamma level for the blue channel
      * @param bGamma the gamma level for the green channel
-     * @see #getGamma
      */
 	public void setGamma(float rGamma, float gGamma, float bGamma) {
 		this.rGamma = rGamma;
@@ -65,7 +64,6 @@ public class GammaFilter extends TransferFilter {
     /**
      * Set the gamma level.
      * @param gamma the gamma level for all RGB channels
-     * @see #getGamma
      */
 	public void setGamma(float gamma) {
 		setGamma(gamma, gamma, gamma);

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlowFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/GlowFilter.java
@@ -35,7 +35,6 @@ public class GlowFilter extends GaussianFilter {
 	 * @param amount the amount
      * min-value 0
      * max-value 1
-     * @see #getAmount
 	 */
 	public void setAmount( float amount ) {
 		this.amount = amount;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/Gradient.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/Gradient.java
@@ -159,7 +159,6 @@ public class Gradient extends ArrayColormap implements Cloneable {
      * Get a knot type.
      * @param n the knot index
      * @return the knot type
-     * @see #setKnotType
      */
 	public int getKnotType(int n) {
 		return (byte)(knotTypes[n] & COLOR_MASK);
@@ -169,7 +168,6 @@ public class Gradient extends ArrayColormap implements Cloneable {
      * Get a knot blend type.
      * @param n the knot index
      * @return the knot blend type
-     * @see #setKnotBlend
      */
 	public byte getKnotBlend(int n) {
 		return (byte)(knotTypes[n] & BLEND_MASK);
@@ -180,7 +178,6 @@ public class Gradient extends ArrayColormap implements Cloneable {
      * @param x the knot position
      * @param color the color
      * @param type the knot type
-     * @see #removeKnot
      */
 	public void addKnot(int x, int color, int type) {
 		int[] nx = new int[numKnots+1];
@@ -265,7 +262,6 @@ public class Gradient extends ArrayColormap implements Cloneable {
      * Get a knot position.
      * @param n the knot index
      * @return the knot position
-     * @see #setKnotPosition
      */
 	public int getKnotPosition(int n) {
 		return xKnots[n];

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/LensBlurFilter.java
@@ -34,7 +34,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      * Set the radius of the kernel, and hence the amount of blur.
      *
      * @param radius the radius of the blur in pixels.
-     * @see #getRadius
      */
     public void setRadius(float radius) {
         this.radius = radius;
@@ -44,7 +43,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      * Set the number of sides of the aperture.
      *
      * @param sides the number of sides
-     * @see #getSides
      */
     public void setSides(int sides) {
         this.sides = sides;
@@ -54,7 +52,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      * Set the bloom factor.
      *
      * @param bloom the bloom factor
-     * @see #getBloom
      */
     public void setBloom(float bloom) {
         this.bloom = bloom;
@@ -64,7 +61,6 @@ public class LensBlurFilter extends AbstractBufferedImageOp {
      * Set the bloom threshold.
      *
      * @param bloomThreshold the bloom threshold
-     * @see #getBloomThreshold
      */
     public void setBloomThreshold(float bloomThreshold) {
         this.bloomThreshold = bloomThreshold;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/MotionBlurOp.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/MotionBlurOp.java
@@ -54,7 +54,6 @@ public class MotionBlurOp extends AbstractBufferedImageOp {
 	/**
      * Specifies the angle of blur.
      * @param angle the angle of blur.
-     * @see #getAngle
      */
 	public void setAngle( float angle ) {
 		this.angle = angle;
@@ -63,7 +62,6 @@ public class MotionBlurOp extends AbstractBufferedImageOp {
 	/**
      * Set the distance of blur.
      * @param distance the distance of blur.
-     * @see #getDistance
      */
 	public void setDistance( float distance ) {
 		this.distance = distance;
@@ -72,7 +70,6 @@ public class MotionBlurOp extends AbstractBufferedImageOp {
 	/**
      * Set the blur rotation.
      * @param rotation the angle of rotation.
-     * @see #getRotation
      */
 	public void setRotation( float rotation ) {
 		this.rotation = rotation;
@@ -81,7 +78,6 @@ public class MotionBlurOp extends AbstractBufferedImageOp {
 	/**
      * Set the blur zoom.
      * @param zoom the zoom factor.
-     * @see #getZoom
      */
 	public void setZoom( float zoom ) {
 		this.zoom = zoom;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OilFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OilFilter.java
@@ -33,7 +33,6 @@ public class OilFilter extends WholeImageFilter {
      * Set the range of the effect in pixels.
      *
      * @param range the range
-     * @see #getRange
      */
     public void setRange(int range) {
         this.range = range;
@@ -43,7 +42,6 @@ public class OilFilter extends WholeImageFilter {
      * Set the number of levels for the effect.
      *
      * @param levels the number of levels
-     * @see #getLevels
      */
     public void setLevels(int levels) {
         this.levels = levels;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OpacityFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/OpacityFilter.java
@@ -42,7 +42,6 @@ public class OpacityFilter extends PointFilter {
 	/**
 	 * Set the opacity.
 	 * @param opacity the opacity (alpha) in the range 0..255
-     * @see #getOpacity
 	 */
 	public void setOpacity(int opacity) {
 		this.opacity = opacity;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PosterizeFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/PosterizeFilter.java
@@ -32,7 +32,6 @@ public class PosterizeFilter extends PointFilter {
 	/**
      * Set the number of levels in the output image.
      * @param numLevels the number of levels
-     * @see #getNumLevels
      */
     public void setNumLevels(int numLevels) {
 		this.numLevels = numLevels;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RippleFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RippleFilter.java
@@ -64,7 +64,6 @@ public class RippleFilter extends TransformFilter {
      * Set the amplitude of ripple in the X direction.
      *
      * @param xAmplitude the amplitude (in pixels).
-     * @see #getXAmplitude
      */
     public void setXAmplitude(float xAmplitude) {
         this.xAmplitude = xAmplitude;
@@ -74,7 +73,6 @@ public class RippleFilter extends TransformFilter {
      * Set the wavelength of ripple in the X direction.
      *
      * @param xWavelength the wavelength (in pixels).
-     * @see #getXWavelength
      */
     public void setXWavelength(float xWavelength) {
         this.xWavelength = xWavelength;
@@ -84,7 +82,6 @@ public class RippleFilter extends TransformFilter {
      * Set the amplitude of ripple in the Y direction.
      *
      * @param yAmplitude the amplitude (in pixels).
-     * @see #getYAmplitude
      */
     public void setYAmplitude(float yAmplitude) {
         this.yAmplitude = yAmplitude;
@@ -94,7 +91,6 @@ public class RippleFilter extends TransformFilter {
      * Set the wavelength of ripple in the Y direction.
      *
      * @param yWavelength the wavelength (in pixels).
-     * @see #getYWavelength
      */
     public void setYWavelength(float yWavelength) {
         this.yWavelength = yWavelength;
@@ -105,7 +101,6 @@ public class RippleFilter extends TransformFilter {
      * Set the wave type.
      *
      * @param waveType the type.
-     * @see #getWaveType
      */
     public void setWaveType(int waveType) {
         this.waveType = waveType;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ThresholdFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/ThresholdFilter.java
@@ -45,7 +45,6 @@ public class ThresholdFilter extends PointFilter {
 	/**
      * Set the lower threshold value.
      * @param lowerThreshold the threshold value
-     * @see #getLowerThreshold
      */
 	public void setLowerThreshold(int lowerThreshold) {
 		this.lowerThreshold = lowerThreshold;
@@ -54,7 +53,6 @@ public class ThresholdFilter extends PointFilter {
 	/**
      * Set the upper threshold value.
      * @param upperThreshold the threshold value
-     * @see #getUpperThreshold
      */
 	public void setUpperThreshold(int upperThreshold) {
 		this.upperThreshold = upperThreshold;
@@ -63,7 +61,6 @@ public class ThresholdFilter extends PointFilter {
 	/**
      * Set the color to be used for pixels above the upper threshold.
      * @param white the color
-     * @see #getWhite
      */
 	public void setWhite(int white) {
 		this.white = white;
@@ -72,7 +69,6 @@ public class ThresholdFilter extends PointFilter {
 	/**
      * Set the color to be used for pixels below the lower threshold.
      * @param black the color
-     * @see #getBlack
      */
 	public void setBlack(int black) {
 		this.black = black;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/TritoneFilter.java
@@ -51,7 +51,6 @@ public class TritoneFilter extends PointFilter {
     /**
      * Set the shadow color.
      * @param shadowColor the shadow color
-     * @see #getShadowColor
      */
 	public void setShadowColor( int shadowColor ) {
 		this.shadowColor = shadowColor;

--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/UnsharpFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/UnsharpFilter.java
@@ -34,7 +34,6 @@ public class UnsharpFilter extends GaussianFilter {
 	/**
      * Set the threshold value.
      * @param threshold the threshold value
-     * @see #getThreshold
      */
 	public void setThreshold( int threshold ) {
 		this.threshold = threshold;
@@ -45,7 +44,6 @@ public class UnsharpFilter extends GaussianFilter {
 	 * @param amount the amount
      * min-value 0
      * max-value 1
-     * @see #getAmount
 	 */
 	public void setAmount( float amount ) {
 		this.amount = amount;


### PR DESCRIPTION
## Problem

`master` is red: the `deploy-snapshots` job fails at `:scrimage-filters:javadoc` with `error: reference not found` (the `build`/test job passes).

The vendored-thirdparty dead-code removal PRs (#766–#828 etc.) deleted unused getters/setters in several jhlabs filters, but those methods were still referenced by `@see #method` tags in the javadoc of sibling methods. The dead-method detection was bytecode-based, and **javadoc `@see`/`{@link}` references don't appear in bytecode**, so these dangling tags weren't caught — `javac` and tests are fine, but `javadoc` (run in the deploy job, with `failOnError`) treats them as errors.

## Fix

Removes the 43 dangling `@see` tags across 17 jhlabs filter classes (the targets no longer exist):

`CausticsFilter`, `ChromeFilter`, `ContrastFilter`, `DiffuseFilter`, `GainFilter`, `GammaFilter`, `GlowFilter`, `Gradient`, `LensBlurFilter`, `MotionBlurOp`, `OilFilter`, `OpacityFilter`, `PosterizeFilter`, `RippleFilter`, `ThresholdFilter`, `TritoneFilter`, `UnsharpFilter`.

Each removed line is a standalone `@see #removedMethod` tag, so prose javadoc is unaffected. Verified locally: `:scrimage-filters:javadoc` now succeeds and the filters test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)