### PR TITLE
docs: pad requires a color argument

### DIFF
--- a/docs/pad.md
+++ b/docs/pad.md
@@ -4,7 +4,7 @@ Pad
 Resizes the canvas by adding a number of pixels around the edges in a given color.
 This is the opposite of the [trim](trim.md) operation.
 
-Pad can add pixels uniformly around all edges using `pad(k)` or on a specified edge only, using `padLeft(k)` and so on.
+Pad can add pixels uniformly around all edges using `pad(k, color)` or on a specified edge only, using `padLeft(k)` and so on.
 
 
 


### PR DESCRIPTION
The pad page refers to `pad(k)`, but there is no single-argument overload — the method is `pad(size, color)`. Updated the reference to `pad(k, color)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)