### PR TITLE
Fix StreamingGifWriter per-frame overrides leaking into later frames and corrupting compressed GIFs

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/nio/StreamingGifWriter.java
@@ -158,6 +158,28 @@ public class StreamingGifWriter extends AbstractGifWriter {
 
          @Override
          public GifStream writeFrame(ImmutableImage image) throws IOException {
+            return writeFrame(image, null, null);
+         }
+
+         @Override
+         public GifStream writeFrame(ImmutableImage image, Duration delay) throws IOException {
+            return writeFrame(image, delay, null);
+         }
+
+         @Override
+         public GifStream writeFrame(ImmutableImage image, DisposeMethod disposeMethod) throws IOException {
+            return writeFrame(image, null, disposeMethod);
+         }
+
+         @Override
+         public GifStream writeFrame(ImmutableImage image, Duration delay, DisposeMethod disposalMethod) throws IOException {
+            // All overloads funnel through here so that per-frame delay/dispose overrides and the
+            // compressed transparency-diff always compose. Previously the override overloads wrote the
+            // frame directly, which (a) leaked the overridden GraphicControlExtension attributes into
+            // every later frame (the shared imageMetaData was mutated and never restored), and (b) in
+            // compressed mode skipped the diff and the `last` snapshot update, so the next plain frame
+            // diffed against a stale image and zeroed pixels that should have been visible.
+            setGraphicControlExtensionAttributes(delay, disposalMethod);
             if (compressed && last != null) {
                // Copy the input so we don't mutate the caller's image when zero-filling
                // pixels that match the previous frame (the diff step below).
@@ -199,33 +221,18 @@ public class StreamingGifWriter extends AbstractGifWriter {
             return this;
          }
 
-         @Override
-         public GifStream writeFrame(ImmutableImage image, Duration delay) throws IOException {
-            return writeFrame(image, delay, null);
-         }
-
-         @Override
-         public GifStream writeFrame(ImmutableImage image, DisposeMethod disposeMethod) throws IOException {
-            return writeFrame(image, null, disposeMethod);
-         }
-
-         @Override
-         public GifStream writeFrame(ImmutableImage image, Duration delay, DisposeMethod disposalMethod) throws IOException {
-            setOverriddenGraphicControlExtensionAttributes(delay, disposalMethod);
-            writer.writeToSequence(new IIOImage(image.awt(), null, imageMetaData), imageWriteParam);
-            return this;
-         }
-
-         private void setOverriddenGraphicControlExtensionAttributes(Duration delay, DisposeMethod disposeMethod)
+         private void setGraphicControlExtensionAttributes(Duration delay, DisposeMethod disposeMethod)
             throws IIOInvalidTreeException {
+            // Both attributes are always written, falling back to the writer's defaults when no
+            // override is given. The shared imageMetaData instance carries the attributes of the
+            // previously written frame, so writing only the non-null overrides would let a
+            // per-frame override leak into every subsequent frame.
             IIOMetadataNode rootOverride = (IIOMetadataNode) imageMetaData.getAsTree(metaFormatName);
             IIOMetadataNode graphicsControlExtensionNodeOverride = getNode(rootOverride, "GraphicControlExtension");
-            if (delay != null) {
-               graphicsControlExtensionNodeOverride.setAttribute("delayTime", (delay.toMillis() / 10L) + "");
-            }
-            if (disposeMethod != null) {
-               graphicsControlExtensionNodeOverride.setAttribute("disposalMethod", disposeMethod.getDisposeMethodValue());
-            }
+            Duration effectiveDelay = delay == null ? frameDelay : delay;
+            graphicsControlExtensionNodeOverride.setAttribute("delayTime", (effectiveDelay.toMillis() / 10L) + "");
+            DisposeMethod effectiveDispose = disposeMethod == null ? DisposeMethod.NONE : disposeMethod;
+            graphicsControlExtensionNodeOverride.setAttribute("disposalMethod", effectiveDispose.getDisposeMethodValue());
             imageMetaData.setFromTree(metaFormatName, rootOverride);
          }
 

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/nio/StreamingGifWriterTest.kt
@@ -2,6 +2,7 @@
 
 package com.sksamuel.scrimage.core.nio
 
+import com.sksamuel.scrimage.DisposeMethod
 import com.sksamuel.scrimage.ImmutableImage
 import com.sksamuel.scrimage.color.RGBColor
 import com.sksamuel.scrimage.nio.AnimatedGifReader
@@ -12,6 +13,7 @@ import io.kotest.core.spec.style.wordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.apache.commons.io.IOUtils
+import java.awt.Color
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferByte
 import java.awt.image.DataBufferInt
@@ -203,6 +205,71 @@ class StreamingGifWriterTest : WordSpec({
          decoded.getFrame(0).height shouldBe h
          decoded.getFrame(1).width shouldBe w
          decoded.getFrame(1).height shouldBe h
+      }
+
+      "not leak a per-frame delay override into later frames" {
+         // The delay overload used to mutate the shared frame metadata without ever
+         // restoring the default, so every frame after an override inherited it:
+         // 2000/100/100 instead of 2000/100/2000.
+         val writer = StreamingGifWriter().withFrameDelay(Duration.ofSeconds(2))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(bird)
+         stream.writeFrame(bird.flipX(), Duration.ofMillis(100))
+         stream.writeFrame(bird.flipY())
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 3
+         decoded.getDelay(0) shouldBe Duration.ofMillis(2000)
+         decoded.getDelay(1) shouldBe Duration.ofMillis(100)
+         decoded.getDelay(2) shouldBe Duration.ofMillis(2000)
+      }
+
+      "not leak a per-frame dispose method override into later frames" {
+         // Same leak as the delay override: a dispose method override stuck for
+         // all subsequent frames instead of reverting to the default "none".
+         val writer = StreamingGifWriter()
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(bird, DisposeMethod.RESTORE_TO_BACKGROUND_COLOR)
+         stream.writeFrame(bird.flipX())
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 2
+         decoded.getDisposeMethod(0) shouldBe DisposeMethod.RESTORE_TO_BACKGROUND_COLOR
+         // GifSequenceReader normalises the discretionary disposal code 0 ("none") to
+         // 1 ("doNotDispose"), so a default frame decodes as DO_NOT_DISPOSE. Before the
+         // fix this frame decoded as RESTORE_TO_BACKGROUND_COLOR, leaked from frame 0.
+         decoded.getDisposeMethod(1) shouldBe DisposeMethod.DO_NOT_DISPOSE
+      }
+
+      "apply the compressed diff and update the last-frame snapshot on override overloads" {
+         // In compressed mode the delay/dispose overloads used to write the frame
+         // directly, skipping the transparency diff and the `last` snapshot update.
+         // The next plain writeFrame then diffed against a stale frame: for
+         // red/blue(50ms)/red the third frame's pixels all matched the stale red
+         // snapshot, were zeroed, and the decoder showed blue where red belonged.
+         val red = ImmutableImage.filled(20, 20, Color.RED, BufferedImage.TYPE_INT_ARGB)
+         val blue = ImmutableImage.filled(20, 20, Color.BLUE, BufferedImage.TYPE_INT_ARGB)
+
+         val writer = StreamingGifWriter().withCompression(true).withFrameDelay(Duration.ofSeconds(2))
+         val output = ByteArrayOutputStream()
+         val stream = writer.prepareStream(output, BufferedImage.TYPE_INT_ARGB)
+         stream.writeFrame(red)
+         stream.writeFrame(blue, Duration.ofMillis(50))
+         stream.writeFrame(red)
+         stream.close()
+
+         val decoded = AnimatedGifReader.read(ImageSource.of(output.toByteArray()))
+         decoded.frameCount shouldBe 3
+         decoded.getFrame(0).pixel(10, 10).argb shouldBe Color.RED.rgb
+         decoded.getFrame(1).pixel(10, 10).argb shouldBe Color.BLUE.rgb
+         decoded.getFrame(2).pixel(10, 10).argb shouldBe Color.RED.rgb
+         decoded.getDelay(0) shouldBe Duration.ofMillis(2000)
+         decoded.getDelay(1) shouldBe Duration.ofMillis(50)
+         decoded.getDelay(2) shouldBe Duration.ofMillis(2000)
       }
 
       "not mutate caller's ImmutableImage in compressed mode" {


### PR DESCRIPTION
## Problems

Two related bugs in the `writeFrame(image, delay, disposeMethod)` overloads of `StreamingGifWriter`:

**1. Overrides leak into every later frame.** `setOverriddenGraphicControlExtensionAttributes` mutated the *shared* `imageMetaData` via `setFromTree` and never restored the defaults. With a writer configured for a 2s default delay:

```kotlin
stream.writeFrame(f1)
stream.writeFrame(f2, Duration.ofMillis(100))
stream.writeFrame(f3)
```

decoded delays were **2000/100/100** — f3 wrongly inherited the 100ms override. The same leak applied to the dispose method: `writeFrame(f1, RESTORE_TO_BACKGROUND_COLOR)` followed by `writeFrame(f2)` gave f2 `restoreToBackgroundColor` too.

**2. Compressed mode corruption.** With `withCompression(true)`, the override overloads wrote the frame directly, skipping the transparency diff and never updating the `last` frame snapshot. The next plain `writeFrame` then diffed against a stale frame and zeroed pixels that should have been visible: writing red, blue (with a 50ms override), red decoded frame 2 as **blue** instead of red — every red pixel matched the stale red snapshot and was zeroed to transparent.

## Fix

All four `writeFrame` overloads now funnel through a single code path that:

- applies the compressed diff and updates `last` regardless of overrides, and
- always sets **both** `GraphicControlExtension` attributes per frame — `delayTime` defaulting to the writer's configured `frameDelay` when the override is null, `disposalMethod` defaulting to `"none"` when null — so an override applies only to its own frame.

## Tests

New tests in `StreamingGifWriterTest` (all three fail before the fix):

- delay override does not leak: three-frame case decodes as 2000/100/2000
- dispose override does not leak: `RESTORE_TO_BACKGROUND_COLOR` then default decodes as `RESTORE_TO_BACKGROUND_COLOR` / `DO_NOT_DISPOSE` (the reader normalises the discretionary disposal code 0 "none" to "doNotDispose", so that is the observable default)
- compressed red/blue(50ms)/red round-trips with correct centre pixels and delays

The existing golden-byte tests ("write to memory", compressed "fallingroof") and the dispose-method round-trip suites still pass, confirming byte-identical output on the default path. Full `scrimage-tests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)