### PR TITLE
Fix BmpWriter failing on images with an alpha channel

### DIFF
--- a/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/BmpWriter.java
+++ b/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/BmpWriter.java
@@ -1,9 +1,40 @@
 package com.sksamuel.scrimage.nio;
 
+import com.sksamuel.scrimage.AwtImage;
+import com.sksamuel.scrimage.metadata.ImageMetadata;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+
 public class BmpWriter extends TwelveMonkeysWriter {
 
     @Override
     public String format() {
         return "bmp";
+    }
+
+    // The TwelveMonkeys BMP encoder rejects 32bpp input ("Image can not be encoded with
+    // compression type BI_RGB and 32 bits per pixel"), so any image with an alpha channel —
+    // including scrimage's default TYPE_INT_ARGB — must be flattened to a non-alpha type
+    // first. Composites onto white, matching JpegWriter's handling of the same limitation.
+    @Override
+    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
+        if (image.awt().getColorModel().hasAlpha()) {
+            BufferedImage noAlpha = new BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2 = noAlpha.createGraphics();
+            try {
+                g2.setColor(Color.WHITE);
+                g2.fillRect(0, 0, image.width, image.height);
+                g2.drawImage(image.awt(), 0, 0, null);
+            } finally {
+                g2.dispose();
+            }
+            super.write(new AwtImage(noAlpha), metadata, out);
+        } else {
+            super.write(image, metadata, out);
+        }
     }
 }

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/TwelveMonkeysWriterTest.kt
@@ -34,6 +34,24 @@ class TwelveMonkeysWriterTest : FunSpec({
       actual.height shouldBe original.height
    }
 
+   // The TwelveMonkeys BMP encoder cannot encode 32bpp images, so BmpWriter must flatten
+   // alpha before encoding. Before the fix this threw IOException("Image can not be encoded
+   // with compression type BI_RGB and 32 bits per pixel") for TYPE_INT_ARGB images.
+   test("BmpWriter supports images with an alpha channel") {
+      val argb = ImmutableImage.create(40, 30).fill(java.awt.Color.RED)
+      argb.awt().type shouldBe java.awt.image.BufferedImage.TYPE_INT_ARGB
+      val actual = ImmutableImage.loader().fromBytes(argb.bytes(BmpWriter()))
+      actual.width shouldBe 40
+      actual.height shouldBe 30
+      actual.pixel(20, 15).toARGBInt() shouldBe 0xFFFF0000.toInt()
+   }
+
+   test("BmpWriter composites transparent pixels onto white") {
+      val transparent = ImmutableImage.create(10, 10) // fully transparent ARGB
+      val actual = ImmutableImage.loader().fromBytes(transparent.bytes(BmpWriter()))
+      actual.pixel(5, 5).toARGBInt() shouldBe 0xFFFFFFFF.toInt()
+   }
+
    test("BmpWriter write does not leak resources on repeated writes") {
       repeat(100) {
          original.bytes(BmpWriter())


### PR DESCRIPTION
## Problem

The TwelveMonkeys BMP encoder rejects 32bpp input, so `BmpWriter` fails for **any image with an alpha channel** — including scrimage's own default image type (`ImmutableImage.DEFAULT_DATA_TYPE` is `TYPE_INT_ARGB`):

```kotlin
ImmutableImage.create(40, 30).fill(Color.RED).bytes(BmpWriter())
// java.io.IOException: Image can not be encoded with compression type BI_RGB and 32 bits per pixel
```

Also fails for `TYPE_4BYTE_ABGR` (what a PNG with alpha loads as) and `TYPE_INT_ARGB_PRE`. The existing test only passed because it loads a JPEG, which decodes to the non-alpha `TYPE_3BYTE_BGR`. So "create an image (or load a PNG/WebP), save as BMP" — arguably the most common BMP flow — always crashed.

## Fix

Flatten alpha before encoding: composite onto white into a `TYPE_INT_RGB` copy, exactly mirroring `JpegWriter`'s handling of the same encoder limitation. Non-alpha images are passed through untouched.

## Testing

New regression tests: an ARGB image round-trips pixel-perfect through BMP, and fully-transparent pixels composite onto white. Existing round-trip and leak tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)