### PR TITLE
Fix master CI: drop dangling @see tags in RaysFilter

### DIFF
--- a/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RaysFilter.java
+++ b/scrimage-filters/src/main/java/thirdparty/jhlabs/image/RaysFilter.java
@@ -37,7 +37,6 @@ public class RaysFilter extends MotionBlurOp {
 	/**
      * Set the opacity of the rays.
      * @param opacity the opacity.
-     * @see #getOpacity
      */
 	public void setOpacity(float opacity) {
 		this.opacity = opacity;
@@ -46,7 +45,6 @@ public class RaysFilter extends MotionBlurOp {
 	/**
      * Set the threshold value.
      * @param threshold the threshold value
-     * @see #getThreshold
      */
 	public void setThreshold( float threshold ) {
 		this.threshold = threshold;
@@ -55,7 +53,6 @@ public class RaysFilter extends MotionBlurOp {
 	/**
      * Set the strength of the rays.
      * @param strength the strength.
-     * @see #getStrength
      */
 	public void setStrength( float strength ) {
 		this.strength = strength;


### PR DESCRIPTION
## Problem

`master` is red again: `:scrimage-filters:javadoc` fails in the `deploy-snapshots` job with `error: reference not found` in `RaysFilter.java` (the `build`/test job passes).

The merged RaysFilter PR (#819) removed unused getters (`getOpacity`, `getThreshold`, `getStrength`, etc.) but left `@see #getX` tags in sibling methods' javadoc pointing at them. #819 was deliberately excluded from the earlier `@see` sweep (#829) because it also added the `raysOnly` feature, so its danglers were never stripped — and javadoc only runs in the deploy job, not per-PR, so it surfaced after merge.

## Fix

Removes the 3 dangling `@see` tags in `RaysFilter`. `:scrimage-filters:javadoc` now passes (verified locally), and a full re-scan of the filters javadoc shows no other dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)