### PR TITLE
Add fail-fast validation for the end parameter in VignetteFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/VignetteFilter.java
@@ -43,6 +43,13 @@ public class VignetteFilter implements Filter {
         if (!(blur >= 0 && blur <= 1)) {
             throw new IllegalArgumentException("blur must be in [0, 1]; got " + blur);
         }
+        // end scales the radius of the RadialGradientPaint (image.radius() * end),
+        // which requires a radius strictly greater than zero. Without this check,
+        // end <= 0 surfaced at apply time as a cryptic "Radius must be greater
+        // than zero" from RadialGradientPaint.
+        if (!(end > 0 && end <= 1)) {
+            throw new IllegalArgumentException("end must be in (0, 1]; got " + end);
+        }
         this.start = start;
         this.end = end;
         this.blur = blur;

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VignetteFilterRangeTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/VignetteFilterRangeTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.scrimage.filter
 
+import com.sksamuel.scrimage.ImmutableImage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldContain
@@ -13,6 +14,11 @@ class VignetteFilterRangeTest : FunSpec({
    // about gradient fractions; out-of-range blur was passed to
    // GaussianBlurFilter as a negative radius. Now both reject up front
    // with a clear IllegalArgumentException naming the offending value.
+   //
+   // end was not validated at all: end <= 0 surfaced at apply time as a
+   // cryptic "Radius must be greater than zero" from RadialGradientPaint
+   // (the gradient radius is image.radius() * end). It now fails fast in
+   // the constructor too, with (0, 1] as the valid range.
 
    test("constructor rejects start below 0") {
       val ex = shouldThrow<IllegalArgumentException> {
@@ -50,5 +56,36 @@ class VignetteFilterRangeTest : FunSpec({
       // Both 0 and 1 are valid (inclusive bounds).
       VignetteFilter(0f, 0.95f, 0f, Color.BLACK)
       VignetteFilter(1f, 0.95f, 1f, Color.BLACK)
+   }
+
+   test("constructor rejects end of 0") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(0.85f, 0f, 0.3f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("end")
+      ex.message!!.shouldContain("0.0")
+   }
+
+   test("constructor rejects negative end") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(0.85f, -0.5f, 0.3f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("end")
+      ex.message!!.shouldContain("-0.5")
+   }
+
+   test("constructor rejects end above 1") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         VignetteFilter(0.85f, 1.5f, 0.3f, Color.BLACK)
+      }
+      ex.message!!.shouldContain("end")
+      ex.message!!.shouldContain("1.5")
+   }
+
+   test("default construction and valid end values still apply cleanly") {
+      val image = ImmutableImage.create(32, 32)
+      image.filter(VignetteFilter())
+      image.filter(VignetteFilter(0.85f, 0.95f, 0.3f, Color.BLACK))
+      image.filter(VignetteFilter(0.5f, 1f, 0.2f, Color.RED)) // end = 1 boundary
    }
 })


### PR DESCRIPTION
## Summary

`VignetteFilter`'s constructor validates `start` and `blur` but not `end`. Passing `end <= 0` only blew up later, at apply time, as a cryptic `IllegalArgumentException: Radius must be greater than zero` thrown from `RadialGradientPaint` — the gradient radius is `image.radius() * end`, so the invalid argument surfaced far from where it was supplied.

This adds fail-fast constructor validation for `end`, in the same style and message format as the existing `start`/`blur` checks. The valid range is `(0, 1]`: `end` must be strictly positive (a zero radius is rejected by `RadialGradientPaint`) and, matching the `[0, 1]` convention of the other parameters, at most 1. All existing in-repo usages (defaults, `SummerFilter`, `NashvilleFilter`, examples) use `end` values of 0.95–1.

## Tests

Extended `VignetteFilterRangeTest`:
- constructor rejects `end` of 0, negative `end`, and `end > 1`, each with a message naming the parameter and the offending value
- default construction and valid values (including the `end = 1` boundary) still construct and apply cleanly to an image

Full `:scrimage-filters:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)