### PR TITLE
Fix PnmWriter failing on images with an alpha channel

### DIFF
--- a/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/PnmWriter.java
+++ b/scrimage-formats-extra/src/main/java/com/sksamuel/scrimage/nio/PnmWriter.java
@@ -1,11 +1,40 @@
 package com.sksamuel.scrimage.nio;
 
+import com.sksamuel.scrimage.AwtImage;
+import com.sksamuel.scrimage.metadata.ImageMetadata;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+
 public class PnmWriter extends TwelveMonkeysWriter {
 
     @Override
     public String format() {
         return "pnm";
     }
+
+    // The PNM formats have no alpha channel and the TwelveMonkeys PNM encoder throws an
+    // undeclared IllegalArgumentException ("Unknown TupleType for BufferedImage") for
+    // images with one - including scrimage's default TYPE_INT_ARGB. Flatten alpha onto
+    // white first, matching JpegWriter's handling of the same limitation.
+    @Override
+    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
+        if (image.awt().getColorModel().hasAlpha()) {
+            BufferedImage noAlpha = new BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2 = noAlpha.createGraphics();
+            try {
+                g2.setColor(Color.WHITE);
+                g2.fillRect(0, 0, image.width, image.height);
+                g2.drawImage(image.awt(), 0, 0, null);
+            } finally {
+                g2.dispose();
+            }
+            super.write(new AwtImage(noAlpha), metadata, out);
+        } else {
+            super.write(image, metadata, out);
+        }
+    }
 }
-
-

--- a/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/PnmWriterTest.kt
+++ b/scrimage-formats-extra/src/test/kotlin/com/sksamuel/scrimage/io/PnmWriterTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.scrimage.io
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.PnmWriter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+class PnmWriterTest : FunSpec({
+
+   test("PnmWriter round-trips a non-alpha image") {
+      val original = ImmutableImage.loader().fromStream(javaClass.getResourceAsStream("/picard.jpeg"))
+         .scaleTo(100, 100)
+      val actual = ImmutableImage.loader().fromBytes(original.bytes(PnmWriter()))
+      actual.width shouldBe original.width
+      actual.height shouldBe original.height
+   }
+
+   // PNM has no alpha channel and the TwelveMonkeys encoder used to throw an undeclared
+   // IllegalArgumentException ("Unknown TupleType for BufferedImage") for alpha types,
+   // including scrimage's default TYPE_INT_ARGB. PnmWriter must flatten alpha first.
+   test("PnmWriter supports images with an alpha channel") {
+      val argb = ImmutableImage.create(40, 30).fill(java.awt.Color.RED)
+      argb.awt().type shouldBe BufferedImage.TYPE_INT_ARGB
+      val actual = ImmutableImage.loader().fromBytes(argb.bytes(PnmWriter()))
+      actual.width shouldBe 40
+      actual.height shouldBe 30
+      actual.pixel(20, 15).toARGBInt() shouldBe 0xFFFF0000.toInt()
+   }
+
+   test("PnmWriter composites transparent pixels onto white") {
+      val transparent = ImmutableImage.create(10, 10) // fully transparent ARGB
+      val actual = ImmutableImage.loader().fromBytes(transparent.bytes(PnmWriter()))
+      actual.pixel(5, 5).toARGBInt() shouldBe 0xFFFFFFFF.toInt()
+   }
+})


### PR DESCRIPTION
## Problem

The PNM formats have no alpha channel, and the TwelveMonkeys PNM encoder throws for any image that has one — including scrimage's own default image type:

```kotlin
ImmutableImage.create(40, 30).bytes(PnmWriter())
// java.lang.IllegalArgumentException: Unknown TupleType for BufferedImage...
```

Fails for `TYPE_INT_ARGB` (the default), `TYPE_INT_ARGB_PRE`, and `TYPE_4BYTE_ABGR` (what a PNG with alpha loads as). As a bonus wart, the `IllegalArgumentException` is undeclared — it escapes an API whose contract is `throws IOException`. There was no PnmWriter test at all, so this was never caught.

## Fix

Flatten alpha before encoding: composite onto white into a `TYPE_INT_RGB` copy, mirroring `JpegWriter`'s handling of the same limitation (same fix as the sibling BmpWriter PR). Non-alpha images pass through untouched and round-trip pixel-perfect.

(An alternative would be routing alpha images to TwelveMonkeys' PAM writer, which does support RGBA — but flattening keeps the output a plain PPM that any PNM consumer can read.)

## Testing

New `PnmWriterTest`: non-alpha round-trip, ARGB image round-trips pixel-perfect, and fully-transparent pixels composite onto white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)