### PR TITLE
Correct Color.average javadoc: it is a SrcOver blend, not an average

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -70,12 +70,15 @@ public interface Color {
    }
 
    /**
-    * Returns the average of this Color merged with another Color.
-    * Takes into account alpha and returns the average as an RGB value.
+    * Returns the result of compositing this Color over the other Color using a
+    * Porter-Duff SrcOver alpha blend — not an arithmetic mean of the channels.
+    * As a consequence, if this colour is fully opaque it completely occludes the
+    * other colour, since SrcOver of an opaque source over any destination yields
+    * the source.
     * <p>
     * See https://stackoverflow.com/questions/1944095/how-to-mix-two-argb-pixels
     *
-    * @return the alpha-weighted average of this colour and the other colour as an RGBColor
+    * @return the SrcOver blend of this colour over the other colour as an RGBColor
     */
    default RGBColor average(Color other) {
       RGBColor c1 = this.toRGB();


### PR DESCRIPTION
Doc-only change, no behaviour change.

The javadoc on `Color.average(Color)` says it returns "the average of this Color merged with another Color ... the alpha-weighted average". The implementation is actually a Porter-Duff SrcOver alpha blend: if `this` is fully opaque it completely occludes `other` (SrcOver of an opaque source over any destination yields the source), which is not an average in any arithmetic sense. That behaviour is deliberate and pinned by tests (#358), so this PR only fixes the documentation.

The new wording mirrors the javadoc adopted for `AwtImage.average()` in #724, which folds pixels with this very method and was corrected for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)