### PR TITLE
Reject negative radius in GaussianBlurFilter

### DIFF
--- a/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GaussianBlurFilter.java
+++ b/scrimage-filters/src/main/java/com/sksamuel/scrimage/filter/GaussianBlurFilter.java
@@ -22,6 +22,13 @@ public class GaussianBlurFilter extends BufferedOpFilter {
     private final int radius;
 
     public GaussianBlurFilter(int radius) {
+        // A negative radius only blew up at apply time, as a cryptic
+        // NegativeArraySizeException from GaussianFilter.makeKernel.
+        // Fail fast with a clear message instead. Radius 0 is a safe
+        // no-op and remains allowed.
+        if (radius < 0) {
+            throw new IllegalArgumentException("radius must be >= 0; got " + radius);
+        }
         this.radius = radius;
     }
 

--- a/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GaussianBlurFilterValidationTest.kt
+++ b/scrimage-filters/src/test/kotlin/com/sksamuel/scrimage/filter/GaussianBlurFilterValidationTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.scrimage.filter
+
+import com.sksamuel.scrimage.ImmutableImage
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class GaussianBlurFilterValidationTest : FunSpec({
+
+   // Regression: a negative radius was accepted by the constructor and only
+   // blew up at apply time, as a cryptic NegativeArraySizeException from
+   // thirdparty GaussianFilter.makeKernel. It now fails fast in the
+   // constructor with a clear IllegalArgumentException. Radius 0 is a safe
+   // no-op and remains allowed.
+
+   test("constructor rejects negative radius") {
+      val ex = shouldThrow<IllegalArgumentException> {
+         GaussianBlurFilter(-1)
+      }
+      ex.message!!.shouldContain("radius")
+      ex.message!!.shouldContain("-1")
+      shouldThrow<IllegalArgumentException> {
+         GaussianBlurFilter(-10)
+      }
+   }
+
+   test("radius 0 is a no-op and still applies cleanly") {
+      val image = ImmutableImage.create(16, 16)
+      image.filter(GaussianBlurFilter(0))
+   }
+
+   test("positive radius and default construction still apply cleanly") {
+      val image = ImmutableImage.create(16, 16)
+      image.filter(GaussianBlurFilter())
+      image.filter(GaussianBlurFilter(3))
+   }
+})


### PR DESCRIPTION
## Summary

`GaussianBlurFilter` accepted any radius at construction time; a negative radius only blew up later when the filter was applied, as a cryptic `NegativeArraySizeException` thrown from thirdparty `GaussianFilter.makeKernel` — far from where the bad value was supplied.

The constructor now validates `radius >= 0` and throws a clear `IllegalArgumentException` naming the offending value. Radius 0 is a safe no-op in `GaussianFilter` and remains allowed, as do all positive values.

## Tests

New `GaussianBlurFilterValidationTest`:
- negative radius throws `IllegalArgumentException` at construction, with a message naming the parameter and value
- radius 0 still constructs and applies cleanly (no-op)
- positive radius and the default constructor still construct and apply cleanly

Full `:scrimage-filters:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)