### PR TITLE
Fix rotate() and FastScale crashing on TYPE_CUSTOM images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -628,7 +628,10 @@ public class AwtImage {
       int neww = (int) Math.floor(width * cos + height * sin),
          newh = (int) Math.floor(height * cos + width * sin);
 
-      BufferedImage rotated = ImmutableImage.filled(neww, newh, bgcolor, getType()).awt();
+      // TYPE_CUSTOM (0) cannot be passed to the BufferedImage constructor;
+      // fall back to ARGB like blank()/empty()/fromAwt() do.
+      int type = getType() == BufferedImage.TYPE_CUSTOM ? BufferedImage.TYPE_INT_ARGB : getType();
+      BufferedImage rotated = ImmutableImage.filled(neww, newh, bgcolor, type).awt();
       Graphics2D graphic = rotated.createGraphics();
       try {
          graphic.translate((neww - width) / 2.0, (newh - height) / 2.0);

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/AwtNearestNeighbourScale.java
@@ -26,7 +26,10 @@ public class AwtNearestNeighbourScale implements Scale {
             dst[k++] = src[srcRow + (int) (x * xRatio)];
          }
       }
-      BufferedImage target = new BufferedImage(w, h, in.getType());
+      // TYPE_CUSTOM (0) cannot be passed to the BufferedImage constructor
+      // (e.g. 16-bit PNGs decode to a custom type); fall back to ARGB.
+      int type = in.getType() == BufferedImage.TYPE_CUSTOM ? BufferedImage.TYPE_INT_ARGB : in.getType();
+      BufferedImage target = new BufferedImage(w, h, type);
       target.setRGB(0, 0, w, h, dst, 0, w);
       return target;
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/TypeCustomOpsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/TypeCustomOpsTest.kt
@@ -1,0 +1,56 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import com.sksamuel.scrimage.angles.Degrees
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Transparency
+import java.awt.color.ColorSpace
+import java.awt.image.BufferedImage
+import java.awt.image.ComponentColorModel
+import java.awt.image.DataBuffer
+
+/**
+ * Regression tests for operations on TYPE_CUSTOM (type 0) images.
+ *
+ * The JDK PNG reader decodes 16-bit/channel PNGs to a TYPE_CUSTOM BufferedImage,
+ * and the default loader preserves the type. rotate() and nearest-neighbour scaling
+ * passed getType() straight into the BufferedImage constructor, which throws
+ * "IllegalArgumentException: Unknown image type 0". blank()/empty()/subimage()/fromAwt()
+ * already special-case type 0; these two call sites were missed.
+ */
+class TypeCustomOpsTest : FunSpec({
+
+   // a 16-bit-per-channel RGB image, reporting BufferedImage.TYPE_CUSTOM (0)
+   fun custom16bit(w: Int, h: Int): BufferedImage {
+      val cm = ComponentColorModel(
+         ColorSpace.getInstance(ColorSpace.CS_sRGB),
+         intArrayOf(16, 16, 16),
+         false,
+         false,
+         Transparency.OPAQUE,
+         DataBuffer.TYPE_USHORT
+      )
+      val image = BufferedImage(cm, cm.createCompatibleWritableRaster(w, h), false, null)
+      for (y in 0 until h) for (x in 0 until w) image.setRGB(x, y, 0xFF336699.toInt())
+      return image
+   }
+
+   test("rotate works on a TYPE_CUSTOM image") {
+      val awt = custom16bit(30, 20)
+      awt.type shouldBe BufferedImage.TYPE_CUSTOM
+      val rotated = ImmutableImage.wrapAwt(awt).rotate(Degrees(90))
+      rotated.width shouldBe 20
+      rotated.height shouldBe 30
+      rotated.pixel(10, 15).toARGBInt() shouldBe 0xFF336699.toInt()
+   }
+
+   test("scaleTo with FastScale works on a TYPE_CUSTOM image") {
+      val awt = custom16bit(30, 20)
+      val scaled = ImmutableImage.wrapAwt(awt).scaleTo(10, 10, ScaleMethod.FastScale)
+      scaled.width shouldBe 10
+      scaled.height shouldBe 10
+      scaled.pixel(5, 5).toARGBInt() shouldBe 0xFF336699.toInt()
+   }
+})


### PR DESCRIPTION
## Problem

The JDK PNG reader decodes 16-bit/channel PNGs to a `TYPE_CUSTOM` (type 0) `BufferedImage`, and the default loader preserves the underlying type. Both of these then crash:

```kotlin
val img = ImmutableImage.loader().fromBytes(png16bit)   // getType() == 0
img.rotate(Degrees(90))                     // IllegalArgumentException: Unknown image type 0
img.scaleTo(20, 20, ScaleMethod.FastScale)  // same
```

`rotateByRadians` passes `getType()` into `ImmutableImage.filled(...)`, and `AwtNearestNeighbourScale` passes `in.getType()` into the `BufferedImage` constructor — which rejects type 0. The codebase already special-cases type 0 in `blank()`, `empty()`, `subimage()` and `fromAwt()`; these two call sites were missed.

## Fix

Fall back to `TYPE_INT_ARGB` when the source type is `TYPE_CUSTOM`, matching the existing convention. Standard-type images are unaffected.

## Testing

New `TypeCustomOpsTest` builds a real 16-bit-per-channel RGB image (`ComponentColorModel`/`TYPE_USHORT`, reports type 0) and verifies rotate and FastScale produce correct dimensions and pixel values. Existing rotate tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)