### PR TITLE
Add invert(), gamma() and no-arg toGrayscale() to ImmutableImage

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -568,6 +568,55 @@ public class ImmutableImage extends MutableImage {
    }
 
    /**
+    * Returns a new image with the colours inverted (photographic negative). Each of the red, green
+    * and blue channels is replaced by 255 minus its value; the alpha channel is left unchanged.
+    *
+    * @return a new inverted Image
+    */
+   public ImmutableImage invert() {
+      ImmutableImage target = copy();
+      int w = target.width;
+      int h = target.height;
+      int[] argb = target.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         // keep the alpha byte, invert the low 24 (RGB) bits
+         argb[i] = (argb[i] & 0xFF000000) | (~argb[i] & 0x00FFFFFF);
+      }
+      target.awt().setRGB(0, 0, w, h, argb, 0, w);
+      return target;
+   }
+
+   /**
+    * Returns a new image with gamma correction applied to the red, green and blue channels.
+    * The alpha channel is left unchanged. A gamma of 1.0 leaves the image unchanged, values
+    * greater than 1.0 brighten the midtones and values below 1.0 darken them.
+    *
+    * @param gamma the gamma level to apply to all RGB channels
+    * @return a new gamma-corrected Image
+    */
+   public ImmutableImage gamma(double gamma) {
+      int[] table = new int[256];
+      for (int i = 0; i < 256; i++) {
+         int v = (int) (255.0 * Math.pow(i / 255.0, 1.0 / gamma) + 0.5);
+         table[i] = Math.min(v, 255);
+      }
+      ImmutableImage target = copy();
+      int w = target.width;
+      int h = target.height;
+      int[] argb = target.awt().getRGB(0, 0, w, h, null, 0, w);
+      for (int i = 0; i < argb.length; i++) {
+         int p = argb[i];
+         int a = p & 0xFF000000;
+         int r = table[(p >> 16) & 0xFF];
+         int g = table[(p >> 8) & 0xFF];
+         int b = table[p & 0xFF];
+         argb[i] = a | (r << 16) | (g << 8) | b;
+      }
+      target.awt().setRGB(0, 0, w, h, argb, 0, w);
+      return target;
+   }
+
+   /**
     * Convenience method for cover(targetWidth, targetHeight, ScaleMethod.Bicubic, Position.Center)
     *
     * @return a new Image scaled to cover the given dimensions
@@ -1977,6 +2026,17 @@ public class ImmutableImage extends MutableImage {
 
    public ImmutableImage transform(Transform transform) throws IOException {
       return transform.apply(this);
+   }
+
+   /**
+    * Returns a grayscale copy of this image using the default {@link GrayscaleMethod#LUMA}
+    * method (Rec. 709 perceived luminance). For other weighting schemes use
+    * {@link #toGrayscale(GrayscaleMethod)}.
+    *
+    * @return a new grayscale Image
+    */
+   public ImmutableImage toGrayscale() {
+      return toGrayscale(GrayscaleMethod.LUMA);
    }
 
    public ImmutableImage toGrayscale(GrayscaleMethod method) {

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageColorOpsTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageColorOpsTest.kt
@@ -1,0 +1,55 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.color.LumaGrayscale
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the ImmutableImage colour convenience methods: invert, gamma and the
+ * no-arg toGrayscale.
+ *
+ * All tests use opaque alpha (255): copy() routes through Graphics2D which
+ * premultiplies and loses precision when alpha != 255 (a pre-existing behaviour
+ * shared with toGrayscale(GrayscaleMethod)).
+ */
+class ImageColorOpsTest : FunSpec({
+
+   fun image1x1(r: Int, g: Int, b: Int, a: Int = 255) =
+      ImmutableImage.create(1, 1, arrayOf(Pixel(0, 0, r, g, b, a)))
+
+   test("invert flips RGB and preserves alpha") {
+      val p = image1x1(10, 20, 30, 255).invert().pixel(0, 0)
+      p.red() shouldBe 245
+      p.green() shouldBe 235
+      p.blue() shouldBe 225
+      p.alpha() shouldBe 255
+   }
+
+   test("invert leaves the source image unchanged") {
+      val src = image1x1(10, 20, 30, 255)
+      src.invert()
+      src.pixel(0, 0).red() shouldBe 10
+   }
+
+   test("gamma of 1.0 leaves pixels unchanged") {
+      val p = image1x1(64, 128, 200, 255).gamma(1.0).pixel(0, 0)
+      p.red() shouldBe 64
+      p.green() shouldBe 128
+      p.blue() shouldBe 200
+      p.alpha() shouldBe 255
+   }
+
+   test("gamma of 2.0 brightens midtones per the jhlabs formula") {
+      // v = round(255 * (64/255)^(1/2)) = round(127.75 + 0.5) = 128
+      image1x1(64, 64, 64, 255).gamma(2.0).pixel(0, 0).red() shouldBe 128
+   }
+
+   test("no-arg toGrayscale matches the LUMA method") {
+      val src = image1x1(100, 150, 200, 255)
+      src.toGrayscale().pixel(0, 0).red() shouldBe src.toGrayscale(LumaGrayscale()).pixel(0, 0).red()
+      // LumaGrayscale: round(0.2126*100 + 0.7152*150 + 0.0722*200) = 143
+      src.toGrayscale().pixel(0, 0).red() shouldBe 143
+   }
+})


### PR DESCRIPTION
Adds three colour convenience methods to `ImmutableImage`. Each is implemented directly in `scrimage-core` with pixel math, since core cannot depend on `scrimage-filters`.

## Methods
- **`invert()`** — photographic negative; inverts the R/G/B channels and preserves alpha.
- **`gamma(double)`** — gamma correction using the same lookup-table formula as the jhlabs `GammaFilter` (`255·(i/255)^(1/γ)`), so output is identical to the existing filter. `gamma(1.0)` is a no-op.
- **`toGrayscale()`** — no-arg overload defaulting to `GrayscaleMethod.LUMA` (Rec. 709). Callers no longer need to know the `GrayscaleMethod` enum for the common case; `toGrayscale(GrayscaleMethod)` remains for other weightings.

## Tests
`ImageColorOpsTest` (5 tests): invert channel/alpha behaviour + immutability, gamma no-op and midtone brightening against the exact formula, and no-arg grayscale matching `LumaGrayscale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)