### PR TITLE
Fix PngWriter and GifSequenceWriter crashing on TYPE_CUSTOM images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/GifSequenceWriter.java
@@ -70,7 +70,10 @@ public class GifSequenceWriter extends AbstractGifWriter {
       try {
          ImageWriteParam imageWriteParam = writer.getDefaultWriteParam();
 
-         ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromBufferedImageType(images[0].awt().getType());
+         // createFromRenderedImage rather than createFromBufferedImageType: the latter throws
+         // IllegalArgumentException for TYPE_CUSTOM (type 0), which is what the JDK PNG reader
+         // returns for 16-bit per channel PNGs — so such frames could never be written to a gif.
+         ImageTypeSpecifier imageTypeSpecifier = ImageTypeSpecifier.createFromRenderedImage(images[0].awt());
          IIOMetadata imageMetaData = writer.getDefaultImageMetadata(imageTypeSpecifier, imageWriteParam);
 
          String metaFormatName = imageMetaData.getNativeMetadataFormatName();

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
@@ -68,7 +68,10 @@ public class PngWriter implements ImageWriter {
    @Override
    public void write(AwtImage image, ImageMetadata metadata, OutputStream out) throws IOException {
 
-      ImageTypeSpecifier type = ImageTypeSpecifier.createFromBufferedImageType(image.getType());
+      // createFromRenderedImage rather than createFromBufferedImageType: the latter throws
+      // IllegalArgumentException for TYPE_CUSTOM (type 0), which is what the JDK PNG reader
+      // returns for 16-bit per channel PNGs — so such images could never be written back out.
+      ImageTypeSpecifier type = ImageTypeSpecifier.createFromRenderedImage(image.awt());
       javax.imageio.ImageWriter writer = ImageIO.getImageWriters(type, "png").next();
       try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
          ImageWriteParam param = writer.getDefaultWriteParam();

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/TypeCustomWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/TypeCustomWriterTest.kt
@@ -1,0 +1,85 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.sksamuel.scrimage.core.nio
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.AnimatedGifReader
+import com.sksamuel.scrimage.nio.GifSequenceWriter
+import com.sksamuel.scrimage.nio.ImageSource
+import com.sksamuel.scrimage.nio.PngWriter
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Transparency
+import java.awt.color.ColorSpace
+import java.awt.image.BufferedImage
+import java.awt.image.ComponentColorModel
+import java.awt.image.DataBuffer
+import java.awt.image.Raster
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+/**
+ * Regression tests: PngWriter and GifSequenceWriter built their ImageTypeSpecifier with
+ * ImageTypeSpecifier.createFromBufferedImageType(image.getType()), which throws
+ * IllegalArgumentException("Cannot create from TYPE_CUSTOM!") when the image type is
+ * TYPE_CUSTOM (0). The JDK PNG reader decodes 16-bit per channel PNGs to TYPE_CUSTOM,
+ * so a 16-bit PNG loaded with ImmutableImage.loader() could not be written back out.
+ */
+class TypeCustomWriterTest : WordSpec({
+
+   // a 16-bit per channel RGB image; BufferedImage reports these as TYPE_CUSTOM
+   fun custom16bitRgbImage(w: Int, h: Int): BufferedImage {
+      val cs = ColorSpace.getInstance(ColorSpace.CS_sRGB)
+      val cm = ComponentColorModel(cs, intArrayOf(16, 16, 16), false, false, Transparency.OPAQUE, DataBuffer.TYPE_USHORT)
+      val raster = Raster.createInterleavedRaster(DataBuffer.TYPE_USHORT, w, h, 3, null)
+      for (y in 0 until h) {
+         for (x in 0 until w) {
+            raster.setPixel(x, y, intArrayOf(0x8080, 0x4040, 0xC0C0))
+         }
+      }
+      return BufferedImage(cm, raster, false, null)
+   }
+
+   // a 16-bit RGB png as produced by any external tool; the JDK reader decodes it to TYPE_CUSTOM
+   fun sixteenBitPng(w: Int, h: Int): ByteArray {
+      val baos = ByteArrayOutputStream()
+      ImageIO.write(custom16bitRgbImage(w, h), "png", baos)
+      return baos.toByteArray()
+   }
+
+   "PngWriter" should {
+      "write an image backed by a TYPE_CUSTOM BufferedImage" {
+         val awt = custom16bitRgbImage(20, 10)
+         awt.type shouldBe BufferedImage.TYPE_CUSTOM
+         val image = ImmutableImage.wrapAwt(awt)
+         val bytes = image.bytes(PngWriter())
+         val decoded = ImmutableImage.loader().fromBytes(bytes)
+         decoded.width shouldBe 20
+         decoded.height shouldBe 10
+         decoded.pixel(0, 0).argb shouldBe 0xFF8040C0.toInt()
+      }
+      "round-trip a 16-bit png loaded from bytes" {
+         val png = sixteenBitPng(20, 10)
+         val image = ImmutableImage.loader().fromBytes(png)
+         image.awt().type shouldBe BufferedImage.TYPE_CUSTOM
+         val bytes = image.bytes(PngWriter())
+         val decoded = ImmutableImage.loader().fromBytes(bytes)
+         decoded.width shouldBe 20
+         decoded.height shouldBe 10
+         decoded.pixel(0, 0).argb shouldBe image.pixel(0, 0).argb
+      }
+   }
+
+   "GifSequenceWriter" should {
+      "write frames backed by TYPE_CUSTOM BufferedImages" {
+         val frame = ImmutableImage.loader().fromBytes(sixteenBitPng(20, 10))
+         frame.awt().type shouldBe BufferedImage.TYPE_CUSTOM
+         val bytes = GifSequenceWriter().withFrameDelay(100).bytes(arrayOf(frame, frame))
+         val decoded = AnimatedGifReader.read(ImageSource.of(bytes))
+         decoded.frameCount shouldBe 2
+         decoded.getFrame(0).width shouldBe 20
+         decoded.getFrame(0).height shouldBe 10
+      }
+   }
+
+})


### PR DESCRIPTION
## Bug

`PngWriter.write` and `GifSequenceWriter.bytes` build their `ImageTypeSpecifier` with `ImageTypeSpecifier.createFromBufferedImageType(image.getType())`, which throws `IllegalArgumentException("Cannot create from TYPE_CUSTOM!")` for images of type `TYPE_CUSTOM` (0).

The JDK PNG reader decodes 16-bit per channel PNGs to `TYPE_CUSTOM`, so:

```kotlin
ImmutableImage.loader().fromBytes(png16bit).bytes(PngWriter())
```

crashed — a 16-bit PNG could not be round-tripped at all. The same applied to writing such an image as an animated gif frame. The unchecked IAE also escapes a method declared `throws IOException`.

## Fix

Build the specifier with `ImageTypeSpecifier.createFromRenderedImage(image.awt())`, which derives it from the image's actual `ColorModel`/`SampleModel` — the same approach `ImageIO.write` itself uses — and works for standard and custom types alike. Verified that the JDK PNG and GIF writers successfully encode the same images once the specifier is created this way.

## Tests

New `TypeCustomWriterTest` builds a 16-bit per channel RGB `BufferedImage` (reported as `TYPE_CUSTOM`) and asserts:
- `PngWriter` writes it and it round-trips with correct dimensions and pixel values
- a 16-bit PNG loaded via `ImmutableImage.loader()` (JDK reader → `TYPE_CUSTOM`) round-trips through `PngWriter`
- `GifSequenceWriter` writes frames backed by `TYPE_CUSTOM` images

Existing byte-exact gif and png writer tests still pass (the derived specifier is equivalent for standard image types). Full `scrimage-tests` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)