### PR TITLE
Fix pixels() returning garbage for sub-raster images and throwing for INT_BGR/ARGB_PRE

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -15,6 +15,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -127,36 +128,43 @@ public class AwtImage {
     * @return an array of the image's pixels
     */
    public Pixel[] pixels() {
-      DataBuffer buffer = awt().getRaster().getDataBuffer();
+      Raster raster = awt().getRaster();
+      DataBuffer buffer = raster.getDataBuffer();
       if (buffer instanceof DataBufferInt) {
          DataBufferInt intbuffer = (DataBufferInt) buffer;
          int[] data = intbuffer.getData();
-         int index = 0;
-         Pixel[] pixels = new Pixel[data.length];
-         if (awt().getType() == BufferedImage.TYPE_INT_ARGB) {
-            while (index < data.length) {
+         // Indexing the backing array directly is only valid when the raster
+         // maps 1:1 onto the buffer. A sub-image view (BufferedImage.getSubimage)
+         // shares the parent's buffer with a translated origin and the parent's
+         // scanline stride, but still reports the parent's type, so raw indexing
+         // would return the wrong pixels (and the wrong number of them).
+         boolean mapsOneToOne = raster.getSampleModelTranslateX() == 0
+            && raster.getSampleModelTranslateY() == 0
+            && intbuffer.getOffset() == 0
+            && data.length == width * height;
+         if (mapsOneToOne && awt().getType() == BufferedImage.TYPE_INT_ARGB) {
+            Pixel[] pixels = new Pixel[data.length];
+            for (int index = 0; index < data.length; index++) {
                pixels[index] = new Pixel(index % width, index / width, data[index]);
-               index++;
             }
-         } else if (awt().getType() == BufferedImage.TYPE_INT_RGB) {
-            while (index < data.length) {
+            return pixels;
+         } else if (mapsOneToOne && awt().getType() == BufferedImage.TYPE_INT_RGB) {
+            Pixel[] pixels = new Pixel[data.length];
+            for (int index = 0; index < data.length; index++) {
                pixels[index] = new Pixel(index % width, index / width, data[index] | 0xFF000000);
-               index++;
             }
-         } else {
-            throw new RuntimeException("Unsupported image type " + awt().getType());
+            return pixels;
          }
-         return pixels;
-      } else {
-         Pixel[] pixels = new Pixel[count()];
-         int index = 0;
-         for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-               pixels[index++] = new Pixel(x, y, awt().getRGB(x, y));
-            }
-         }
-         return pixels;
+         // Sub-raster layouts and other int-packed types (TYPE_INT_BGR,
+         // TYPE_INT_ARGB_PRE, ...) fall through to getRGB below, which
+         // converts correctly via the colour model.
       }
+      int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+      Pixel[] pixels = new Pixel[argb.length];
+      for (int i = 0; i < argb.length; i++) {
+         pixels[i] = new Pixel(i % width, i / width, argb[i]);
+      }
+      return pixels;
    }
 
    /**

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PixelsFastPathTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/PixelsFastPathTest.kt
@@ -1,0 +1,88 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+import java.awt.image.BufferedImage
+
+/**
+ * Pin-down tests for the DataBufferInt fast path in AwtImage.pixels().
+ *
+ * The fast path indexes the raster's backing int[] directly, which is only
+ * valid when the raster maps 1:1 onto the buffer. A sub-image view created
+ * with BufferedImage.getSubimage shares the parent's buffer with a translated
+ * origin and the parent's scanline stride, but still reports TYPE_INT_ARGB,
+ * so it used to take the fast path and return the parent's full buffer
+ * (wrong count, wrong values, wrong coordinates).
+ *
+ * The fast path also used to throw RuntimeException for other int-packed
+ * types (TYPE_INT_BGR, TYPE_INT_ARGB_PRE) even though the getRGB fallback
+ * handles them correctly.
+ */
+class PixelsFastPathTest : FunSpec({
+
+   fun parentWithCoordinateColors(): BufferedImage {
+      val parent = BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB)
+      for (y in 0 until 8) {
+         for (x in 0 until 8) {
+            // encode the coordinates in the pixel value so misreads are obvious
+            parent.setRGB(x, y, (0xFF shl 24) or (x shl 16) or (y shl 8) or 0x12)
+         }
+      }
+      return parent
+   }
+
+   test("pixels() on a wrapAwt'd subimage returns w*h pixels with the view's values and coordinates") {
+      val parent = parentWithCoordinateColors()
+      val view = ImmutableImage.wrapAwt(parent.getSubimage(2, 2, 4, 4))
+      val pixels = view.pixels()
+      pixels.size shouldBe 16
+      for (p in pixels) {
+         // pixel (x,y) of the view is pixel (x+2,y+2) of the parent
+         p.argb shouldBe ((0xFF shl 24) or ((p.x + 2) shl 16) or ((p.y + 2) shl 8) or 0x12)
+      }
+   }
+
+   test("pixels() coordinates on a subimage use the view's width, not the parent's") {
+      val parent = parentWithCoordinateColors()
+      val view = ImmutableImage.wrapAwt(parent.getSubimage(2, 2, 4, 4))
+      val pixels = view.pixels()
+      pixels.map { it.x to it.y } shouldBe (0 until 4).flatMap { y -> (0 until 4).map { x -> x to y } }
+   }
+
+   test("pixels() works for TYPE_INT_BGR instead of throwing") {
+      val image = ImmutableImage.filled(4, 4, Color.RED, BufferedImage.TYPE_INT_BGR)
+      val pixels = image.pixels()
+      pixels.size shouldBe 16
+      pixels.forEach { it.argb shouldBe 0xFFFF0000.toInt() }
+   }
+
+   test("pixels() works for TYPE_INT_ARGB_PRE instead of throwing") {
+      val image = ImmutableImage.filled(4, 4, Color.RED, BufferedImage.TYPE_INT_ARGB_PRE)
+      val pixels = image.pixels()
+      pixels.size shouldBe 16
+      pixels.forEach { it.argb shouldBe 0xFFFF0000.toInt() }
+   }
+
+   test("pixels() fast path still used for a plain TYPE_INT_ARGB image") {
+      val image = ImmutableImage.filled(3, 2, Color.GREEN, BufferedImage.TYPE_INT_ARGB)
+      val pixels = image.pixels()
+      pixels.size shouldBe 6
+      pixels.forEach { it.argb shouldBe 0xFF00FF00.toInt() }
+   }
+
+   test("patch() on a subimage-backed image returns the correct values") {
+      val parent = parentWithCoordinateColors()
+      val view = ImmutableImage.wrapAwt(parent.getSubimage(2, 2, 4, 4))
+      val patch = view.patch(1, 1, 2, 2)
+      patch.size shouldBe 4
+      // patch (1,1)-(2,2) of the view maps to (3,3)-(4,4) of the parent
+      patch.map { it.argb } shouldBe listOf(
+         (0xFF shl 24) or (3 shl 16) or (3 shl 8) or 0x12,
+         (0xFF shl 24) or (4 shl 16) or (3 shl 8) or 0x12,
+         (0xFF shl 24) or (3 shl 16) or (4 shl 8) or 0x12,
+         (0xFF shl 24) or (4 shl 16) or (4 shl 8) or 0x12
+      )
+   }
+})


### PR DESCRIPTION
## Problem

The `DataBufferInt` fast path in `AwtImage.pixels()` indexes the raster's backing `int[]` directly, assuming the raster maps 1:1 onto the buffer (offset 0, scanline stride == width, `data.length == width*height`). That assumption is false for a `BufferedImage` view returned by `parent.getSubimage(x, y, w, h)`: the child raster shares the parent's buffer with a non-zero sample-model translation and the parent's stride, while still reporting `TYPE_INT_ARGB` — so it took the fast path.

Two user-visible bugs:

1. **Sub-raster garbage**: `ImmutableImage.wrapAwt(parent8x8.getSubimage(2,2,4,4)).pixels()` returned **64** pixels (expected 16) with the parent's values and coordinates computed against the wrong width. This silently poisons `patch()`/`patches()`, which slice the `pixels()` array.
2. **Spurious exception**: the fast path threw `RuntimeException("Unsupported image type")` for `TYPE_INT_BGR` and `TYPE_INT_ARGB_PRE`, even though the generic `getRGB` fallback (already used for byte-backed types) handles both correctly, including un-premultiplying `ARGB_PRE`.

## Fix

Only take the fast path when the buffer maps 1:1 (`sampleModelTranslateX/Y == 0`, buffer offset 0, `data.length == width*height`) **and** the type is `TYPE_INT_ARGB`/`TYPE_INT_RGB`. Everything else falls through to a bulk `getRGB(0, 0, w, h, ...)` path (the old fallback was per-pixel `getRGB`), which converts via the colour model.

## Tests

New `PixelsFastPathTest` covers: `pixels()` on a `wrapAwt`'d subimage returns w*h pixels with the view's values and coordinates; `pixels()` works for `TYPE_INT_BGR` and `TYPE_INT_ARGB_PRE`; the plain `TYPE_INT_ARGB` path is unchanged; `patch()` on a subimage-backed image returns correct values. Full `scrimage-tests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)