### PR TITLE
Fix fit/max/bound/cover crashing on extreme aspect ratios

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/DimensionTools.java
@@ -64,9 +64,12 @@ public class DimensionTools {
       // 60000 × 50000 source against a 60000 maxWidth produces
       // 60000 * 50000 = 3e9, overflowing int and flipping the sign,
       // selecting the wrong scale branch).
+      // Clamp the derived dimension to at least 1: for aspect ratios more extreme than
+      // the target's (e.g. a 1x1000 source fitted into 100x100) the division floors to 0,
+      // which is not a valid image dimension (mirrors the clamps in resizeTo*/scaleTo*).
       if ((long) maxWidth * source.getY() < (long) maxHeight * source.getX())
-         return new Dimension(maxWidth, (int) ((long) source.getY() * maxWidth / source.getX()));
+         return new Dimension(maxWidth, Math.max(1, (int) ((long) source.getY() * maxWidth / source.getX())));
       else
-         return new Dimension((int) ((long) source.getX() * maxHeight / source.getY()), maxHeight);
+         return new Dimension(Math.max(1, (int) ((long) source.getX() * maxHeight / source.getY())), maxHeight);
    }
 }

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1508,6 +1508,14 @@ public class ImmutableImage extends MutableImage {
     * @return a new Image resampled to the given target width and height
     */
    private ImmutableImage resample(ResampleFilter filter, int targetWidth, int targetHeight) {
+      // ResampleOp rejects targets smaller than 3x3 and sources smaller than the filter
+      // support — geometries that arise from extreme aspect ratios (e.g. fit/max/bound
+      // or cover on a 1x1000 image). Fall back to nearest-neighbour instead of throwing.
+      // canResample mirrors doFilter's exact validation, so this only triggers where
+      // resampling previously crashed.
+      if (!ResampleOp.canResample(filter, width, height, targetWidth, targetHeight)) {
+         return scaleTo(targetWidth, targetHeight, ScaleMethod.FastScale);
+      }
       ResampleOp resampleOp = new ResampleOp(filter, targetWidth, targetHeight);
       if (!awt().getColorModel().hasAlpha())
          return op(resampleOp);

--- a/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
+++ b/scrimage-core/src/main/java/thirdparty/mortennobel/ResampleOp.java
@@ -114,6 +114,32 @@ public class ResampleOp extends AdvancedResizeOp {
     return out;
   }
 
+  /**
+   * The maximum number of source contributors per destination pixel for the given axis
+   * geometry. Extracted from createSubSampling so canResample can share the exact formula.
+   */
+  private static int numContributors(ResampleFilter filter, int srcSize, int dstSize) {
+    float scale = (float) dstSize / (float) srcSize;
+    final float fwidth = filter.getSamplingRadius();
+    if (scale < 1.0f) {
+      return (int) Math.ceil((fwidth / scale) * 2.0f) + 2;
+    } else {
+      return (int) Math.ceil(fwidth * 2.0f) + 2;
+    }
+  }
+
+  /**
+   * Returns true if doFilter can resample the given geometry: the target must be at
+   * least 3x3 and the source must be at least as large as the filter support on each
+   * axis. Callers can use this to fall back to another scaler instead of triggering
+   * the RuntimeExceptions thrown by doFilter.
+   */
+  public static boolean canResample(ResampleFilter filter, int srcWidth, int srcHeight, int dstWidth, int dstHeight) {
+    if (dstWidth < 3 || dstHeight < 3) return false;
+    return srcWidth >= numContributors(filter, srcWidth, dstWidth)
+      && srcHeight >= numContributors(filter, srcHeight, dstHeight);
+  }
+
   static SubSamplingData createSubSampling(ResampleFilter filter,
                                            int srcSize,
                                            int dstSize) {
@@ -134,7 +160,7 @@ public class ResampleOp extends AdvancedResizeOp {
       // contributors. The previous "(int)(width*2 + 2)" pad truncated and was one short for certain
       // scale factors (e.g. resampling a 121px axis down to 3px), letting the final contributor write
       // into the next destination row/column's segment and corrupting both. Size from the true window.
-      numContributors = (int) Math.ceil(width * 2.0f) + 2;
+      numContributors = numContributors(filter, srcSize, dstSize);
       arrWeight = new float[dstSize * numContributors];
       arrPixel = new int[dstSize * numContributors];
 
@@ -186,7 +212,7 @@ public class ResampleOp extends AdvancedResizeOp {
       // See the downscale branch: the window [floor(center-fwidth), ceil(center+fwidth)] can hold up
       // to ceil(2*fwidth) + 2 contributors, so size the segment to that to avoid spilling into the
       // next destination row/column.
-      numContributors = (int) Math.ceil(fwidth * 2.0f) + 2;
+      numContributors = numContributors(filter, srcSize, dstSize);
       arrWeight = new float[dstSize * numContributors];
       arrPixel = new int[dstSize * numContributors];
       //

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ExtremeAspectRatioTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ExtremeAspectRatioTest.kt
@@ -1,0 +1,63 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.ScaleMethod
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression tests for operations on images with extreme aspect ratios.
+ *
+ * Two distinct failures used to crash these:
+ *  - DimensionTools.dimensionsToFit floored the derived dimension to 0 (a 1x1000 image
+ *    fitted into 100x100 produced a 0x100 target), so fit/max/bound threw
+ *    "Error doing rescale. Target size was 0x100 but must be at least 3x3."
+ *  - ResampleOp (the Bicubic/Bilinear/BSpline/Lanczos3 scaler) rejects targets smaller
+ *    than 3x3 and sources smaller than the filter support, so even valid extreme targets
+ *    (1x100) or sources (1px wide) crashed. resample() now falls back to nearest-neighbour
+ *    for exactly those geometries.
+ */
+class ExtremeAspectRatioTest : FunSpec({
+
+   val tall = ImmutableImage.create(1, 1000).fill(java.awt.Color.RED)
+
+   test("fit handles extreme aspect ratios") {
+      val fitted = tall.fit(100, 100)
+      fitted.width shouldBe 100
+      fitted.height shouldBe 100
+   }
+
+   test("max handles extreme aspect ratios") {
+      val maxed = tall.max(100, 100)
+      maxed.width shouldBe 1
+      maxed.height shouldBe 100
+   }
+
+   test("bound handles extreme aspect ratios") {
+      val bounded = tall.bound(100, 100)
+      bounded.width shouldBe 1
+      bounded.height shouldBe 100
+   }
+
+   test("cover handles sources narrower than the resample filter support") {
+      val covered = tall.cover(100, 100)
+      covered.width shouldBe 100
+      covered.height shouldBe 100
+      covered.pixel(50, 50).toARGBInt() shouldBe 0xFFFF0000.toInt()
+   }
+
+   test("scaleToWidth(1) does not throw for resample scale methods") {
+      val image = ImmutableImage.create(100, 100).fill(java.awt.Color.BLUE)
+      val scaled = image.scaleToWidth(1)
+      scaled.width shouldBe 1
+      scaled.height shouldBe 1
+   }
+
+   test("scale to tiny targets does not throw for resample scale methods") {
+      val image = ImmutableImage.create(100, 100).fill(java.awt.Color.BLUE)
+      val scaled = image.scale(0.02, ScaleMethod.Bicubic)
+      scaled.width shouldBe 2
+      scaled.height shouldBe 2
+      scaled.pixel(1, 1).toARGBInt() shouldBe 0xFF0000FF.toInt()
+   }
+})


### PR DESCRIPTION
## Problem

Operations on images with extreme aspect ratios crash. On a 1x1000 image:

```kotlin
tall.fit(100, 100)   // RuntimeException: Error doing rescale. Target size was 0x100 but must be at least 3x3.
tall.max(100, 100)   // same
tall.cover(100, 100) // RuntimeException: Error doing rescale. Source size was 1x1000 but must be at least 6x6
```

Two independent causes:

1. **`DimensionTools.dimensionsToFit` floors to 0** when the source aspect ratio is more extreme than the target's. This is the same bug class as #710 (`resizeTo*`) and #725 (`scaleTo*`), which didn't cover the `dimensionsToFit` path used by fit/max/bound.
2. **ResampleOp rejects degenerate geometries** — targets < 3x3 and sources smaller than the filter support — so even with a clamped 1x100 target (or a 1px-wide source into `cover`), the default Bicubic scaler still throws. `scaleToWidth(1)` and `scale(0.02)` hit this too, even after #725.

## Fix

- Clamp both computed dimensions in `dimensionsToFit` to ≥ 1.
- Add `ResampleOp.canResample(filter, srcW, srcH, dstW, dstH)`, sharing the exact contributor formula `doFilter` validates with (extracted into a common helper, no duplication), and have `ImmutableImage.resample()` fall back to nearest-neighbour when it returns false.

Because `canResample` mirrors the validation exactly, the fallback triggers **only where resampling previously crashed** — output of all currently-working calls is unchanged.

## Testing

New `ExtremeAspectRatioTest`: fit/max/bound/cover on a 1x1000 image, `scaleToWidth(1)`, `scale(0.02)` — all produce correct dimensions and pixels. Full `scrimage-core`, `scrimage-filters` and `scrimage-tests` suites pass (golden images unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)