### PR TITLE
Throw a descriptive IOException when no ImageIO encoder exists for a format

### DIFF
--- a/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TwelveMonkeysWriter.java
+++ b/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/TwelveMonkeysWriter.java
@@ -9,6 +9,7 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.stream.ImageOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Iterator;
 
 abstract class TwelveMonkeysWriter implements ImageWriter {
 
@@ -16,7 +17,13 @@ abstract class TwelveMonkeysWriter implements ImageWriter {
 
     @Override
     public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
-        javax.imageio.ImageWriter writer = ImageIO.getImageWritersByFormatName(format()).next();
+        Iterator<javax.imageio.ImageWriter> writers = ImageIO.getImageWritersByFormatName(format());
+        if (!writers.hasNext()) {
+            throw new IOException(
+               "No ImageIO encoder is available for format '" + format() + "'. " +
+                  "Some formats (such as PCX and SGI) are read-only: the TwelveMonkeys plugin provides a decoder but no encoder.");
+        }
+        javax.imageio.ImageWriter writer = writers.next();
         try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
             ImageWriteParam params = writer.getDefaultWriteParam();
             writer.setOutput(ios);

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/MissingEncoderTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/MissingEncoderTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.scrimage.io
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.PcxWriter
+import com.sksamuel.scrimage.nio.SgiWriter
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import java.io.IOException
+
+// The TwelveMonkeys PCX and SGI plugins are read-only (they register no ImageWriterSpi),
+// so no encoder exists for these formats. Writing used to fail with a bare
+// NoSuchElementException from Iterator.next(); it should be a descriptive IOException.
+class MissingEncoderTest : FunSpec({
+
+   val image = ImmutableImage.create(40, 30)
+
+   test("PcxWriter reports a descriptive error when no PCX encoder is available") {
+      val e = shouldThrow<IOException> {
+         image.bytes(PcxWriter())
+      }
+      e.message.shouldContain("pcx")
+   }
+
+   test("SgiWriter reports a descriptive error when no SGI encoder is available") {
+      val e = shouldThrow<IOException> {
+         image.bytes(SgiWriter())
+      }
+      e.message.shouldContain("sgi")
+   }
+})


### PR DESCRIPTION
## Problem

`TwelveMonkeysWriter.write()` calls `ImageIO.getImageWritersByFormatName(format()).next()` without checking `hasNext()`.

The TwelveMonkeys **PCX** and **SGI** plugins are read-only — their jars register an `ImageReaderSpi` but no `ImageWriterSpi` (and the JDK ships no encoder for either format). As a result, `PcxWriter` and `SgiWriter` fail on **every** invocation:

```kotlin
ImmutableImage.create(40, 30).bytes(PcxWriter())
// java.util.NoSuchElementException (no message)
```

## Fix

Guard the iterator and throw a descriptive `IOException` naming the format and explaining that the plugin is read-only. Writers for formats that do have encoders (BMP, PNM, TIFF, TGA, IFF, PICT) are unaffected.

An alternative would be to delete `PcxWriter`/`SgiWriter` outright since they have never worked, but that's an API removal — left to your judgement; the guard is worth having in the shared base class either way.

## Testing

New `MissingEncoderTest` pins the descriptive failure for both writers; existing `TwelveMonkeysWriterTest` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)