### PR TITLE
docs: fix copy example calling instance method statically

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -33,5 +33,5 @@ specify the type of the copy as well.
 image.copy()
 
 // copy with the data duplicated, and the raster using the specified type
-ImmutableImage.copy(BufferedImage.TYPE_4BYTE_ABGR)
+image.copy(BufferedImage.TYPE_4BYTE_ABGR)
 ```


### PR DESCRIPTION
The create page's last example calls `ImmutableImage.copy(BufferedImage.TYPE_4BYTE_ABGR)`, but `copy(int type)` is an instance method. Changed the example to `image.copy(BufferedImage.TYPE_4BYTE_ABGR)`, matching the surrounding examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)