### PR TITLE
Add diff() and rmse() image comparison to ImmutableImage

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -816,6 +816,64 @@ public class ImmutableImage extends MutableImage {
    }
 
    /**
+    * Returns a new image representing the absolute per-channel difference between this image and the
+    * other. Identical pixels become black; the greater the difference in a channel, the brighter that
+    * channel is in the result. The result is fully opaque (differences in alpha are not visualised).
+    *
+    * @param other another image, which must have the same dimensions as this image.
+    * @return a new Image showing the difference between the two images.
+    * @throws IllegalArgumentException if the images have different dimensions.
+    */
+   public ImmutableImage diff(ImmutableImage other) {
+      requireSameDimensions(other, "diff");
+      int[] a = awt().getRGB(0, 0, width, height, null, 0, width);
+      int[] b = other.awt().getRGB(0, 0, width, height, null, 0, width);
+      int[] out = new int[a.length];
+      for (int i = 0; i < a.length; i++) {
+         int dr = Math.abs(((a[i] >> 16) & 0xFF) - ((b[i] >> 16) & 0xFF));
+         int dg = Math.abs(((a[i] >> 8) & 0xFF) - ((b[i] >> 8) & 0xFF));
+         int db = Math.abs((a[i] & 0xFF) - (b[i] & 0xFF));
+         out[i] = 0xFF000000 | (dr << 16) | (dg << 8) | db;
+      }
+      ImmutableImage target = ImmutableImage.create(width, height, CANONICAL_DATA_TYPE);
+      target.awt().setRGB(0, 0, width, height, out, 0, width);
+      return target;
+   }
+
+   /**
+    * Returns the root mean square error between this image and the other, computed over the red, green
+    * and blue channels and normalised to the range 0.0 (the images are pixel-identical) to 1.0 (every
+    * channel of every pixel differs by the maximum of 255). This is a measure of dissimilarity: the
+    * smaller the value, the more alike the two images are. Alpha is not considered.
+    *
+    * @param other another image, which must have the same dimensions as this image.
+    * @return the normalised RMSE in the range [0.0, 1.0].
+    * @throws IllegalArgumentException if the images have different dimensions.
+    */
+   public double rmse(ImmutableImage other) {
+      requireSameDimensions(other, "rmse");
+      int[] a = awt().getRGB(0, 0, width, height, null, 0, width);
+      int[] b = other.awt().getRGB(0, 0, width, height, null, 0, width);
+      double sum = 0.0;
+      for (int i = 0; i < a.length; i++) {
+         int dr = ((a[i] >> 16) & 0xFF) - ((b[i] >> 16) & 0xFF);
+         int dg = ((a[i] >> 8) & 0xFF) - ((b[i] >> 8) & 0xFF);
+         int db = (a[i] & 0xFF) - (b[i] & 0xFF);
+         sum += (double) dr * dr + (double) dg * dg + (double) db * db;
+      }
+      double mse = sum / (a.length * 3.0);
+      return Math.sqrt(mse) / 255.0;
+   }
+
+   private void requireSameDimensions(ImmutableImage other, String op) {
+      if (other.width != width || other.height != height) {
+         throw new IllegalArgumentException(String.format(
+            "Cannot %s images of different dimensions: %dx%d vs %dx%d",
+            op, width, height, other.width, other.height));
+      }
+   }
+
+   /**
     * Applies an affine transform in place.
     *
     * @return the BufferedImage resulting from applying the affine transform

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageCompareTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageCompareTest.kt
@@ -1,0 +1,52 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for the ImmutableImage comparison methods: diff and rmse.
+ */
+class ImageCompareTest : FunSpec({
+
+   fun image1x1(r: Int, g: Int, b: Int, a: Int = 255) =
+      ImmutableImage.create(1, 1, arrayOf(Pixel(0, 0, r, g, b, a)))
+
+   test("diff produces absolute per-channel difference, fully opaque") {
+      val a = image1x1(200, 100, 50, 255)
+      val b = image1x1(50, 100, 200, 255)
+      val p = a.diff(b).pixel(0, 0)
+      p.red() shouldBe 150
+      p.green() shouldBe 0
+      p.blue() shouldBe 150
+      p.alpha() shouldBe 255
+   }
+
+   test("diff of identical images is black") {
+      val a = image1x1(123, 45, 67, 255)
+      val p = a.diff(a).pixel(0, 0)
+      p.red() shouldBe 0
+      p.green() shouldBe 0
+      p.blue() shouldBe 0
+   }
+
+   test("rmse is 0.0 for identical images") {
+      val a = image1x1(123, 45, 67, 255)
+      a.rmse(a) shouldBe 0.0
+   }
+
+   test("rmse of pure red vs black is sqrt(255^2/3)/255") {
+      // dr=255, dg=0, db=0 -> mse = 65025/3 = 21675 -> sqrt/255 = 0.5773..
+      image1x1(255, 0, 0, 255).rmse(image1x1(0, 0, 0, 255)) shouldBe (0.57735 plusOrMinus 0.0001)
+   }
+
+   test("diff and rmse reject mismatched dimensions") {
+      val a = ImmutableImage.create(2, 2)
+      val b = ImmutableImage.create(3, 3)
+      shouldThrow<IllegalArgumentException> { a.diff(b) }
+      shouldThrow<IllegalArgumentException> { a.rmse(b) }
+   }
+})


### PR DESCRIPTION
Adds two comparison methods to `ImmutableImage`. Both require the two images to have the same dimensions and throw `IllegalArgumentException` otherwise.

## Methods
- **`diff(ImmutableImage)`** — returns a new image of the absolute per-channel difference between the two images. Identical pixels are black; the larger the delta in a channel, the brighter that channel. The result is fully opaque (alpha differences are not visualised).
- **`rmse(ImmutableImage)`** — root mean square error over the R/G/B channels, normalised to `[0.0, 1.0]` where `0.0` means pixel-identical. This is the numeric similarity metric the library was missing: `equals()` is exact-only, so there was previously no way to measure *how* alike two images are — handy for visual-regression assertions.

## Tests
`ImageCompareTest` (5 tests): per-channel diff, diff of identical images is black, rmse of identical images is `0.0`, rmse of red-vs-black against the closed-form value, and dimension-mismatch rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)