### PR TITLE
Fix fillInPlace corrupting pixels outside sub-raster image views

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -63,10 +63,23 @@ public class MutableImage extends AwtImage {
       WritableRaster raster = awt().getRaster();
       DataBuffer buffer = raster.getDataBuffer();
       if (buffer instanceof DataBufferInt) {
-         Object colorElements = awt().getColorModel().getDataElements(target, null);
-         if (colorElements instanceof int[] && ((int[]) colorElements).length == 1) {
-            Arrays.fill(((DataBufferInt) buffer).getData(), ((int[]) colorElements)[0]);
-            return;
+         DataBufferInt intbuffer = (DataBufferInt) buffer;
+         int[] data = intbuffer.getData();
+         // Arrays.fill on the backing array is only valid when the raster maps
+         // 1:1 onto the buffer. A sub-image view (BufferedImage.getSubimage)
+         // shares the parent's buffer with a translated origin and the parent's
+         // scanline stride, so filling the whole array would corrupt parent
+         // pixels outside the view.
+         boolean mapsOneToOne = raster.getSampleModelTranslateX() == 0
+            && raster.getSampleModelTranslateY() == 0
+            && intbuffer.getOffset() == 0
+            && data.length == width * height;
+         if (mapsOneToOne) {
+            Object colorElements = awt().getColorModel().getDataElements(target, null);
+            if (colorElements instanceof int[] && ((int[]) colorElements).length == 1) {
+               Arrays.fill(data, ((int[]) colorElements)[0]);
+               return;
+            }
          }
       }
       // Generic fallback: build the packed-ARGB row once and bulk setRGB it.

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FillInPlaceTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/FillInPlaceTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.scrimage.core
 
 import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.MutableImage
 import com.sksamuel.scrimage.color.RGBColor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -47,5 +48,40 @@ class FillInPlaceTest : FunSpec({
       image.setColor(1, 0, RGBColor(0, 255, 0, 255))
       image.fillInPlace(RGBColor(0, 0, 255, 255).awt())
       image.pixels().forEach { p -> p.argb shouldBe 0xFF0000FF.toInt() }
+   }
+
+   test("fillInPlace on a subimage view does not modify parent pixels outside the view") {
+      // A getSubimage view shares the parent's DataBufferInt with a translated
+      // origin and the parent's scanline stride, so the Arrays.fill fast path
+      // used to overwrite the parent's entire buffer.
+      val blue = 0xFF0000FF.toInt()
+      val red = 0xFFFF0000.toInt()
+      val parent = BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB)
+      for (y in 0 until 8) {
+         for (x in 0 until 8) {
+            parent.setRGB(x, y, blue)
+         }
+      }
+
+      val view = MutableImage(parent.getSubimage(2, 2, 4, 4))
+      view.fillInPlace(RGBColor(255, 0, 0, 255).awt())
+
+      for (y in 0 until 8) {
+         for (x in 0 until 8) {
+            val inside = x in 2..5 && y in 2..5
+            parent.getRGB(x, y) shouldBe if (inside) red else blue
+         }
+      }
+   }
+
+   test("fillInPlace on a subimage view fills the view completely") {
+      val parent = BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB)
+      val view = MutableImage(parent.getSubimage(2, 2, 4, 4))
+      view.fillInPlace(RGBColor(100, 200, 50, 255).awt())
+      for (y in 0 until 4) {
+         for (x in 0 until 4) {
+            view.awt().getRGB(x, y) shouldBe 0xFF64C832.toInt()
+         }
+      }
    }
 })


### PR DESCRIPTION
## Problem

`MutableImage.fillInPlace` used `Arrays.fill` on the raster's backing `int[]` whenever the buffer was a `DataBufferInt`. For a sub-image view created with `BufferedImage.getSubimage(x, y, w, h)`, that array is the **parent image's entire buffer** — the child raster shares it with a translated origin and the parent's scanline stride. So:

```java
new MutableImage(parent.getSubimage(2, 2, 4, 4)).fillInPlace(Color.RED);
```

overwrote every pixel of the parent, including pixels outside the logical 4x4 view (verified: parent pixel (0,0) outside the view turned red). Reachable via the public `MutableImage(BufferedImage)` constructor and `ImmutableImage.wrapAwt`.

## Fix

The `Arrays.fill` fast path is now only taken when the buffer maps 1:1 onto the raster (`sampleModelTranslateX/Y == 0`, buffer offset 0, `data.length == width*height`). Otherwise the existing generic fallback runs, which bulk-`setRGB`s only the view's own `width x height` region.

## Tests

Added to `FillInPlaceTest`: filling a subimage view leaves all parent pixels outside the view untouched while turning the view's region red, and the view itself is filled completely. Full `scrimage-tests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)