### PR TITLE
docs: use public API in metadata orientation example

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -71,10 +71,10 @@ The orientation tag is a commonly used tag, so there is a function to specifical
 if defined (sometimes, eg on Sony cameras, it is defined more than once!).
 
 
-These helper methods are found in the `OrientationTools` class.
-
 For example:
 
 ```
-OrientationTools.imageOrientationsOf(image.metadata);
+image.getMetadata().getOrientation();
 ```
+
+Further helper methods, such as `requiresReorientation` and `reorient`, are found in the `OrientationTools` class.


### PR DESCRIPTION
The orientation example on the metadata page calls `OrientationTools.imageOrientationsOf(image.metadata)`, but `imageOrientationsOf` is package-private and `metadata` is a private field, so the sample does not compile from user code. Replaced it with the public API `image.getMetadata().getOrientation()`, and noted the public `OrientationTools` helpers (`requiresReorientation`, `reorient`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)