### PR TITLE
docs: add scrimage-hash to quick start module list

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,7 +2,7 @@
 
 Scrimage is available on maven central. There are several modules.
 
-One is the `scrimage-core` library which is required. The others are `scrimage-filters`, `scrimage-formats-extra`, `scrimage-webp`.
+One is the `scrimage-core` library which is required. The others are `scrimage-filters`, `scrimage-formats-extra`, `scrimage-webp`, `scrimage-hash`.
 
 They are split into several modules because the image filters is a large jar, and most people just want the basic resize/scale/load/save functionality.
 


### PR DESCRIPTION
The quick start page lists the published modules but omits `scrimage-hash`, which is part of the build (see `settings.gradle.kts`) and published alongside the others. Added it to the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)