### PR TITLE
Fix PngWriter.MinCompression producing uncompressed PNGs

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/PngWriter.java
@@ -80,7 +80,12 @@ public class PngWriter implements ImageWriter {
                   break;
                default:
                   param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-                  param.setCompressionQuality((9 - compressionLevel) / 8.0f);
+                  // The JDK PNG writer maps quality back to a deflate level as
+                  // 9 - round(9 * quality), so dividing by 9 makes our level N a
+                  // deflate level N. The previous /8 mapping sent level 1 to
+                  // quality 1.0 = deflate level 0 (stored), so MinCompression
+                  // wrote fully uncompressed files, identical to NoCompression.
+                  param.setCompressionQuality((9 - compressionLevel) / 9.0f);
                   break;
             }
          }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/PngWriterTest.kt
@@ -6,9 +6,12 @@ import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.nio.PngReader
 import com.sksamuel.scrimage.nio.PngWriter
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 import org.apache.commons.io.IOUtils
+import java.awt.Color
 
 class PngWriterTest : WordSpec({
 
@@ -54,6 +57,26 @@ class PngWriterTest : WordSpec({
       "valid boundary compression levels 0 and 9 are accepted" {
          original.bytes(PngWriter(0)).size shouldBe original.bytes(PngWriter.NoCompression).size
          original.bytes(PngWriter(9)).size shouldBe original.bytes(PngWriter.MaxCompression).size
+      }
+      // Regression test: the level -> quality mapping divided by 8, so level 1 mapped to
+      // quality 1.0, which the JDK PNG writer turns back into deflate level 0 (stored) —
+      // MinCompression wrote fully uncompressed files, identical to NoCompression.
+      "MinCompression actually compresses, unlike NoCompression" {
+         val image = ImmutableImage.filled(100, 100, Color.RED)
+         val none = image.bytes(PngWriter.NoCompression).size
+         val min = image.bytes(PngWriter.MinCompression).size
+         val max = image.bytes(PngWriter.MaxCompression).size
+         // a single colour image is highly compressible: even deflate level 1
+         // must beat an uncompressed file by an order of magnitude
+         (min * 10) shouldBeLessThan none
+         max shouldBeLessThanOrEqual min
+      }
+      "every explicit compression level compresses relative to NoCompression" {
+         val image = ImmutableImage.filled(100, 100, Color.RED)
+         val none = image.bytes(PngWriter.NoCompression).size
+         for (level in 1..9) {
+            image.bytes(PngWriter(level)).size shouldBeLessThan none
+         }
       }
    }
 


### PR DESCRIPTION
## Bug

`PngWriter` maps its 0-9 compression level to an ImageIO quality with `(9 - compressionLevel) / 8.0f`. For level 1 (`PngWriter.MinCompression`) that yields quality 1.0, and the JDK PNG writer converts quality back to a deflate level as `9 - Math.round(9 * quality)` — i.e. deflate level 0, which stores the data uncompressed.

So `MinCompression` wrote fully uncompressed files, identical in size to `NoCompression`: a 20x20 single-colour image encodes to 1688 bytes at levels 0 **and** 1, vs 96 bytes at level 5.

## Fix

Divide by 9 instead: `(9 - compressionLevel) / 9.0f`. Writer level N then round-trips to exactly deflate level N (level 1 → quality 8/9 → deflate 1; level 9 → quality 0 → deflate 9). Level 0 keeps its existing `MODE_DISABLED` handling, unchanged.

## Tests

Two new regression tests in `PngWriterTest`:
- `MinCompression` output for a compressible (single-colour) image must be an order of magnitude smaller than `NoCompression`, with `MaxCompression` no larger than `MinCompression`
- every explicit level 1-9 must produce output smaller than `NoCompression`

Both fail before the fix and pass after. The existing pixel-based compression round-trip tests still pass, and full `scrimage-tests` suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)