### PR TITLE
Fix copy() corrupting every pixel of palette-based images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -13,8 +13,10 @@ import com.sksamuel.scrimage.subpixel.LinearSubpixelInterpolator;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.IndexColorModel;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -539,23 +541,40 @@ public class AwtImage {
     * @return a new, non-shared, BufferedImage with the same data as this Image.
     */
    public BufferedImage toNewBufferedImage(int type) {
-      BufferedImage target = new BufferedImage(width, height, type);
       if (awt.getType() == type) {
          // Same type — copy the raster data directly. Going through
          // Graphics2D.drawImage would composite via SrcOver, which
          // premultiplies alpha and rounds away ±1 from each colour channel
          // when alpha doesn't divide 255 cleanly.
+         BufferedImage target = sameTypeCopyTarget(type);
          awt.copyData(target.getRaster());
+         return target;
       } else {
          // Type conversion — Graphics2D handles the colour-space conversion.
+         BufferedImage target = new BufferedImage(width, height, type);
          Graphics2D g2 = (Graphics2D) target.getGraphics();
          try {
             g2.drawImage(awt, 0, 0, null);
          } finally {
             g2.dispose();
          }
+         return target;
       }
-      return target;
+   }
+
+   /**
+    * Creates the target for a same-type raster copy. For palette-based types
+    * (TYPE_BYTE_INDEXED, TYPE_BYTE_BINARY) the target must reuse the source's own
+    * IndexColorModel: new BufferedImage(width, height, type) would get the *default*
+    * palette, and copyData copies raw palette indices, so every pixel would be
+    * remapped through the wrong palette.
+    */
+   private BufferedImage sameTypeCopyTarget(int type) {
+      ColorModel cm = awt.getColorModel();
+      if (cm instanceof IndexColorModel) {
+         return new BufferedImage(cm, cm.createCompatibleWritableRaster(width, height), cm.isAlphaPremultiplied(), null);
+      }
+      return new BufferedImage(width, height, type);
    }
 
    /**
@@ -792,22 +811,24 @@ public class AwtImage {
     */
    public AwtImage clone(int imageType) {
       if (imageType <= 0) throw new IllegalArgumentException("Image type must be > 0");
-      BufferedImage target = new BufferedImage(awt.getWidth(null), awt.getHeight(null), imageType);
       if (awt.getType() == imageType) {
          // Same type — copy the raster data directly. Going through
          // Graphics2D.drawImage would composite via SrcOver, which
          // premultiplies alpha and rounds away ±1 from each colour channel
          // when alpha doesn't divide 255 cleanly.
+         BufferedImage target = sameTypeCopyTarget(imageType);
          awt.copyData(target.getRaster());
+         return new AwtImage(target);
       } else {
          // Type conversion — Graphics2D handles the colour-space conversion.
+         BufferedImage target = new BufferedImage(awt.getWidth(null), awt.getHeight(null), imageType);
          Graphics g2 = target.getGraphics();
          try {
             g2.drawImage(awt, 0, 0, null);
          } finally {
             g2.dispose();
          }
+         return new AwtImage(target);
       }
-      return new AwtImage(target);
    }
 }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyPrecisionTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/CopyPrecisionTest.kt
@@ -74,6 +74,29 @@ class CopyPrecisionTest : FunSpec({
       converted.pixel(0, 0).alpha() shouldBe 255
    }
 
+   // The same-type copyData fast path must not be combined with a target created via
+   // new BufferedImage(w, h, type): for palette-based types that target gets the *default*
+   // palette, and copyData copies raw palette indices, so every pixel is remapped through
+   // the wrong palette. The target must reuse the source's own IndexColorModel.
+   test("copy preserves colors for palette-based images (GIF, TYPE_BYTE_INDEXED)") {
+      val original = ImmutableImage.loader().fromStream(javaClass.getResourceAsStream("/github174.gif"))
+      original.awt().type shouldBe BufferedImage.TYPE_BYTE_INDEXED
+      val copy = original.copy()
+      copy.awt().type shouldBe BufferedImage.TYPE_BYTE_INDEXED
+      copy.argbints() shouldBe original.argbints()
+   }
+
+   test("copy preserves colors for an indexed image with a custom palette") {
+      val palette = intArrayOf(0xFF112233.toInt(), 0xFF446688.toInt(), 0xFFAABBCC.toInt(), 0xFF010203.toInt())
+      val icm = java.awt.image.IndexColorModel(8, 4, palette, 0, false, -1, java.awt.image.DataBuffer.TYPE_BYTE)
+      val buf = BufferedImage(4, 4, BufferedImage.TYPE_BYTE_INDEXED, icm)
+      for (y in 0 until 4) for (x in 0 until 4) buf.setRGB(x, y, palette[(x + y) % 4])
+      val original = ImmutableImage.wrapAwt(buf)
+      val copy = original.copy()
+      copy.awt().type shouldBe BufferedImage.TYPE_BYTE_INDEXED
+      copy.argbints() shouldBe original.argbints()
+   }
+
    test("copy preserves channels for TYPE_4BYTE_ABGR with non-255 alpha") {
       // Same precision invariant must hold for non-int-buffer image types.
       val buf = BufferedImage(2, 2, BufferedImage.TYPE_4BYTE_ABGR)


### PR DESCRIPTION
## Problem

The same-type fast path added in #414/#416 does:

```java
BufferedImage target = new BufferedImage(width, height, imageType);
if (awt.getType() == imageType) {
   awt.copyData(target.getRaster());   // copies raw palette INDICES
}
```

For `TYPE_BYTE_INDEXED` / `TYPE_BYTE_BINARY`, that target gets the **default** palette, while the source has its own `IndexColorModel`. `copyData` copies raw palette indices, so every pixel is remapped through the wrong palette.

The default loader preserves the underlying format type, so any GIF or PNG-8 loads as `TYPE_BYTE_INDEXED`. Verified against the repo's own test resource: `loader().fromFile("github174.gif").copy()` → **160,688 of 160,688 pixels wrong** (e.g. `ff0b0b0c` → `ff669900`).

Everything routing through `copy()` was poisoned: `filter()` (any `BufferedOpFilter` wrapper), `map()`, `brightness()`, `contrast()`, `composite()`, `overlay()`, `toGrayscale()`, `replaceTransparency()`, and public `fromAwt(awt)` on an indexed image.

## Fix

When the source color model is an `IndexColorModel` and the types match, build the target around the source's own color model:

```java
new BufferedImage(cm, cm.createCompatibleWritableRaster(w, h), cm.isAlphaPremultiplied(), null)
```

This produces an exact copy (type stays 13, colors identical) and keeps the precision benefit of the raster copy from #414/#416 (no SrcOver rounding). It is also strictly better than the pre-#414 `drawImage` fallback, which loses GIF transparency by compositing SrcOver onto opaque palette[0]. Applied identically in `clone(int)` and `toNewBufferedImage(int)` (shared helper).

## Testing

New regression tests in `CopyPrecisionTest`: a GIF copy is pixel-identical and stays `TYPE_BYTE_INDEXED`; a custom-palette indexed image copies exactly. Full `scrimage-core` + `scrimage-tests` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)