### PR TITLE
Add histogram() and toSquare()

### DIFF
--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/AwtImage.java
@@ -739,6 +739,15 @@ public class AwtImage {
    }
 
    /**
+    * Returns the per-channel distribution of pixel values across this image.
+    *
+    * @return a {@link Histogram} describing this image.
+    */
+   public Histogram histogram() {
+      return new Histogram(this);
+   }
+
+   /**
     * Returns true if all the pixels on this image are a single color.
     *
     * @param color the color to test pixels against

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/Histogram.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/Histogram.java
@@ -1,0 +1,77 @@
+package com.sksamuel.scrimage;
+
+/**
+ * The distribution of channel values across all pixels of an image.
+ * <p>
+ * Each channel is represented as a 256-element array where index <code>i</code>
+ * holds the number of pixels whose value in that channel is exactly <code>i</code>.
+ * Counts are held as <code>long</code>s so that large images cannot overflow a bucket.
+ */
+public class Histogram {
+
+   private final long[] red = new long[256];
+   private final long[] green = new long[256];
+   private final long[] blue = new long[256];
+   private final long[] alpha = new long[256];
+   private final long[] luminance = new long[256];
+
+   /**
+    * Builds a histogram in a single pass over every pixel of the given image.
+    *
+    * @param image the image to analyse
+    */
+   public Histogram(AwtImage image) {
+      int[] argb = image.awt().getRGB(0, 0, image.width, image.height, null, 0, image.width);
+      for (int p : argb) {
+         int a = (p >>> 24) & 0xFF;
+         int r = (p >> 16) & 0xFF;
+         int g = (p >> 8) & 0xFF;
+         int b = p & 0xFF;
+         alpha[a]++;
+         red[r]++;
+         green[g]++;
+         blue[b]++;
+         // Rec. 709 perceived luminance, computed per pixel.
+         luminance[(int) Math.round(0.2126 * r + 0.7152 * g + 0.0722 * b)]++;
+      }
+   }
+
+   /**
+    * @return the per-value counts for the red channel; index i holds the number of pixels with red == i.
+    */
+   public long[] red() {
+      return red.clone();
+   }
+
+   /**
+    * @return the per-value counts for the green channel; index i holds the number of pixels with green == i.
+    */
+   public long[] green() {
+      return green.clone();
+   }
+
+   /**
+    * @return the per-value counts for the blue channel; index i holds the number of pixels with blue == i.
+    */
+   public long[] blue() {
+      return blue.clone();
+   }
+
+   /**
+    * @return the per-value counts for the alpha channel; index i holds the number of pixels with alpha == i.
+    */
+   public long[] alpha() {
+      return alpha.clone();
+   }
+
+   /**
+    * Returns the distribution of perceived brightness. Each pixel contributes to a single bucket,
+    * computed from its red, green and blue channels using the Rec. 709 weights
+    * (0.2126R + 0.7152G + 0.0722B). The counts therefore sum to the pixel count of the image.
+    *
+    * @return a 256-element array of luminance counts.
+    */
+   public long[] luminance() {
+      return luminance.clone();
+   }
+}

--- a/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
+++ b/scrimage-core/src/main/java/com/sksamuel/scrimage/ImmutableImage.java
@@ -1228,6 +1228,30 @@ public class ImmutableImage extends MutableImage {
       return padWith(x, y, w - width - x, h - height - y, color);
    }
 
+   /**
+    * Returns a square version of this image by padding the shorter side, centring the existing
+    * image within the new canvas. The added area is transparent. An image that is already square
+    * is returned unchanged in size.
+    *
+    * @return a new square Image.
+    */
+   public ImmutableImage toSquare() {
+      return toSquare(Colors.Transparent.awt());
+   }
+
+   /**
+    * Returns a square version of this image by padding the shorter side with the given colour,
+    * centring the existing image within the new canvas. An image that is already square is
+    * returned unchanged in size.
+    *
+    * @param color the background colour for the padded area.
+    * @return a new square Image.
+    */
+   public ImmutableImage toSquare(Color color) {
+      int size = Math.max(width, height);
+      return padTo(size, size, color);
+   }
+
    public ImmutableImage padWith(int left, int top, int right, int bottom) {
       return padWith(left, top, right, bottom, Colors.Transparent.awt());
    }

--- a/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageHistogramSquareTest.kt
+++ b/scrimage-tests/src/test/kotlin/com/sksamuel/scrimage/core/ImageHistogramSquareTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.scrimage.core
+
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.pixels.Pixel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.awt.Color
+
+/**
+ * Tests for histogram() (inherited from AwtImage) and toSquare().
+ */
+class ImageHistogramSquareTest : FunSpec({
+
+   test("histogram counts every pixel per channel") {
+      val pixels = arrayOf(
+         Pixel(0, 0, 0, 0, 0, 255),       // black
+         Pixel(1, 0, 255, 255, 255, 255), // white
+         Pixel(0, 1, 255, 0, 0, 255),     // red
+         Pixel(1, 1, 0, 0, 255, 255)      // blue
+      )
+      val hist = ImmutableImage.create(2, 2, pixels).histogram()
+
+      hist.red().sum() shouldBe 4L
+      hist.red()[0] shouldBe 2L      // black + blue
+      hist.red()[255] shouldBe 2L    // white + red
+
+      hist.alpha()[255] shouldBe 4L
+      hist.luminance().sum() shouldBe 4L
+   }
+
+   test("histogram getters return defensive copies") {
+      val hist = ImmutableImage.create(1, 1).histogram()
+      val before = hist.red()[0]
+      hist.red()[0] = 999L                 // mutate the returned array
+      hist.red()[0] shouldBe before        // a fresh call is unaffected
+   }
+
+   test("toSquare pads the shorter side and centres the image") {
+      val squared = ImmutableImage.filled(4, 2, Color.RED).toSquare(Color.BLACK)
+      squared.width shouldBe 4
+      squared.height shouldBe 4
+      // original red band centred vertically (rows 1..2), black padding top and bottom
+      squared.pixel(0, 0).toARGBInt() shouldBe Color.BLACK.rgb
+      squared.pixel(0, 1).toARGBInt() shouldBe Color.RED.rgb
+      squared.pixel(0, 3).toARGBInt() shouldBe Color.BLACK.rgb
+   }
+
+   test("toSquare leaves an already-square image the same size") {
+      val squared = ImmutableImage.create(5, 5).toSquare()
+      squared.width shouldBe 5
+      squared.height shouldBe 5
+   }
+})


### PR DESCRIPTION
Adds an image histogram and a square-padding convenience method.

## Methods
- **`Histogram`** (new class) — per-value counts as `long[256]` for the red, green, blue and alpha channels, plus a true per-pixel `luminance()` distribution using the Rec. 709 weights. Everything is computed in a single pass over the pixels; the channel getters return defensive copies so callers can't mutate the internal state.
- **`AwtImage.histogram()`** — builds a `Histogram` for the image. Placed on `AwtImage` alongside the other read-only introspection methods (`average()`, `count()`, `colours()`), so both `AwtImage` and `ImmutableImage` get it.
- **`ImmutableImage.toSquare()` / `toSquare(Color)`** — pads the shorter side (centred) to produce a square image; transparent background by default. An already-square image is returned at the same size. Thin wrapper over the existing `padTo`.

## Tests
`ImageHistogramSquareTest` (4 tests): per-channel counts and luminance sum, defensive-copy behaviour of the getters, `toSquare` padding/centring, and `toSquare` leaving a square image unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)