### PR TITLE
Fix ScrimageNearestNeighbourScale reading with wrong stride for sub-raster images

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/ScrimageNearestNeighbourScale.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/scaling/ScrimageNearestNeighbourScale.java
@@ -3,6 +3,7 @@ package com.sksamuel.scrimage.scaling;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
 
 public class ScrimageNearestNeighbourScale implements Scale {
 
@@ -15,14 +16,30 @@ public class ScrimageNearestNeighbourScale implements Scale {
         // this method with no useful context. ImmutableImage.scaleTo
         // guards this for its callers but the class is public so a
         // direct user can still land here.
-        DataBuffer inBuf = in.getRaster().getDataBuffer();
+        Raster raster = in.getRaster();
+        DataBuffer inBuf = raster.getDataBuffer();
         if (!(inBuf instanceof DataBufferInt))
             throw new IllegalArgumentException(
                 "ScrimageNearestNeighbourScale requires an int-buffer BufferedImage, got "
                     + inBuf.getClass().getSimpleName() + " (image type " + in.getType() + ")");
 
+        DataBufferInt intBuf = (DataBufferInt) inBuf;
+        int[] pixels = intBuf.getData();
+
+        // Indexing the backing array directly is only valid when the raster
+        // maps 1:1 onto the buffer. A sub-image view (BufferedImage.getSubimage)
+        // shares the parent's buffer with a translated origin and the parent's
+        // scanline stride, so raw indexing would read the wrong pixels.
+        // Delegate those to the getRGB/setRGB based implementation, which
+        // handles any raster layout.
+        boolean mapsOneToOne = raster.getSampleModelTranslateX() == 0
+            && raster.getSampleModelTranslateY() == 0
+            && intBuf.getOffset() == 0
+            && pixels.length == in.getWidth() * in.getHeight();
+        if (!mapsOneToOne)
+            return new AwtNearestNeighbourScale().scale(in, w, h);
+
         BufferedImage out = new BufferedImage(w, h, in.getType());
-        int[] pixels = ((DataBufferInt) inBuf).getData();
         int[] newpixels = ((DataBufferInt) out.getRaster().getDataBuffer()).getData();
 
         int n = 0;

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ScrimageNearestNeighbourScaleSubRasterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/scaling/ScrimageNearestNeighbourScaleSubRasterTest.kt
@@ -1,0 +1,79 @@
+package com.sksamuel.scrimage.core.scaling
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import com.sksamuel.scrimage.scaling.ScrimageNearestNeighbourScale
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.image.BufferedImage
+
+/**
+ * Regression: ScrimageNearestNeighbourScale read the source raster's backing
+ * int[] assuming it maps 1:1 onto the image (offset 0, stride == width). A
+ * sub-image view created with BufferedImage.getSubimage shares the parent's
+ * buffer with a translated origin and the parent's scanline stride, but still
+ * reports TYPE_INT_ARGB, so wrapAwt(subimage).scaleTo(w, h, FastScale) read
+ * with the wrong stride/origin and produced wrong pixels.
+ *
+ * Sub-raster sources now delegate to the getRGB-based AwtNearestNeighbourScale.
+ * Scale ratios in these tests are exact powers of two so both implementations
+ * sample identical source pixels.
+ */
+class ScrimageNearestNeighbourScaleSubRasterTest : FunSpec({
+
+   fun parentWithCoordinateColors(): BufferedImage {
+      val parent = BufferedImage(8, 8, BufferedImage.TYPE_INT_ARGB)
+      for (y in 0 until 8) {
+         for (x in 0 until 8) {
+            // encode the coordinates in the pixel value so misreads are obvious
+            parent.setRGB(x, y, (0xFF shl 24) or (x shl 16) or (y shl 8) or 0x12)
+         }
+      }
+      return parent
+   }
+
+   test("scale on a subimage source matches scale on a defensive copy of the view") {
+      val parent = parentWithCoordinateColors()
+      val sub = parent.getSubimage(2, 2, 4, 4)
+      val copy = ImmutableImage.fromAwt(sub).awt()
+
+      val fromView = ScrimageNearestNeighbourScale().scale(sub, 2, 2)
+      val fromCopy = ScrimageNearestNeighbourScale().scale(copy, 2, 2)
+
+      for (y in 0 until 2) {
+         for (x in 0 until 2) {
+            fromView.getRGB(x, y) shouldBe fromCopy.getRGB(x, y)
+         }
+      }
+      // nearest neighbour with a 2:1 ratio samples view (0,0) = parent (2,2)
+      fromView.getRGB(0, 0) shouldBe ((0xFF shl 24) or (2 shl 16) or (2 shl 8) or 0x12)
+   }
+
+   test("scaleTo with FastScale on a subimage-backed image matches a defensive copy") {
+      val parent = parentWithCoordinateColors()
+      val sub = parent.getSubimage(2, 2, 4, 4)
+
+      val view = ImmutableImage.wrapAwt(sub)
+      val copy = ImmutableImage.fromAwt(sub)
+
+      val scaledView = view.scaleTo(2, 2, ScaleMethod.FastScale)
+      val scaledCopy = copy.scaleTo(2, 2, ScaleMethod.FastScale)
+
+      scaledView.pixels().map { it.argb } shouldBe scaledCopy.pixels().map { it.argb }
+   }
+
+   test("upscaling a subimage source matches upscaling a defensive copy") {
+      val parent = parentWithCoordinateColors()
+      val sub = parent.getSubimage(2, 2, 4, 4)
+      val copy = ImmutableImage.fromAwt(sub).awt()
+
+      val fromView = ScrimageNearestNeighbourScale().scale(sub, 8, 8)
+      val fromCopy = ScrimageNearestNeighbourScale().scale(copy, 8, 8)
+
+      for (y in 0 until 8) {
+         for (x in 0 until 8) {
+            fromView.getRGB(x, y) shouldBe fromCopy.getRGB(x, y)
+         }
+      }
+   }
+})


### PR DESCRIPTION
## Problem

`ScrimageNearestNeighbourScale` indexes the source raster's backing `int[]` directly, assuming the buffer maps 1:1 onto the image (offset 0, scanline stride == width, `data.length == width*height`). A sub-image view created with `BufferedImage.getSubimage(x, y, w, h)` shares the parent's buffer with a non-zero sample-model translation and the parent's scanline stride, while still reporting `TYPE_INT_ARGB` — so:

```java
ImmutableImage.wrapAwt(parent.getSubimage(2, 2, 4, 4)).scaleTo(2, 2, ScaleMethod.FastScale)
```

took the fast path in `ImmutableImage.scaleTo` and read with the wrong stride and origin, producing wrong pixels (verified: `ff000000` where the view's content was `ff000012`).

## Fix

The raw-array path is now only taken when the buffer maps 1:1 onto the raster (`sampleModelTranslateX/Y == 0`, buffer offset 0, `length == width*height`). Other layouts delegate to `AwtNearestNeighbourScale`, whose bulk `getRGB`/`setRGB` implementation handles any raster layout and any image type correctly. Delegation was chosen over reading into a re-strided array because `getRGB` returns packed ARGB, which is only safe to write raw back into a buffer whose native layout is ARGB — `setRGB` round-trips through the colour model for every type.

## Tests

New `ScrimageNearestNeighbourScaleSubRasterTest`: scaling a subimage source directly, via `scaleTo(..., FastScale)`, and upscaling, all produce the same pixels as scaling a defensive copy (`ImmutableImage.fromAwt`) of the same view; plus an explicit sampled-value assertion. Scale ratios are exact powers of two so both implementations sample identical source pixels. Full `scrimage-tests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)