### PR TITLE
docs: fix animated GIF examples to match current API

### DIFF
--- a/docs/animated_gif.md
+++ b/docs/animated_gif.md
@@ -23,8 +23,8 @@ frames, delay per frame and so on.
 
     ```kotlin
     val gif = AnimatedGifReader.read(ImageSource.of(...))
-    val firstFrame = gif.frames().first()
-    val lastFrame = gif.frames().last()
+    val firstFrame = gif.frames.first()
+    val lastFrame = gif.frames.last()
     ```
 
 === "Scala"
@@ -45,21 +45,21 @@ and the AWT image type we want the images to be created with.
 === "Java"
 
     ```java
-    StreamingGifWriter writer = new StreamingGifWriter(Duration.ofSeconds(2), true);
+    StreamingGifWriter writer = new StreamingGifWriter(Duration.ofSeconds(2), true, false);
     GifStream gif = writer.prepareStream("/path/to/gif.gif", BufferedImage.TYPE_INT_ARGB);
     ```
 
 === "Kotlin"
 
     ```kotlin
-    val writer = StreamingGifWriter(Duration.ofSeconds(2), true)
+    val writer = StreamingGifWriter(Duration.ofSeconds(2), true, false)
     val gif = writer.prepareStream("/path/to/gif.gif", BufferedImage.TYPE_INT_ARGB)
     ```
 
 === "Scala"
 
     ```scala
-    val writer = new StreamingGifWriter(Duration.ofSeconds(2), true)
+    val writer = new StreamingGifWriter(Duration.ofSeconds(2), true, false)
     val gif = writer.prepareStream("/path/to/gif.gif", BufferedImage.TYPE_INT_ARGB)
     ```
 
@@ -72,10 +72,10 @@ gif.writeFrame(image1);
 gif.writeFrame(imageN);
 ```
 
-Finally, we close the stream by invoking finish, and the data is finalized to the output stream or path.
+Finally, we close the stream by invoking close, and the data is finalized to the output stream or path.
 
 ```
-gif.finish();
+gif.close();
 ```
 
 !!! note


### PR DESCRIPTION
Three fixes to the animated GIF page so the samples compile against the current API:

- `new StreamingGifWriter(Duration.ofSeconds(2), true)` — there is no 2-arg constructor; added the `compressed` flag: `new StreamingGifWriter(Duration.ofSeconds(2), true, false)`.
- `gif.finish()` — `GifStream` has no `finish()` method; it extends `AutoCloseable`, so the stream is finalized with `gif.close()`.
- Kotlin reading sample used `gif.frames().first()` — the method is `getFrames()`, which Kotlin accesses via property syntax: `gif.frames.first()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)