### PR TITLE
docs: correct fit default background color to transparent

### DIFF
--- a/docs/fit.md
+++ b/docs/fit.md
@@ -14,7 +14,7 @@ with a background color so that it precisely matches the input dimensions.
 The difference between this and [cover](cover.md) is that cover will also return an image with the specified dimensions, but
 will size the image to ensure there is no background padding required, but potentially losing some of the source image.
 
-To use, invoke with the target dimenions and optionally, a background color (defaults to Color.WHITE),
+To use, invoke with the target dimenions and optionally, a background color (defaults to transparent),
 a scale method (defaults to ScaleMethod.Bicubic), and the position of the source image in the
 target (defaults to Position.Center).
 


### PR DESCRIPTION
The fit page says the background color defaults to `Color.WHITE`, but the `fit` overloads that omit a color pass `Colors.Transparent` (see `ImmutableImage.fit(int, int)`). Corrected the docs to say the default is transparent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)