### PR TITLE
docs: fix zoom example that showed scaleToHeight

### DIFF
--- a/docs/zoom.md
+++ b/docs/zoom.md
@@ -27,7 +27,7 @@ image.zoom(1.3)
 
 ```kotlin
 // zoom with a specified scale method.
-image.scaleToHeight(200, Scalemethod.FastScale)
+image.zoom(1.3, ScaleMethod.FastScale)
 ```
 
 ![zoom](images/zoom_fastscale.jpg)


### PR DESCRIPTION
The zoom page's "zoom with a specified scale method" example showed `image.scaleToHeight(200, Scalemethod.FastScale)` — a different operation entirely, with the class name misspelled. Corrected to `image.zoom(1.3, ScaleMethod.FastScale)`, matching the preceding default-method example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)