### PR TITLE
Fix javadoc typos in the color package

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/Color.java
@@ -15,8 +15,8 @@ public interface Color {
    RGBColor toRGB();
 
    /**
-    * Returns a conversion of this color into a CYMK color.
-    * If this colour is already a CYMK then the same instance will be returned.
+    * Returns a conversion of this color into a CMYK color.
+    * If this colour is already a CMYK then the same instance will be returned.
     *
     * @return this colour as a CMYKColor
     */

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/HSLColor.java
@@ -3,10 +3,10 @@ package com.sksamuel.scrimage.color;
 /**
  * Hue/Saturation/Lightness
  * <p>
- * The hue component should be between0.0and360.0
- * The saturation component should be between0.0and1.0
- * The lightness component should be between0.0and1.0
- * The alpha component should be between0.0and1.0
+ * The hue component should be between 0.0 and 360.0
+ * The saturation component should be between 0.0 and 1.0
+ * The lightness component should be between 0.0 and 1.0
+ * The alpha component should be between 0.0 and 1.0
  */
 public class HSLColor implements Color {
 

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/color/RGBColor.java
@@ -70,7 +70,7 @@ public class RGBColor implements Color {
 
    /**
     * Returns as an int the value of this color.
-    * The RGB and alpha components are packed as rgba.
+    * The alpha and RGB components are packed as ARGB.
     * Use toARGBInt() for clarity.
     *
     * @return the packed ARGB integer value of this color
@@ -110,8 +110,8 @@ public class RGBColor implements Color {
    }
 
    /**
-    * Returns a conversion of this color into a CYMK color.
-    * If this colour is already a CYMK then the same instance will be returned.
+    * Returns a conversion of this color into a CMYK color.
+    * If this colour is already a CMYK then the same instance will be returned.
     *
     * @return this color converted to a CMYKColor
     */


### PR DESCRIPTION
Doc-only change, no behaviour change.

- `RGBColor.toInt()`: the javadoc claimed the components are packed as "rgba", but the value is actually packed as ARGB (it delegates to `toARGBInt()` / `PixelTools.argb`). Anyone unpacking per the stated bit order would read every channel wrong.
- `Color.toCMYK()` and `RGBColor.toCMYK()`: "CYMK" -> "CMYK".
- `HSLColor`: the class javadoc was missing spaces around the component ranges, e.g. "between0.0and360.0" -> "between 0.0 and 360.0" (all four lines fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)