### PR TITLE
Reject NaN in HSL/HSV/CMYK color component validation

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/CMYKColor.java
@@ -30,7 +30,8 @@ public class CMYKColor implements Color {
     }
 
     private static void requireInRange(String component, float value) {
-        if (value < 0 || value > 1f)
+        // negated form so that NaN, for which all comparisons are false, is also rejected
+        if (!(value >= 0 && value <= 1f))
             throw new IllegalArgumentException(
                 "CMYKColor " + component + " component must be in [0, 1] but was " + value);
     }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
@@ -33,7 +33,8 @@ public class HSLColor implements Color {
     }
 
     private static void requireInRange(String component, float value, float bound) {
-        if (value < 0 || value > bound)
+        // negated form so that NaN, for which all comparisons are false, is also rejected
+        if (!(value >= 0 && value <= bound))
             throw new IllegalArgumentException(
                     "HSLColor " + component + " must be in [0, " + bound + "] but was " + value);
     }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSVColor.java
@@ -33,7 +33,8 @@ public class HSVColor implements Color {
    }
 
    private static void requireInRange(String component, float value, float max) {
-      if (value < 0 || value > max)
+      // negated form so that NaN, for which all comparisons are false, is also rejected
+      if (!(value >= 0 && value <= max))
          throw new IllegalArgumentException(
             "HSVColor " + component + " component must be in [0, " + max + "] but was " + value);
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/CMYKColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/CMYKColorTest.kt
@@ -24,4 +24,14 @@ class CMYKColorTest : StringSpec({
       shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, -0.1f, 1f) }
       shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, 0f, 1.1f) }
    }
+
+   // NaN compares false against any bound, so a naive `value < 0 || value > 1` check lets it
+   // through and toRGB() silently produces a garbage color.
+   "NaN components are rejected with IllegalArgumentException" {
+      shouldThrow<IllegalArgumentException> { CMYKColor(Float.NaN, 0f, 0f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, Float.NaN, 0f, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, Float.NaN, 0f, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, Float.NaN, 1f) }
+      shouldThrow<IllegalArgumentException> { CMYKColor(0f, 0f, 0f, 0f, Float.NaN) }
+   }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSLColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSLColorTest.kt
@@ -39,4 +39,13 @@ class HSLColorTest : StringSpec({
       shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 0f, -0.1f) }
       shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 0f, 1.1f) }
    }
+
+   // NaN compares false against any bound, so a naive `value < 0 || value > bound` check
+   // lets it through and toRGB() silently produces a garbage colour.
+   "rejects NaN components" {
+      shouldThrow<IllegalArgumentException> { HSLColor(Float.NaN, 0f, 0f, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, Float.NaN, 0f, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, Float.NaN, 0f) }
+      shouldThrow<IllegalArgumentException> { HSLColor(0f, 0f, 0f, Float.NaN) }
+   }
 })

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSVColorTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/HSVColorTest.kt
@@ -30,5 +30,14 @@ class HSVColorTest : StringSpec() {
          shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, 1.1f, 1f) }
          shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, 0f, 1.1f) }
       }
+
+      // NaN compares false against any bound, so a naive `value < 0 || value > max` check
+      // lets it through and toRGB() silently produces a garbage colour.
+      "NaN components are rejected with IllegalArgumentException" {
+         shouldThrow<IllegalArgumentException> { HSVColor(Float.NaN, 0f, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, Float.NaN, 0f, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, Float.NaN, 1f) }
+         shouldThrow<IllegalArgumentException> { HSVColor(0f, 0f, 0f, Float.NaN) }
+      }
    }
 }


### PR DESCRIPTION
## Problem

The constructor range checks in `HSLColor`, `HSVColor` and `CMYKColor` use `value < 0 || value > bound`. Every comparison against `NaN` is false, so `NaN` passes validation — defeating the fail-fast checks these classes gained in #665/#726 — and conversion silently produces garbage:

```java
new HSVColor(Float.NaN, 0.5f, 0.5f, 1f).toRGB()  // RGBColor(128, 0, 64, 255)
new HSLColor(Float.NaN, Float.NaN, Float.NaN, Float.NaN).toRGB()  // RGBColor(0, 0, 0, 0)
new CMYKColor(Float.NaN, 0, 0, 0).toRGB()  // RGBColor(0, 255, 255, 255)
```

`NaN` arises naturally from user arithmetic, e.g. `0f/0f` in a saturation computation.

## Fix

Use the negated form `!(value >= 0 && value <= bound)`, which is false for `NaN` and therefore rejects it. Infinities were already rejected. One-line change in each of the three classes.

## Testing

New NaN-rejection cases in `HSLColorTest`, `HSVColorTest`, `CMYKColorTest`; existing validation tests unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)