### PR TITLE
Fix premultiplied-alpha math in replaceTransparencyWithColor for translucent colors

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/pixels/PixelTools.java
@@ -218,9 +218,16 @@ public class PixelTools {
     */
    public static int replaceTransparencyWithColor(int pixel, int colorRed, int colorGreen, int colorBlue, int colorAlpha) {
       int a = alpha(pixel);
-      int r = (red(pixel) * a + colorRed * colorAlpha * (255 - a) / 255) / 255;
-      int g = (green(pixel) * a + colorGreen * colorAlpha * (255 - a) / 255) / 255;
-      int b = (blue(pixel) * a + colorBlue * colorAlpha * (255 - a) / 255) / 255;
-      return argb(255, r, g, b);
+      // SrcOver composite of the pixel over the replacement colour. The premultiplied
+      // channel sums must be divided by the composite alpha (not by 255, which would
+      // darken the result whenever the replacement colour is translucent), and the
+      // composite alpha must be kept rather than forced opaque. All terms are kept on
+      // a common 255*255 scale so that no channel can exceed 255 through truncation.
+      int aNum = 255 * a + colorAlpha * (255 - a); // composite alpha scaled by 255
+      if (aNum == 0) return argb(0, 0, 0, 0);
+      int r = (255 * red(pixel) * a + colorRed * colorAlpha * (255 - a)) / aNum;
+      int g = (255 * green(pixel) * a + colorGreen * colorAlpha * (255 - a)) / aNum;
+      int b = (255 * blue(pixel) * a + colorBlue * colorAlpha * (255 - a)) / aNum;
+      return argb(aNum / 255, r, g, b);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/color/PixelToolsTest.kt
@@ -114,4 +114,60 @@ class PixelToolsTest : FunSpec({
       PixelTools.blue(scaled) shouldBe 67
    }
 
+   // Regression: replaceTransparencyWithColor divided the premultiplied SrcOver
+   // channel sums by 255 instead of by the composite alpha, and forced the output
+   // alpha to 255. With a translucent replacement colour this darkened the result:
+   // a fully transparent pixel replaced with 50%-alpha red came back as opaque
+   // (128, 0, 0) instead of half-transparent pure red (255, 0, 0, 128).
+   test("replaceTransparencyWithColor composites a translucent colour without darkening") {
+      val transparent = Pixel(0, 0, 0, 0, 0, 0)
+      val result = PixelTools.replaceTransparencyWithColor(transparent, Color(255, 0, 0, 128))
+      result.alpha() shouldBe 128
+      result.red() shouldBe 255
+      result.green() shouldBe 0
+      result.blue() shouldBe 0
+   }
+
+   test("replaceTransparencyWithColor blends a semi-transparent pixel with a translucent colour using the composite alpha") {
+      // white at 50% alpha over red at 50% alpha:
+      // aOut = 128 + 128 * 127 / 255 = 191
+      val semiWhite = Pixel(0, 0, 255, 255, 255, 128)
+      val result = PixelTools.replaceTransparencyWithColor(semiWhite, Color(255, 0, 0, 128))
+      result.alpha() shouldBe 191
+      // red channel: (255*128 + 255*128*127/255) / 191 = 255
+      result.red() shouldBe 255
+      // green/blue: 255*128 / 191 = 170
+      result.green() shouldBe 170
+      result.blue() shouldBe 170
+   }
+
+   test("replaceTransparencyWithColor returns fully transparent black when both alphas are zero") {
+      val transparent = Pixel(0, 0, 10, 20, 30, 0)
+      val result = PixelTools.replaceTransparencyWithColor(transparent, Color(255, 0, 0, 0))
+      result.argb shouldBe 0
+   }
+
+   test("replaceTransparencyWithColor with an opaque colour behaves as before") {
+      // fully transparent pixel -> exactly the replacement colour, opaque
+      val transparent = Pixel(0, 0, 0, 0, 0, 0)
+      val replaced = PixelTools.replaceTransparencyWithColor(transparent, Color(12, 34, 56, 255))
+      replaced.alpha() shouldBe 255
+      replaced.red() shouldBe 12
+      replaced.green() shouldBe 34
+      replaced.blue() shouldBe 56
+
+      // semi-transparent pixel -> the original formula's blend, opaque:
+      // channel = (c * a + colorC * (255 - a)) / 255
+      val semi = Pixel(0, 0, 200, 100, 50, 128)
+      val blended = PixelTools.replaceTransparencyWithColor(semi, Color(10, 20, 30, 255))
+      blended.alpha() shouldBe 255
+      blended.red() shouldBe (200 * 128 + 10 * 127) / 255
+      blended.green() shouldBe (100 * 128 + 20 * 127) / 255
+      blended.blue() shouldBe (50 * 128 + 30 * 127) / 255
+
+      // opaque pixel -> unchanged
+      val opaque = Pixel(0, 0, 1, 2, 3, 255)
+      PixelTools.replaceTransparencyWithColor(opaque, Color(255, 255, 255, 255)).argb shouldBe opaque.argb
+   }
+
 })


### PR DESCRIPTION
## Problem

`PixelTools.replaceTransparencyWithColor` (reachable via `ImmutableImage.removeTransparency(Color)` and `MutableImage.replaceTransparencyInPlace`) computes a SrcOver composite of the pixel over the replacement colour, but the premultiplied channel sums were divided by 255 instead of by the composite alpha, and the composite alpha itself was discarded in favour of a hardcoded 255:

```java
int r = (red(pixel) * a + colorRed * colorAlpha * (255 - a) / 255) / 255;
...
return argb(255, r, g, b);
```

For a translucent replacement colour this darkens the output. Concrete example: replacing a fully transparent pixel with `new java.awt.Color(255, 0, 0, 128)` (50%-alpha red) produced opaque `(128, 0, 0)` — a dark opaque red — instead of the correct SrcOver result, half-transparent pure red `(255, 0, 0, 128)`.

## Fix

Compute the composite alpha and use it both as the divisor for the premultiplied sums and as the output alpha, guarding the all-transparent case with fully transparent black. All terms are kept on a common 255*255 scale so that truncation cannot push a channel past 255 (e.g. 50%-white over 50%-red would otherwise compute red = 48896/191 = 256).

```java
int aNum = 255 * a + colorAlpha * (255 - a); // composite alpha scaled by 255
if (aNum == 0) return argb(0, 0, 0, 0);
int r = (255 * red(pixel) * a + colorRed * colorAlpha * (255 - a)) / aNum;
...
return argb(aNum / 255, r, g, b);
```

## Behaviour notes for review

- **Opaque replacement colours (the common case) are unchanged.** With `colorAlpha == 255`, `aNum == 255 * 255`, and each channel reduces exactly — including integer truncation — to the previous formula `(c*a + colorC*(255-a)) / 255` with output alpha 255. Existing `removeTransparency` tests with `Color.BLACK` / `Color.WHITE` pass unchanged.
- **Behavioural change, flagged for review:** for *translucent* replacement colours the output alpha now reflects the SrcOver composite alpha instead of being forced opaque, and channels are no longer darkened. Anyone relying on the old always-opaque output for translucent replacement colours will see different results.

## Tests

Added regression tests in `PixelToolsTest` covering: fully transparent pixel + 50%-alpha red -> (255, 0, 0, 128); the truncation-overflow blend case; both-alphas-zero -> fully transparent black; and opaque-colour behaviour matching the previous formula exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)