### PR TITLE
Fix brightness() throwing on palette-based images such as GIFs

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/MutableImage.java
@@ -8,6 +8,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.IndexColorModel;
 import java.awt.image.RescaleOp;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
@@ -108,6 +109,23 @@ public class MutableImage extends AwtImage {
     * Mutates this image by scaling all pixel values by the given factor (brightness in other words).
     */
    public void rescaleInPlace(double factor) {
+      if (awt().getColorModel() instanceof IndexColorModel) {
+         // RescaleOp rejects palette-based images ("Rescaling cannot be performed on an
+         // indexed image"), and GIFs / PNG-8s load as TYPE_BYTE_INDEXED by default.
+         // Scale the unpacked ARGB values instead, like contrastInPlace; setRGB maps each
+         // result back to the nearest palette entry. Alpha is left untouched, matching
+         // RescaleOp's single-factor behavior.
+         int[] argb = awt().getRGB(0, 0, width, height, null, 0, width);
+         for (int i = 0; i < argb.length; i++) {
+            int p = argb[i];
+            int r = PixelTools.truncate(factor * PixelTools.red(p));
+            int g = PixelTools.truncate(factor * PixelTools.green(p));
+            int b = PixelTools.truncate(factor * PixelTools.blue(p));
+            argb[i] = PixelTools.argb(PixelTools.alpha(p), r, g, b);
+         }
+         awt().setRGB(0, 0, width, height, argb, 0, width);
+         return;
+      }
       RescaleOp rescale = new RescaleOp((float) factor, 0f,
          new RenderingHints(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY));
       rescale.filter(awt(), awt());

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/BrightnessIndexedTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/BrightnessIndexedTest.kt
@@ -1,0 +1,58 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression test for brightness() on palette-based images.
+ *
+ * rescaleInPlace used java.awt.image.RescaleOp unconditionally, and RescaleOp
+ * rejects IndexColorModel images. Since the default loader preserves the
+ * underlying image type, any GIF (TYPE_BYTE_INDEXED) crashed with
+ * "IllegalArgumentException: Rescaling cannot be performed on an indexed image".
+ */
+class BrightnessIndexedTest : FunSpec({
+
+   fun luminanceSum(image: ImmutableImage): Long {
+      var sum = 0L
+      image.forEach { p -> sum += p.red() + p.green() + p.blue() }
+      return sum
+   }
+
+   test("brightness works on an indexed image with the default palette") {
+      // default-palette TYPE_BYTE_INDEXED, filled with a mid-gray
+      val buf = BufferedImage(20, 20, BufferedImage.TYPE_BYTE_INDEXED)
+      val g2 = buf.createGraphics()
+      g2.color = java.awt.Color(102, 102, 102)
+      g2.fillRect(0, 0, 20, 20)
+      g2.dispose()
+      val original = ImmutableImage.wrapAwt(buf)
+
+      val brightened = original.brightness(1.5)
+      brightened.width shouldBe 20
+      brightened.height shouldBe 20
+      // 102 * 1.5 = 153, quantized to the nearest default-palette entry
+      (brightened.pixel(10, 10).red() > 102) shouldBe true
+   }
+
+   test("brightness works on an indexed image loaded from a GIF") {
+      val original = ImmutableImage.loader().fromStream(javaClass.getResourceAsStream("/github174.gif"))
+      original.awt().type shouldBe BufferedImage.TYPE_BYTE_INDEXED
+
+      // compare against a factor-1.0 pass through the same pipeline so the assertion
+      // holds regardless of any quirks elsewhere in the copy() path
+      val unchanged = original.brightness(1.0)
+      val brightened = original.brightness(1.5)
+      luminanceSum(brightened) shouldBeGreaterThan luminanceSum(unchanged)
+   }
+
+   test("brightness on an indexed image leaves the original untouched") {
+      val original = ImmutableImage.loader().fromStream(javaClass.getResourceAsStream("/github174.gif"))
+      val before = original.argbints()
+      original.brightness(1.5)
+      original.argbints() shouldBe before
+   }
+})


### PR DESCRIPTION
## Problem

`MutableImage.rescaleInPlace` uses `java.awt.image.RescaleOp` unconditionally, and RescaleOp rejects `IndexColorModel` images. The default loader preserves the underlying image type, so GIFs decode to `TYPE_BYTE_INDEXED` and:

```kotlin
ImmutableImage.loader().fromFile("image.gif").brightness(1.2)
// java.lang.IllegalArgumentException: Rescaling cannot be performed on an indexed image
```

`contrast()` on the same image works fine, because `contrastInPlace` transforms unpacked ARGB values via get/setRGB.

## Fix

For indexed images, take the same approach as `contrastInPlace`: bulk-read the ARGB values, scale the color channels (alpha untouched, matching RescaleOp's single-factor behavior), and bulk-write back — `setRGB` maps each result to the nearest palette entry. Non-indexed images keep the RescaleOp path, so existing behavior/goldens are unchanged.

Brightness on an indexed image is inherently palette-quantized (the result must map back into the palette), but that beats crashing; users wanting exact results can `copy(TYPE_INT_ARGB)` first.

## Testing

New `BrightnessIndexedTest`: default-palette indexed image brightens, a real GIF brightens (luminance-sum comparison), original untouched. Existing suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)