### PR TITLE
Fix ImageIOReader disposing caller-supplied readers, making withJavaxImageReaders loaders single-use

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/ImageIOReader.java
@@ -26,7 +26,10 @@ public class ImageIOReader implements ImageReader {
       this.readers = readers;
    }
 
-   private ImmutableImage tryLoad(javax.imageio.ImageReader reader, ImageInputStream iis, Rectangle rectangle) throws IOException {
+   private ImmutableImage tryLoad(javax.imageio.ImageReader reader,
+                                  ImageInputStream iis,
+                                  Rectangle rectangle,
+                                  boolean ownsReader) throws IOException {
       try {
          // Rewind the stream to the start before each reader attempt. The same
          // ImageInputStream is reused across multiple readers in read(...)'s
@@ -66,7 +69,18 @@ public class ImageIOReader implements ImageReader {
          //  The contract for javax.imageio.ImageReader is that you must call reader.dispose() when done.
          //  That method triggers the JNI dispose call which runs the corresponding free() on those native structs.
          //  Without it, the memory is permanently leaked for the lifetime of the JVM process.
-         reader.dispose();
+         //
+         //  However, we must only dispose readers that we created ourselves (via ImageIO.getImageReaders,
+         //  which mints fresh instances on every call). Caller-supplied readers are reused across read()
+         //  calls, and a disposed reader throws IllegalStateException("Attempting to use reader after
+         //  dispose()") on any subsequent use — making the loader single-use. For those we reset() instead,
+         //  which returns the reader to its initial state (releasing the input stream reference) while
+         //  keeping it usable; releasing its native resources is the caller's responsibility.
+         if (ownsReader) {
+            reader.dispose();
+         } else {
+            reader.reset();
+         }
       }
    }
 
@@ -81,8 +95,12 @@ public class ImageIOReader implements ImageReader {
          throw new IOException("No ImageInputStream supported this image format");
 
       try {
+         // Readers minted by ImageIO.getImageReaders are fresh instances owned by us and must be
+         // disposed after use. Caller-supplied readers are owned by the caller and are reused on
+         // every read() call, so they must not be disposed here.
+         boolean ownsReaders = readers.isEmpty();
          Iterator<javax.imageio.ImageReader> iter;
-         if (readers.isEmpty())
+         if (ownsReaders)
             iter = ImageIO.getImageReaders(iis);
          else
             iter = readers.iterator();
@@ -90,7 +108,7 @@ public class ImageIOReader implements ImageReader {
          List<String> attempts = new ArrayList<>();
          while (iter.hasNext()) {
             try {
-               return tryLoad(iter.next(), iis, rectangle);
+               return tryLoad(iter.next(), iis, rectangle, ownsReaders);
             } catch (Exception e) {
                attempts.add(e.getMessage());
             }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImageIOReaderTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/ImageIOReaderTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.awt.Rectangle
+import javax.imageio.ImageIO
 
 /**
  * Pin-down tests for ImageIOReader after dropping the redundant
@@ -43,6 +44,37 @@ class ImageIOReaderTest : FunSpec({
       sub.height shouldBe 10
       // The sub-region's top-left pixel should match the full image's top-left.
       sub.pixel(0, 0).argb shouldBe full.pixel(0, 0).argb
+   }
+
+   test("loader with caller-supplied javax readers is reusable across multiple reads") {
+      // Caller-supplied readers are reused on every read() call, so they must not be
+      // disposed after a read. Previously the first read disposed them, making the
+      // second read fail with "Attempting to use reader after dispose()".
+      val loader = ImmutableImage.loader()
+         .withJavaxImageReaders(listOf(ImageIO.getImageReadersByFormatName("jpeg").next()))
+      val first = loader.fromBytes(jpegBytes)
+      val second = loader.fromBytes(jpegBytes)
+      first.width shouldBeGreaterThan 0
+      second.width shouldBe first.width
+      second.height shouldBe first.height
+      second.pixel(0, 0).argb shouldBe first.pixel(0, 0).argb
+   }
+
+   test("ImageIOReader with caller-supplied readers is reusable across multiple reads") {
+      val reader = ImageIOReader(listOf(ImageIO.getImageReadersByFormatName("jpeg").next()))
+      val first = reader.read(jpegBytes, null)
+      val second = reader.read(jpegBytes, null)
+      second.width shouldBe first.width
+      second.height shouldBe first.height
+   }
+
+   test("default loader is reusable across multiple reads") {
+      // The default path mints fresh readers from ImageIO.getImageReaders per call and
+      // disposes them after each read; repeated loads must keep working.
+      val loader = ImmutableImage.loader()
+      repeat(3) {
+         loader.fromBytes(jpegBytes).width shouldBeGreaterThan 0
+      }
    }
 
    test("read throws on null bytes") {


### PR DESCRIPTION
## Problem

`ImageIOReader.tryLoad` disposes the `javax.imageio.ImageReader` in its `finally` block. That is correct for the default path, where `ImageIO.getImageReaders(iis)` mints fresh reader instances on every `read()` call — disposing them releases native decoder memory that the GC cannot see.

But when the `ImageIOReader` is constructed with a caller-supplied `List<javax.imageio.ImageReader>` (public constructor, also exposed via `ImmutableImageLoader.withJavaxImageReaders(readers)`), the **same** reader instances are reused on every `read()` call. Disposing them after the first read made the loader single-use:

```kotlin
val loader = ImmutableImage.loader()
   .withJavaxImageReaders(listOf(ImageIO.getImageReadersByFormatName("jpeg").next()))
loader.fromBytes(jpg) // ok
loader.fromBytes(jpg) // ImageParseException: "Attempting to use reader after dispose()"
```

## Fix

Track ownership. Readers obtained internally from `ImageIO.getImageReaders` are disposed exactly as before. Caller-supplied readers are `reset()` instead, returning them to their initial state (releasing the input stream reference) while keeping them usable; releasing their native resources remains the caller's responsibility, as it was before scrimage started disposing readers at all.

## Tests

New tests in `ImageIOReaderTest`:
- a loader built via `withJavaxImageReaders` can load the same image twice (fails with "Attempting to use reader after dispose()" before this fix)
- a raw `ImageIOReader(readers)` can be used for two consecutive reads (fails before this fix)
- the default loader remains reusable across repeated loads (pins the unchanged default path)

Full `scrimage-tests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)